### PR TITLE
Added separation for buttons

### DIFF
--- a/src/components/atoms/_actions/index.js
+++ b/src/components/atoms/_actions/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+import { spacing } from '../../../tokens/'
+
+const StyledActions = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`
+
+const StyledItem = styled.li`
+  display: inline-block;
+  margin-right: ${spacing.xsmall};
+  &:last-child {
+    margin-right: 0;
+  }
+`
+
+const Actions = props => {
+  const children = React.Children.map(props.children, child => {
+    return <StyledItem>{child}</StyledItem>
+  })
+
+  return <StyledActions>{children}</StyledActions>
+}
+
+Actions.propTypes = {}
+
+Actions.defaultProps = {}
+
+export default Actions

--- a/src/components/molecules/form/index.js
+++ b/src/components/molecules/form/index.js
@@ -11,7 +11,8 @@ import TextArea, { StyledTextArea } from '../../atoms/textarea'
 import Select from '../../atoms/select'
 import Switch from '../../atoms/switch'
 import Button from '../../atoms/button'
-import { Right, Clear } from '../../_helpers/float'
+import Actions from '../../atoms/_actions'
+import { Right, Left, Clear } from '../../_helpers/float'
 
 import StyledLabel from './label'
 import StyledDivider from './divider'
@@ -92,30 +93,36 @@ Form.Switch = props => <FormElement {...props} fieldComponent={Switch} />
 Form.Actions = props => {
   return (
     <StyledActions labelWidth={labelWidth}>
-      {props.primaryAction && (
-        <Button primary onClick={props.primaryAction.method}>
-          {props.primaryAction.label}
-        </Button>
-      )}
-
-      {props.secondaryActions &&
-        props.secondaryActions.map((action, index) => {
-          return (
-            <Button key={index} onClick={action.method}>
-              {action.label}
+      <Left>
+        <Actions>
+          {props.primaryAction && (
+            <Button primary onClick={props.primaryAction.method}>
+              {props.primaryAction.label}
             </Button>
-          )
-        })}
+          )}
 
+          {props.secondaryActions &&
+            props.secondaryActions.map((action, index) => {
+              return (
+                <Button key={index} onClick={action.method}>
+                  {action.label}
+                </Button>
+              )
+            })}
+        </Actions>
+      </Left>
       {props.destructiveActions && (
         <Right>
-          {props.destructiveActions.map((action, index) => (
-            <Button key={index} onClick={action.method} destructive>
-              {action.label}
-            </Button>
-          ))}
+          <Actions>
+            {props.destructiveActions.map((action, index) => (
+              <Button key={index} onClick={action.method} destructive>
+                {action.label}
+              </Button>
+            ))}
+          </Actions>
         </Right>
       )}
+
       <Clear />
     </StyledActions>
   )


### PR DESCRIPTION
Now that buttons don't have margin or spacings, I thought to add a hidden `Actions` component that allows to wrap a set of buttons or actions in an inline list. At first I thought this could be done with the `Stack` component but the result is not the same (there are paddings and the buttons are affected by the width. Using this `Actions` component, it adds a list with the list items as inline-block. This is very predictable and works pretty well for Form.Actions.

wdyt?
