### PR TITLE
Pull out styled input to its own file + rename Input to TextInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8799,8 +8799,7 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.cond": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "glob": "7.1.2",
+    "lodash.camelcase": "4.3.0",
     "markdown-to-jsx": "5.4.2",
     "raw-loader": "0.5.1",
     "react": "^16.0.0",

--- a/src/components/atoms/_styled-input.js
+++ b/src/components/atoms/_styled-input.js
@@ -1,0 +1,63 @@
+import styled from 'styled-components'
+
+import { colors, fonts, spacing, misc } from '../../tokens/'
+
+const config = {
+  basic: {
+    background: colors.white,
+    border: '#ccc',
+    hoverBorder: colors.grayMedium,
+    focusBorder: colors.blue,
+    placeholder: colors.grayMedium
+  },
+  readOnly: {
+    background: colors.grayLightest,
+    border: colors.grayLight,
+    hoverBorder: colors.grayMedium,
+    focusBorder: colors.grayMedium,
+    placeholder: colors.base
+  },
+  error: {
+    background: colors.white,
+    border: colors.orange,
+    hoverBorder: colors.orange,
+    focusBorder: colors.blue
+  }
+}
+
+const getAttributes = props => {
+  if (props.readOnly) return config.readOnly
+  else if (props.error) return config.error
+  else return config.basic
+}
+
+const StyledInput = styled.input`
+  width: 100%;
+  box-sizing: border-box;
+
+  background: ${props => getAttributes(props).background};
+  border: 1px solid;
+  border-color: ${props => getAttributes(props).border};
+  border-radius: ${misc.radius};
+
+  font-family: ${props => (props.code ? fonts.family.code : 'inherit')};
+
+  padding: ${spacing.xsmall} ${spacing.small};
+
+  cursor: ${props => (props.readOnly ? 'not-allowed' : 'auto')};
+  transition: border-color ${misc.animationDuration}, box-shadow ${misc.animationDuration};
+
+  &:hover {
+    border-color: ${props => getAttributes(props).hoverBorder};
+  }
+  &:focus {
+    border-color: ${props => getAttributes(props).focusBorder};
+    box-shadow: 0px 0px 0 1px ${props => getAttributes(props).focusBorder};
+    outline: none;
+  }
+  &::-webkit-input-placeholder {
+    color: ${props => getAttributes(props).placeholder};
+  }
+`
+
+export { StyledInput }

--- a/src/components/atoms/input.js
+++ b/src/components/atoms/input.js
@@ -1,66 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
-import { colors, fonts, spacing, misc } from '../../tokens/'
-
-const config = {
-  basic: {
-    background: colors.white,
-    border: '#ccc',
-    hoverBorder: colors.grayMedium,
-    focusBorder: colors.blue,
-    placeholder: colors.grayMedium
-  },
-  readOnly: {
-    background: colors.grayLightest,
-    border: colors.grayLight,
-    hoverBorder: colors.grayMedium,
-    focusBorder: colors.grayMedium,
-    placeholder: colors.base
-  },
-  error: {
-    background: colors.white,
-    border: colors.orange,
-    hoverBorder: colors.orange,
-    focusBorder: colors.blue
-  }
-}
-
-const getAttributes = props => {
-  if (props.readOnly) return config.readOnly
-  else if (props.error) return config.error
-  else return config.basic
-}
-
-const StyledInput = styled.input`
-  width: 100%;
-  box-sizing: border-box;
-
-  background: ${props => getAttributes(props).background};
-  border: 1px solid;
-  border-color: ${props => getAttributes(props).border};
-  border-radius: ${misc.radius};
-
-  font-family: ${props => (props.code ? fonts.family.code : 'inherit')};
-
-  padding: ${spacing.xsmall} ${spacing.small};
-
-  cursor: ${props => (props.readOnly ? 'not-allowed' : 'auto')};
-  transition: border-color ${misc.animationDuration}, box-shadow ${misc.animationDuration};
-
-  &:hover {
-    border-color: ${props => getAttributes(props).hoverBorder};
-  }
-  &:focus {
-    border-color: ${props => getAttributes(props).focusBorder};
-    box-shadow: 0px 0px 0 1px ${props => getAttributes(props).focusBorder};
-    outline: none;
-  }
-  &::-webkit-input-placeholder {
-    color: ${props => getAttributes(props).placeholder};
-  }
-`
+import { StyledInput } from './_styled-input'
 
 const Input = props => <StyledInput {...props} />
 

--- a/src/components/atoms/select.js
+++ b/src/components/atoms/select.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { StyledInput } from './input'
+import { StyledInput } from './_styled-input'
 
 const StyledSelect = StyledInput.withComponent('select').extend`
   height: 40px;

--- a/src/components/atoms/text-input.js
+++ b/src/components/atoms/text-input.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 
 import { StyledInput } from './_styled-input'
 
-const Input = props => <StyledInput {...props} />
+const TextInput = props => <StyledInput {...props} />
 
-Input.propTypes = {
+TextInput.propTypes = {
   /** Make input readOnly if it does not validate constraint */
   readOnly: PropTypes.bool,
   /** Use when the expected input is code */
@@ -16,12 +16,12 @@ Input.propTypes = {
   onChange: PropTypes.func
 }
 
-Input.defaultProps = {
+TextInput.defaultProps = {
   readOnly: false,
   code: false,
   error: null,
   onChange: null
 }
 
-export default Input
+export default TextInput
 export { StyledInput }

--- a/src/components/atoms/text-input.md
+++ b/src/components/atoms/text-input.md
@@ -2,10 +2,10 @@
   category: Forms
 ```
 
-`import Input from 'cosmos/input'`
+`import TextInput from 'cosmos/text-input'`
 
 ```js props
-<Input {props} placeholder="Placeholder text" />
+<TextInput {props} placeholder="Placeholder text" />
 ```
 
 #### Input types
@@ -17,13 +17,13 @@ It also ships with a `code` prop that is useful when the input is a hash/code va
 ```js multiple
 render(
   <div>
-    <Input type="text" defaultValue="This is plain text field value" />
+    <TextInput type="text" defaultValue="This is plain text field value" />
     <br/><br/>
-    <Input type="password" defaultValue="This is a code field" />
+    <TextInput type="password" defaultValue="This is a code field" />
     <br/><br/>
-    <Input type="number" defaultValue="1" />
+    <TextInput type="number" defaultValue="1" />
     <br/><br/>
-    <Input code defaultValue="DUq0xuJZAD7RvezvqCrA6hpJVb6iDUip" />
+    <TextInput code defaultValue="DUq0xuJZAD7RvezvqCrA6hpJVb6iDUip" />
   </div>
 )
 ```
@@ -37,9 +37,9 @@ To show validation errors, use the `error` prop which takes the error message as
 ```js multiple
 render(
   <div>
-    <Input readOnly placeholder="Field is disabled" />
+    <TextInput readOnly placeholder="Field is disabled" />
     <br/><br/>
-    <Input defaultValue="siddharth@auth..com" error="email id not valid" />
+    <TextInput defaultValue="siddharth@auth..com" error="email id not valid" />
   </div>
 )
 ```
@@ -51,5 +51,5 @@ The `onChange` prop is transparently passed to the input
 ```js multiple
 const method = event => alert(event.target.value)
 
-render(<Input onChange={method} placeholder="change my text" />)
+render(<TextInput onChange={method} placeholder="change my text" />)
 ```

--- a/src/components/atoms/textarea.js
+++ b/src/components/atoms/textarea.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { StyledInput } from './input'
+import { StyledInput } from './_styled-input'
 
 const StyledTextArea = StyledInput.withComponent('textarea').extend`
   resize: ${props => (props.resizable ? 'vertical' : 'none')};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,8 +12,8 @@ import Box from './atoms/_box'
 export { Box }
 
 /* atoms */
-import Input from './atoms/input'
-export { Input }
+import TextInput from './atoms/text-input'
+export { TextInput }
 
 import Select from './atoms/select'
 export { Select }

--- a/src/components/molecules/action-input.js
+++ b/src/components/molecules/action-input.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
-import Input from '../atoms/input'
+import TextInput from '../atoms/text-input'
 import Button, { StyledButton } from '../atoms/button'
 
 const Wrapper = styled.div`
@@ -26,7 +26,7 @@ const ActionInput = props => {
   if (props.actions) {
     return (
       <Wrapper>
-        <Input {...props} />
+        <TextInput {...props} />
         <ButtonGroup>
           {props.actions.map((action, index) => (
             <Button key={index} link icon={action.icon} onClick={action.method} />
@@ -35,12 +35,12 @@ const ActionInput = props => {
       </Wrapper>
     )
   } else {
-    return <Input {...props} />
+    return <TextInput {...props} />
   }
 }
 
 ActionInput.propTypes = {
-  ...Input.propTypes,
+  ...TextInput.propTypes,
   /** Actions to be attached to input */
   actions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -51,7 +51,7 @@ ActionInput.propTypes = {
 }
 
 ActionInput.defaultProps = {
-  ...Input.defaultProps,
+  ...TextInput.defaultProps,
   actions: []
 }
 

--- a/src/docs/sidebar/search.js
+++ b/src/docs/sidebar/search.js
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import { Input } from '../../components'
+import { TextInput } from '../../components'
 
 const SearchBox = props => (
-  <Input
+  <TextInput
     autoFocus
     placeholder="Search for a component"
     onChange={e => props.onChange(e.target.value)}

--- a/src/docs/spec/props.js
+++ b/src/docs/spec/props.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { spacing, colors, fonts, misc } from '../../tokens'
-import { Input, Switch, Code } from '../../components'
+import { TextInput, Switch, Code } from '../../components'
 
 const Table = styled.table`
   width: 100%;
@@ -48,7 +48,7 @@ const PropSwitcher = ({ propName, data, onPropsChange }) => {
   if (data.type.name === 'bool') {
     return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={method} />
   } else if (['string', 'number'].includes(data.type.name)) {
-    return <Input defaultValue={data.value} onChange={e => method(e.target.value)} />
+    return <TextInput defaultValue={data.value} onChange={e => method(e.target.value)} />
   }
   return <div />
 }

--- a/tooling/component-metadata.js
+++ b/tooling/component-metadata.js
@@ -4,12 +4,10 @@ const docgen = require('react-docgen')
 const { createDisplayNameHandler } = require('react-docgen-displayname-handler')
 const chokidar = require('chokidar')
 const { info, warn } = require('prettycli')
+const camelCase = require('lodash.camelcase')
 
 /* CLI param for watch mode */
 const watch = process.argv.includes('-w') || process.argv.includes('--watch')
-
-/* Helper function */
-const capitalize = string => string.charAt(0).toUpperCase() + string.slice(1)
 
 /* Get list of js and md files from atoms and molecules */
 const javascriptFiles = glob.sync('src/components/+(atoms|molecules)/**/*.js')
@@ -82,7 +80,7 @@ const run = () => {
     data.filepath = path
 
     /* infer display name from path */
-    data.displayName = capitalize(
+    data.displayName = camelCase(
       path
         .split('/')
         .pop()


### PR DESCRIPTION
  Fixes https://github.com/auth0/cosmos/issues/64

`TextInput`, `Select`, `TextArea` now extend a common `StyledInput`
  
.+ renames `Input` to `TextInput`
  