### PR TITLE
[Button] Add support for tooltips

### DIFF
--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -59,11 +59,11 @@ Icon buttons work well in compact spaces. You can pick name of `icon` from [docs
 </div>
 ```
 
-### Tooltips
+### Label/Tooltips
 
-Especially with buttons that only have an icon and no text, it might be helpful to add tooltips
+Especially with buttons that only have an icon and no text, it might be helpful to add a label
 which appear when a user hovers over a button.
 
 ```js
-<Button icon="copy" tooltip="Copy to clipboard" />
+<Button icon="copy" label="Copy to clipboard" />
 ```

--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -58,3 +58,12 @@ Icon buttons work well in compact spaces. You can pick name of `icon` from [docs
   <Button icon="copy" />
 </div>
 ```
+
+### Tooltips
+
+Especially with buttons that only have an icon and no text, it might be helpful to add tooltips
+which appear when a user hovers over a button.
+
+```js
+<Button icon="copy" tooltip="Copy to clipboard" />
+```

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -125,9 +125,9 @@ const ButtonWithIconAndText = ({ children, ...props }) => (
 )
 
 const ButtonContent = ({ children, ...props }) => {
-  if (props.icon && children)
+  if (props.icon && children) {
     return <ButtonWithIconAndText {...props}>{children}</ButtonWithIconAndText>
-  else if (props.icon && !children) return <ButtonWithIcon {...props}>{children}</ButtonWithIcon>
+  } else if (props.icon && !children) return <ButtonWithIcon {...props}>{children}</ButtonWithIcon>
   else return <ButtonWithText {...props}>{children}</ButtonWithText>
 }
 
@@ -138,9 +138,9 @@ const Button = ({ children, ...props }) => {
   else if (props.loading) content = <Spinner inverse={props.primary} />
   else content = children
 
-  if (props.tooltip) {
+  if (props.label) {
     return (
-      <Tooltip content={props.tooltip}>
+      <Tooltip content={props.label}>
         <ButtonContent {...props}>{content}</ButtonContent>
       </Tooltip>
     )
@@ -208,7 +208,7 @@ Button.propTypes = {
   icon: PropTypes.string,
 
   /** Tooltip to show when the user hovers over the button */
-  tooltip: PropTypes.string,
+  label: PropTypes.string,
 
   /** Loading state when waiting for an action to complete */
   loading: PropTypes.bool,

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -6,6 +6,7 @@ import { colors, spacing, fonts, misc } from '../../../tokens/'
 import { onlyOneOf } from '../../_helpers/custom-validations'
 import Icon, { StyledIcon } from '../icon'
 import Spinner from '../spinner'
+import Tooltip from '../tooltip'
 
 const config = {
   default: {
@@ -104,34 +105,48 @@ const getAttributes = props => {
   return styles
 }
 
+const ButtonWithIcon = ({ children, ...props }) => (
+  <Button.Element {...props}>
+    <Icon name={props.icon} />
+  </Button.Element>
+)
+
+const ButtonWithText = ({ children, ...props }) => (
+  <Button.Element {...props}>
+    <Button.Content>{children}</Button.Content>
+  </Button.Element>
+)
+
+const ButtonWithIconAndText = ({ children, ...props }) => (
+  <Button.Element {...props}>
+    <Icon name={props.icon} color={getAttributes(props).text} />
+    <Button.Content>{children}</Button.Content>
+  </Button.Element>
+)
+
+const ButtonContent = ({ children, ...props }) => {
+  if (props.icon && children)
+    return <ButtonWithIconAndText {...props}>{children}</ButtonWithIconAndText>
+  else if (props.icon && !children) return <ButtonWithIcon {...props}>{children}</ButtonWithIcon>
+  else return <ButtonWithText {...props}>{children}</ButtonWithText>
+}
+
 const Button = ({ children, ...props }) => {
-  let content = children
+  let content
 
   if (props.success) content = <Icon type="success" />
   else if (props.loading) content = <Spinner inverse={props.primary} />
+  else content = children
 
-  if (props.icon && content) {
+  if (props.tooltip) {
     return (
-      <Button.Element {...props}>
-        <Icon name={props.icon} color={getAttributes(props).text} />
-        <Button.Content>{content}</Button.Content>
-      </Button.Element>
+      <Tooltip content={props.tooltip}>
+        <ButtonContent {...props}>{content}</ButtonContent>
+      </Tooltip>
     )
   }
 
-  if (props.icon) {
-    return (
-      <Button.Element {...props}>
-        <Icon name={props.icon} />
-      </Button.Element>
-    )
-  }
-
-  return (
-    <Button.Element {...props}>
-      <Button.Content>{content}</Button.Content>
-    </Button.Element>
-  )
+  return <ButtonContent {...props}>{content}</ButtonContent>
 }
 
 Button.Element = styled.button`
@@ -157,7 +172,6 @@ Button.Element = styled.button`
 
   ${Icon.Element} {
     color: ${props => getAttributes(props).text};
-    margin-right: ${spacing.xsmall};
   }
 
   &:hover {
@@ -192,6 +206,9 @@ Button.propTypes = {
 
   /** Name of icon */
   icon: PropTypes.string,
+
+  /** Tooltip to show when the user hovers over the button */
+  tooltip: PropTypes.string,
 
   /** Loading state when waiting for an action to complete */
   loading: PropTypes.bool,

--- a/src/components/molecules/_action-input/index.js
+++ b/src/components/molecules/_action-input/index.js
@@ -29,7 +29,13 @@ const ActionInput = props => {
         <TextInput {...props} />
         <ButtonGroup>
           {props.actions.map((action, index) => (
-            <Button key={index} link icon={action.icon} onClick={action.method} />
+            <Button
+              key={index}
+              link
+              icon={action.icon}
+              onClick={action.method}
+              tooltip={action.label}
+            />
           ))}
         </ButtonGroup>
       </Wrapper>
@@ -45,7 +51,8 @@ ActionInput.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       icon: PropTypes.string.isRequired,
-      method: PropTypes.func.isRequired
+      method: PropTypes.func.isRequired,
+      label: PropTypes.string.isRequired
     })
   )
 }

--- a/src/components/molecules/form/field/field.md
+++ b/src/components/molecules/form/field/field.md
@@ -21,7 +21,12 @@ In addition to their own [native props](/docs/TextInput), we add a few more prop
 
 ```js
 <Form>
-  <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+  <Form.TextInput
+    label="Field label"
+    type="text"
+    placeholder="Enter something"
+    actions={[{ icon: 'copy', handler: function() {}, label: 'Copy to clipboard' }]}
+  />
   <Form.TextArea label="Long input" placeholder="Add a lot of text here" />
   <Form.Select
     label="Options list"


### PR DESCRIPTION
Closes #193.

This patch adds a `tooltip` prop to `Button` which, when specified, will wrap the `Button` in a `Tooltip` with the value of the `tooltip` prop as the text content. This patch also expands the action shape used in `ActionInput` (and therefore `Form.TextInput`, etc.) by adding a `label` property. If specified, the action button in the input will be rendered with a tooltip.

On a side note, I don't like what `prettier` did to this function. Yikes! I promise that my original version was much more readable. 😄 

```jsx
const ButtonContent = ({ children, ...props }) => {
  if (props.icon && children)
    return <ButtonWithIconAndText {...props}>{children}</ButtonWithIconAndText>
  else if (props.icon && !children) return <ButtonWithIcon {...props}>{children}</ButtonWithIcon>
  else return <ButtonWithText {...props}>{children}</ButtonWithText>
}
```