### PR TITLE
Temporary fix to reset white spce from the <pre> tags

### DIFF
--- a/src/docs/spec/playground.js
+++ b/src/docs/spec/playground.js
@@ -15,6 +15,7 @@ const Container = styled.div`
     position: relative;
   }
   & .react-live-preview {
+    white-space: normal;
     border: 1px solid ${colors.base.grayLight};
     border-bottom-width: ${props => (props.codeVisible ? 0 : '1px')};
     border-radius: 3px 3px ${props => (props.codeVisible ? '0 0' : '3px 3px')};

--- a/src/docs/spec/props.js
+++ b/src/docs/spec/props.js
@@ -8,6 +8,7 @@ import parseType from './prop-type'
 const Table = styled.table`
   width: 100%;
   margin-bottom: 80px;
+  white-space: normal;
   th,
   td {
     text-align: left;


### PR DESCRIPTION
Added a reset for the `<pre>` tags that affect the Live preview and Props table. This is a temporary fix until we figure out https://github.com/auth0/cosmos/issues/203