### PR TITLE
Added CSS property to display long chunks of code without word-breaks

### DIFF
--- a/src/components/atoms/textarea/index.js
+++ b/src/components/atoms/textarea/index.js
@@ -5,6 +5,7 @@ import { StyledInput } from '../_styled-input'
 
 const StyledTextArea = StyledInput.withComponent('textarea').extend`
   resize: ${props => (props.resizable ? 'vertical' : 'none')};
+  white-space: ${props => (props.code ? 'pre' : 'normal')};
 `
 
 const TextArea = props => <StyledTextArea rows={props.length} {...props} />


### PR DESCRIPTION
Adding white-space: pre to this context makes it look better.

Before:
<img width="734" alt="screen shot 2018-01-29 at 18 54 28" src="https://user-images.githubusercontent.com/239215/35536543-01b4e310-0526-11e8-80b5-30da6004e491.png">

After:
<img width="759" alt="screen shot 2018-01-29 at 18 55 22" src="https://user-images.githubusercontent.com/239215/35536545-02a0fcf0-0526-11e8-86ce-08678eaf1dce.png">