### PR TITLE
Fix bug in connections

### DIFF
--- a/src/components/molecules/list/index.js
+++ b/src/components/molecules/list/index.js
@@ -29,7 +29,7 @@ const List = props => {
           <Subheader>{props.label}</Subheader>
         </StyledLabel>
       ) : null}
-      {props.children.map((child, index) => <StyledRow key={index}>{child}</StyledRow>)}
+      {React.Children.map(props.children, child => <StyledRow>{child}</StyledRow>)}
     </StyledList>
   )
 }


### PR DESCRIPTION
Lesson learned: 

When iterating through children, don't use `props.children.map`, it would fail in the case when there's just one child.

Use `React.Children.map` instead.