### PR TITLE
Added dynamic titles to pages with Helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "raw-loader": "0.5.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-helmet": "^5.2.0",
     "react-live": "1.7.1",
     "react-router-dom": "4.2.2",
     "styled-components": "2.2.3"

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <link rel="mask-icon" href="%PUBLIC_URL%/favicons/safari-pinned-tab.svg" color="#000000">
     <meta name="theme-color" content="#ffffff">
 
-    <title>Cosmos Overview</title>
+    <title>Cosmos &mdash; Auth0 Design System</title>
   </head>
   <body>
     <noscript>

--- a/src/docs/home.js
+++ b/src/docs/home.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import Helmet from 'react-helmet'
 
 import { Heading3, Subheader } from '../components'
 
@@ -7,9 +8,18 @@ const Container = styled.div`
   height: 100vh;
 `
 
-export default props => (
-  <Container>
-    <Heading3>Docs</Heading3>
-    <Subheader>Select a component from the sidebar</Subheader>
-  </Container>
-)
+class Home extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Documentation &mdash; Cosmos" />
+        <Container>
+          <Heading3>Docs</Heading3>
+          <Subheader>Select a component from the sidebar</Subheader>
+        </Container>
+      </div>
+    )
+  }
+}
+
+export default Home

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import styled from 'styled-components'
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
 

--- a/src/docs/spec/index.js
+++ b/src/docs/spec/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-
+import Helmet from 'react-helmet'
 import { metadata as components } from '../metadata.json'
 import documentations from '../docs-loader'
 
@@ -19,6 +19,7 @@ export default props => {
 
   return (
     <Container>
+      <Helmet title={component.displayName + ' — Cosmos'} />
       <Heading3>{component.displayName}</Heading3>
       <Subheader>{component.description || 'Description missing!'}</Subheader>
       <Example docs={docs} component={component} />


### PR DESCRIPTION
Now that we have a better favicon, I thought it would be a good idea to have dynamic titles to pages in the documentation. So I added them via the Helmet library and they seem to work ok!