### PR TITLE
fix line-height and margin for forms

### DIFF
--- a/src/components/atoms/typography.js
+++ b/src/components/atoms/typography.js
@@ -12,11 +12,6 @@ injectGlobal`
     font-weight: 300;
     font-style: normal;
   }
-`
-
-injectGlobal`
-
-
 
   @font-face {
     font-family: fakt-web;
@@ -50,13 +45,12 @@ injectGlobal`
 
   body {
     font-family: ${fonts.text};
+    line-height: 1.6;
   }
-
 `
 
 const Headline = styled.h1`
   margin: 20px 0 14px;
-  line-height: 1.8;
   color: ${colors.base};
   font-size: 48px;
   font-weight: 500;
@@ -64,7 +58,6 @@ const Headline = styled.h1`
 
 const Subheader = styled.h6`
   margin: 20px 0 14px;
-  line-height: 1.8;
   color: ${colors.grayDark};
   font-size: 13px;
   font-weight: 300;

--- a/src/components/molecules/form.js
+++ b/src/components/molecules/form.js
@@ -19,7 +19,7 @@ const FormLabel = styled(Text)`
 `
 
 const FormField = styled.div`
-  margin: ${spacing.small} 0;
+  margin: ${spacing.medium} 0;
 `
 
 const HelperText = styled.div`


### PR DESCRIPTION
- Set global line-height: 1.6
- Set margin between form fields to `spacing.medium`