### PR TITLE
Add doc page-header component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,7 +226,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -16194,8 +16193,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -18344,6 +18342,16 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity":
+        "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "requires": {
+        "argparse": "1.0.9",
+        "glob": "7.1.2"
+      }
     },
     "yargs": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react-helmet": "5.2.0",
     "react-live": "1.7.1",
     "react-router-dom": "4.2.2",
-    "styled-components": "2.2.3"
+    "styled-components": "2.2.3",
+    "yamljs": "0.3.0"
   },
   "scripts": {
     "dev": "run-p dev:build 'update-progress -- -w' 'build:docs -- -w' 'build:icons -- -w'",

--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -1,5 +1,6 @@
 ```meta
   category: Actions
+  description: Buttons are great to ask users for action
 ```
 
 `import Button from 'cosmos/button'`

--- a/src/docs/spec/example.js
+++ b/src/docs/spec/example.js
@@ -39,7 +39,7 @@ const Example = props => {
           )
         } else if (language === 'lang-meta') {
           const metadata = yaml.parse(markdownProps.children)
-          return <PageHeader {...metadata} />
+          return <PageHeader {...metadata} displayName={props.component.displayName} />
         } else {
           return null
         }

--- a/src/docs/spec/example.js
+++ b/src/docs/spec/example.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Markdown from 'markdown-to-jsx'
+import yaml from 'yamljs'
 
 import Playground from './playground'
 import Break from './break'
@@ -7,6 +8,7 @@ import Break from './break'
 import IconBrowser from './icon-browser'
 import { Code } from '../../components'
 import { Text, ListItem, List, Link } from '../docs-components/typography'
+import PageHeader from './page-header'
 import SectionHeader from './section-header'
 import ExampleHeader from './example-header'
 
@@ -25,8 +27,7 @@ const Example = props => {
         const language = markdownProps.className
 
         if (!language) return <Code>{markdownProps.children}</Code>
-        else if (!['lang-js', 'lang-jsx'].includes(language)) return null
-        else {
+        else if (['lang-js', 'lang-jsx'].includes(language)) {
           return (
             <div>
               <Playground
@@ -36,6 +37,11 @@ const Example = props => {
               />
             </div>
           )
+        } else if (language === 'lang-meta') {
+          const metadata = yaml.parse(markdownProps.children)
+          return <PageHeader {...metadata} />
+        } else {
+          return null
         }
       },
       IconBrowser

--- a/src/docs/spec/index.js
+++ b/src/docs/spec/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import Helmet from 'react-helmet'
 import { metadata as components } from '../metadata.json'
 
-import { Heading1, Subheader } from '../docs-components/typography'
+import { Heading1 } from '../docs-components/typography'
 import Example from './example'
 
 const Container = styled.div``
@@ -21,9 +21,6 @@ export default props => {
       <Helmet title={component.displayName + ' — Cosmos'} />
       <Headings>
         <Heading1>{component.displayName}</Heading1>
-        <Subheader>
-          This is the component's description to be taken from the FrontMatter of the markdown file
-        </Subheader>
       </Headings>
 
       <Example documentation={component.documentation} component={component} />

--- a/src/docs/spec/index.js
+++ b/src/docs/spec/index.js
@@ -6,24 +6,14 @@ import { metadata as components } from '../metadata.json'
 import { Heading1 } from '../docs-components/typography'
 import Example from './example'
 
-const Container = styled.div``
-const Headings = styled.div`
-  margin-bottom: 3rem;
-`
-
 export default props => {
   const componentName = props.match.params.componentName
-
   const component = components.filter(component => component.displayName === componentName)[0]
 
   return (
-    <Container>
+    <div>
       <Helmet title={component.displayName + ' — Cosmos'} />
-      <Headings>
-        <Heading1>{component.displayName}</Heading1>
-      </Headings>
-
       <Example documentation={component.documentation} component={component} />
-    </Container>
+    </div>
   )
 }

--- a/src/docs/spec/page-header.js
+++ b/src/docs/spec/page-header.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Subheader } from '../docs-components/typography'
+
+const Header = props => (
+  <div>
+    <Subheader>{props.description}</Subheader>
+  </div>
+)
+
+export default Header

--- a/src/docs/spec/page-header.js
+++ b/src/docs/spec/page-header.js
@@ -1,12 +1,17 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Subheader } from '../docs-components/typography'
+import { Heading1, Subheader } from '../docs-components/typography'
+
+const Headings = styled.div`
+  margin-bottom: 3rem;
+`
 
 const Header = props => (
-  <div>
+  <Headings>
+    <Heading1>{props.displayName}</Heading1>
     <Subheader>{props.description}</Subheader>
-  </div>
+  </Headings>
 )
 
 export default Header


### PR DESCRIPTION
You can drop information at the top of the doc using [yaml](http://docs.ansible.com/ansible/latest/YAMLSyntax.html) like this: 

```meta
  category: Actions
  description: Buttons are great to ask users for action
```

and it will be available in the doc's [`PageHeader`](https://github.com/auth0/cosmos/compare/doc-header?expand=1#diff-ce2b0d4526663a22e8690c07c90193a5) component as props.

Check out  Button [markdown](https://github.com/auth0/cosmos/pull/222/files#diff-0497367b9a8e0c9306ebdd7854d050e5) and [docs](https://auth0-cosmos-doc-header.now.sh/docs/Button) to see an example.

The language choice is very arbitrary. I saw someone use yaml in markdown, so I started using it, we can also use json. That would look like this:

```meta
  {
    "category": "Actions",
    "description": "Buttons are great to ask users for action"
  }
```


Fixes https://github.com/auth0/cosmos/issues/216