### PR TITLE
Fix broken docs

### DIFF
--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -27,42 +27,36 @@ Buttons are great to ask users for action
 * Link button for linky stuff, idk?
 * Destructive buttons warn the user about it's effects. Proceed with caution.
 
-```js multiple
-render(
-  <div>
-    <Button>default</Button>
-    <Button primary>primary</Button>
-    <Button primaryAlt>primary alt</Button>
-    <Button transparent>secondary</Button>
-    <Button link>Clear</Button>
-    <Button destructive>Delete</Button>
-  </div>
-)
+```js
+<div>
+  <Button>default</Button>
+  <Button primary>primary</Button>
+  <Button primaryAlt>primary alt</Button>
+  <Button transparent>secondary</Button>
+  <Button link>Clear</Button>
+  <Button destructive>Delete</Button>
+</div>
 ```
 
 #### Button states
 
 Disable a button if you don't want the user isn't allowed to click on it
 
-```js multiple
-render(
-  <div>
-    <Button disabled>Disabled</Button>
-    <Button loading>Button</Button>
-    <Button success>Button</Button>
-  </div>
-)
+```js
+<div>
+  <Button disabled>Disabled</Button>
+  <Button loading>Button</Button>
+  <Button success>Button</Button>
+</div>
 ```
 
 #### Icons in Buttons
 
 Icon buttons work well in compact spaces. You can pick name of `icon` from [docs/Icon](/docs/Icon)
 
-```js multiple
-render(
-  <div>
-    <Button link icon="copy" />
-    <Button icon="copy" />
-  </div>
-)
+```js
+<div>
+  <Button link icon="copy" />
+  <Button icon="copy" />
+</div>
 ```

--- a/src/components/atoms/switch/switch.md
+++ b/src/components/atoms/switch/switch.md
@@ -26,13 +26,11 @@ You can change the default state of the switch by passing the `on` prop
 
 Switch can be locked in it's initial state with the `readOnly` prop
 
-```js multiple
-render(
-  <div>
-    <Switch readOnly />
-    <Switch on readOnly />
-  </div>
-)
+```js
+<div>
+  <Switch readOnly />
+  <Switch on readOnly />
+</div>
 ```
 
 You can change the accessibility labels by passing an array with two strings

--- a/src/components/atoms/text-input/text-input.md
+++ b/src/components/atoms/text-input/text-input.md
@@ -14,18 +14,19 @@ You can use semantic HMTL property type with input.
 
 It also ships with a `code` prop that is useful when the input is a hash/code value.
 
-```js multiple
-render(
-  <div>
-    <TextInput type="text" defaultValue="This is plain text field value" />
-    <br/><br/>
-    <TextInput type="password" defaultValue="This is a code field" />
-    <br/><br/>
-    <TextInput type="number" defaultValue="1" />
-    <br/><br/>
-    <TextInput code defaultValue="DUq0xuJZAD7RvezvqCrA6hpJVb6iDUip" />
-  </div>
-)
+```js
+<div>
+  <TextInput type="text" defaultValue="This is plain text field value" />
+  <br />
+  <br />
+  <TextInput type="password" defaultValue="This is a code field" />
+  <br />
+  <br />
+  <TextInput type="number" defaultValue="1" />
+  <br />
+  <br />
+  <TextInput code defaultValue="DUq0xuJZAD7RvezvqCrA6hpJVb6iDUip" />
+</div>
 ```
 
 #### Input states
@@ -34,22 +35,19 @@ The `readOnly` prop can be used for disabling input that do not satisfy constrai
 
 To show validation errors, use the `error` prop which takes the error message as a string.
 
-```js multiple
-render(
-  <div>
-    <TextInput readOnly placeholder="Field is disabled" />
-    <br/><br/>
-    <TextInput defaultValue="siddharth@auth..com" error="email id not valid" />
-  </div>
-)
+```js
+<div>
+  <TextInput readOnly placeholder="Field is disabled" />
+  <br />
+  <br />
+  <TextInput defaultValue="siddharth@auth..com" error="email id not valid" />
+</div>
 ```
 
 #### Function
 
 The `onChange` prop is transparently passed to the input
 
-```js multiple
-const method = event => alert(event.target.value)
-
-render(<TextInput onChange={method} placeholder="change my text" />)
+```js
+<TextInput onChange={event => console.log(event.target.value)} placeholder="change my text" />
 ```

--- a/src/components/atoms/textarea/textarea.md
+++ b/src/components/atoms/textarea/textarea.md
@@ -14,28 +14,26 @@ Note: `TextArea` is camelcased, it's not `Textarea`.
 
 You can make the `TextArea` longer by using the `length` prop. By default, it's 5 rows long.
 
-```js multiple
-render(
-  <div>
-    <TextArea length={1} placeholder="Small TextArea" />
-    <br/><br/>
-    <TextArea length={7} placeholder="Really long TextArea" />
-  </div>
-)
+```js
+<div>
+  <TextArea length={1} placeholder="Small TextArea" />
+  <br />
+  <br />
+  <TextArea length={7} placeholder="Really long TextArea" />
+</div>
 ```
 
 #### Resizing
 
 `TextArea` is resizable by the user. If you want to disable that behaviour, set `resizable` to `false` as a boolean value.
 
-```js multiple
-render(
-  <div>
-    <TextArea placeholder="Resizable by default" />
-    <br/><br/>
-    <TextArea resizable={false} placeholder="Can't resize this" />
-  </div>
-)
+```js
+<div>
+  <TextArea placeholder="Resizable by default" />
+  <br />
+  <br />
+  <TextArea resizable={false} placeholder="Can't resize this" />
+</div>
 ```
 
 #### TextArea states
@@ -44,22 +42,19 @@ The `readOnly` prop can be used for disabling input that do not satisfy constrai
 
 To show validation errors, use the `error` prop which takes the error message as a string.
 
-```js multiple
-render(
-  <div>
-    <TextArea readOnly placeholder="Field is disabled" />
-    <br/><br/>
-    <TextArea defaultValue="siddharth@auth..com" error="email id not valid" />
-  </div>
-)
+```js
+<div>
+  <TextArea readOnly placeholder="Field is disabled" />
+  <br />
+  <br />
+  <TextArea defaultValue="siddharth@auth..com" error="email id not valid" />
+</div>
 ```
 
 #### Function
 
 The `onChange` prop is transparently passed to the underlying textarea
 
-```js multiple
-const method = event => alert(event.target.value)
-
-render(<TextArea onChange={method} placeholder="change my text" />)
+```js
+<TextArea onChange={event => console.log(event.target.value)} placeholder="change my text" />
 ```

--- a/src/docs/spec/example.js
+++ b/src/docs/spec/example.js
@@ -20,13 +20,15 @@ const Example = props => {
       li: Heading5,
       /* use playground for js code blocks */
       code: markdownProps => {
-        if (!markdownProps.className) return <Code>{markdownProps.children}</Code>
-        else if (markdownProps.className.indexOf('js') === -1) return null
+        const language = markdownProps.className
+
+        if (!language) return <Code>{markdownProps.children}</Code>
+        else if (!['lang-js', 'lang-jsx'].includes(language)) return null
         else {
           return (
             <Playground
               code={markdownProps.children}
-              tags={markdownProps.className}
+              language={language}
               component={props.component}
             />
           )

--- a/src/docs/spec/playground.js
+++ b/src/docs/spec/playground.js
@@ -71,7 +71,7 @@ const Copy = styled.div`
 class Playground extends React.Component {
   constructor(props) {
     super(props)
-    let showProps = props.tags.includes('lang-jsx')
+    let showProps = props.language === 'lang-jsx'
 
     this.state = {
       showProps,
@@ -118,11 +118,7 @@ class Playground extends React.Component {
           style={{ opacity: 0, height: 0 }}
           onChange={() => {}}
         />
-        <LiveProvider
-          code={code}
-          scope={Components}
-          noInline={this.props.tags.includes('multiple')}
-        >
+        <LiveProvider code={code} scope={Components}>
           <LivePreview />
           <LiveError />
           {/* {this.state.codeVisible ? <LiveEditor /> : null} */}


### PR DESCRIPTION
Multiple classnames was deprecated in `markdown-to-jsx@6`

Because of that examples with `js multiple` didn't work. Got rid of them completely, we don't really need them.

Renamed `props.tags` in playground to `props.language` because now it's only singular.