### PR TITLE
[TextInput] Add new "masked" prop to obscure hidden data

### DIFF
--- a/src/components/atoms/text-input/index.js
+++ b/src/components/atoms/text-input/index.js
@@ -9,10 +9,12 @@ const StyledInputElement = StyledInput.extend`
 
 const TextInput = props => {
   if (props.masked) {
-    const length =
-      props.defaultValue && props.defaultValue.length > 0 ? props.defaultValue.length : 8
+    const { value } = props
+    const length = value && value.length > 0 ? value.length : 8
     const maskedValue = new Array(length).join('•')
-    return <StyledInput {...props} defaultValue={maskedValue} readOnly />
+    return (
+      <StyledInput {...props} value={null} defaultValue={null} placeholder={maskedValue} readOnly />
+    )
   }
   return <StyledInput {...props} />
 }
@@ -27,7 +29,11 @@ TextInput.propTypes = {
   /** Pass error string directly to show error state */
   error: PropTypes.string,
   /** onChange transparently passed to the input */
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  /** Text to display when the input is empty */
+  placeholder: PropTypes.string,
+  /** The value for the field */
+  value: PropTypes.string
 }
 
 TextInput.defaultProps = {

--- a/src/components/atoms/text-input/index.js
+++ b/src/components/atoms/text-input/index.js
@@ -7,9 +7,19 @@ const StyledInputElement = StyledInput.extend`
   height: 44px;
 `
 
-const TextInput = props => <StyledInputElement {...props} />
+const TextInput = props => {
+  if (props.masked) {
+    const length =
+      props.defaultValue && props.defaultValue.length > 0 ? props.defaultValue.length : 8
+    const maskedValue = new Array(length).join('•')
+    return <StyledInput {...props} defaultValue={maskedValue} readOnly />
+  }
+  return <StyledInput {...props} />
+}
 
 TextInput.propTypes = {
+  /** Hide input, similar to passwords but for other private information. Implies readOnly. */
+  masked: PropTypes.bool,
   /** Make input readOnly if it does not validate constraint */
   readOnly: PropTypes.bool,
   /** Use when the expected input is code */

--- a/src/components/atoms/text-input/text-input.md
+++ b/src/components/atoms/text-input/text-input.md
@@ -6,7 +6,7 @@
 `import TextInput from 'cosmos/text-input'`
 
 ```jsx
-<TextInput {props} placeholder="Placeholder text" />
+<TextInput placeholder="Placeholder text" {props} />
 ```
 
 ### Input types
@@ -36,6 +36,15 @@ The `readOnly` prop can be used for disabling input that do not satisfy constrai
 
 ```js
 <TextInput readOnly placeholder="Field is disabled" />
+```
+
+You can also indicate that the value of the input should be masked. This will result
+in a display similar to password fields, but won't trigger password managers.
+
+(Note: this is just a visual effect, and doesn't provide any actual additional security!)
+
+```js
+<TextInput value="secret-client-hash" masked />
 ```
 
 ### Function

--- a/src/manage/settings.js
+++ b/src/manage/settings.js
@@ -40,7 +40,7 @@ class Settings extends React.Component {
         <Form.TextInput
           label="Client Secret"
           type="password"
-          readOnly
+          masked
           defaultValue={this.state.secret}
           actions={[{ icon: 'copy', method: dummyFn }, { icon: 'delete', method: dummyFn }]}
           description="The Client Secret is not base64 encoded."


### PR DESCRIPTION
As described in #185, the use of `type=password` to hide non-password information triggers password managers like 1Password. This patch adds a prop called `masked` to the `TextInput` which will manually obscure the value, and force the input to be `readOnly`.

If we decide to go with this proposal, we should definitely test switching a managed `TextInput` between masked and "not-masked" to make sure the value isn't lost. If the component is managed (that is, the`value` comes from a parent component) it should be okay.

WDYT?