### PR TITLE
Remove description from component code

### DIFF
--- a/src/components/atoms/_box.js
+++ b/src/components/atoms/_box.js
@@ -1,11 +1,11 @@
-/**
+/*
   This is a demo component to show how to write a good component.
   We will create a square box component here.
 
   There are 5 steps to do this
 */
 
-/**
+/*
   Step 1: Import all the dependencies
   - import React and styled-components, thes are the bread and butter
   - import prop type for documentation and validation
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types'
 
 import { colors, misc } from '../../tokens/'
 
-/**
+/*
   Step 2: Create a styled element with css
   You can get the html element from styled.element like styled.a
 */
@@ -41,13 +41,9 @@ const StyledBox = styled.div`
   }
 `
 
-/**
+/*
  * Step 3: Create a React component that returns the styled element,
  * Add description above the component, this will be shown in the docs
- */
-
-/**
- * Think of the box
  */
 
 const Box = props => {
@@ -55,7 +51,7 @@ const Box = props => {
   return <StyledBox {...props} />
 }
 
-/**
+/*
   Step 4: We need to add prop information for our component
   - Add propTypes to make for documentation and validation
   - Add defaultProps for documentation

--- a/src/components/atoms/button.js
+++ b/src/components/atoms/button.js
@@ -139,10 +139,6 @@ const StyledButton = styled.button`
   }
 `
 
-/**
- * You can use a button to request a call to action
- */
-
 const Button = ({ children, ...props }) => {
   let content = children
   if (props.success) content = <Icon type="success" />

--- a/src/components/atoms/code.js
+++ b/src/components/atoms/code.js
@@ -13,10 +13,6 @@ const StyledCode = styled.span`
   border-radius: 3px;
 `
 
-/**
- * Use for decoration of code
- */
-
 const Code = props => <StyledCode {...props}>{props.children}</StyledCode>
 
 Code.propTypes = {}

--- a/src/components/atoms/input.js
+++ b/src/components/atoms/input.js
@@ -62,10 +62,6 @@ const StyledInput = styled.input`
   }
 `
 
-/**
- * Request information from the user
- */
-
 const Input = props => <StyledInput {...props} />
 
 Input.propTypes = {

--- a/src/components/atoms/select.js
+++ b/src/components/atoms/select.js
@@ -6,9 +6,6 @@ import { StyledInput } from './input'
 const StyledSelect = StyledInput.withComponent('select').extend`
   height: 40px;
 `
-/**
- * Use select when you want to limit the input options
- */
 
 const Select = ({ options, ...props }) => {
   /*

--- a/src/components/atoms/switch.js
+++ b/src/components/atoms/switch.js
@@ -55,10 +55,6 @@ const Label = styled.label`
   padding-left: ${spacing.small};
 `
 
-/**
- * Use Switch for boolean inputs
- */
-
 class Switch extends React.Component {
   constructor(props) {
     super(props)

--- a/src/components/molecules/form/index.js
+++ b/src/components/molecules/form/index.js
@@ -51,10 +51,6 @@ const StyledForm = styled.form`
   }
 `
 
-/**
- * Use forms to collect information from user
- */
-
 const Form = props => <StyledForm>{props.children}</StyledForm>
 // TODO: Form will get an layout prop for orientation of labels
 

--- a/src/docs/spec/index.js
+++ b/src/docs/spec/index.js
@@ -19,7 +19,6 @@ export default props => {
     <Container>
       <Helmet title={component.displayName + ' — Cosmos'} />
       <Heading3>{component.displayName}</Heading3>
-      <Subheader>{component.description || 'Description missing!'}</Subheader>
       <Example documentation={component.documentation} component={component} />
     </Container>
   )

--- a/src/docs/spec/index.js
+++ b/src/docs/spec/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import Helmet from 'react-helmet'
 import { metadata as components } from '../metadata.json'
 
-import { Heading3, Subheader } from '../../components'
+import { Heading3 } from '../../components'
 import Example from './example'
 
 const Container = styled.div`


### PR DESCRIPTION
The docgen way of writing descriptions is to put it as a comment on top of a the React component.

Because, we already have a freeform documentation format, this felt disconnected. Description should just be the first thing you write in the doc file