### PR TITLE
Implemented defaultSelected on Select options, removed error prop

### DIFF
--- a/src/components/atoms/select/index.js
+++ b/src/components/atoms/select/index.js
@@ -18,7 +18,7 @@ const Select = ({ options, ...props }) => {
   return (
     <StyledSelect {...props}>
       {options.map((option, index) => (
-        <option key={index} value={option.value}>
+        <option key={index} value={option.value} selected={option.defaultSelected}>
           {option.text}
         </option>
       ))}
@@ -36,14 +36,11 @@ Select.propTypes = {
     })
   ).isRequired,
   /** Make input readOnly if it does not validate constraint */
-  readOnly: PropTypes.bool,
-  /** Pass error string directly to show error state */
-  error: PropTypes.string
+  readOnly: PropTypes.bool
 }
 
 Select.defaultProps = {
-  readOnly: false,
-  error: null
+  readOnly: false
 }
 
 export default Select

--- a/src/components/atoms/select/select.md
+++ b/src/components/atoms/select/select.md
@@ -1,24 +1,29 @@
-Options is required field
+The `<Select>` component renders a styled drop-down selector.
+
+```jsx
+<Select
+  options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
+/>
+```
+
+By default, the first option will be selected. To override this, you can set `defaultSelected`
+to `true` on another option:
 
 ```js
 <Select
   options={[
-    { text: 'One', value: 1, defaultSelected: true },
-    { text: 'Two', value: 2 },
+    { text: 'One', value: 1 },
+    { text: 'Two', value: 2, defaultSelected: true },
     { text: 'Three', value: 3 }
   ]}
 />
 ```
 
-Form can be readOnly
+You can also indicate that a `<Select>` should be read-only by setting the `readOnly` prop:
 
 ```js
 <Select
   readOnly
-  options={[
-    { text: 'One', value: 1, defaultSelected: true },
-    { text: 'Two', value: 2 },
-    { text: 'Three', value: 3 }
-  ]}
+  options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
 />
 ```


### PR DESCRIPTION
Closes #180.

This also removes the `error` prop since that seems to now be a function of form components rather than the atoms themselves.