### PR TITLE
Better documentation for Tabs

### DIFF
--- a/src/components/molecules/tabs/index.js
+++ b/src/components/molecules/tabs/index.js
@@ -69,8 +69,7 @@ Tabs.Tab = props => <TabContent>{props.children}</TabContent>
 
 Tabs.propTypes = {
   /** Children should be an array of React elements */
-  children: PropTypes.arrayOf(PropTypes.element).isRequired,
-  selected: PropTypes.bool
+  children: PropTypes.arrayOf(PropTypes.element).isRequired
 }
 
 Tabs.defaultProps = {

--- a/src/components/molecules/tabs/index.js
+++ b/src/components/molecules/tabs/index.js
@@ -69,7 +69,8 @@ Tabs.Tab = props => <TabContent>{props.children}</TabContent>
 
 Tabs.propTypes = {
   /** Children should be an array of React elements */
-  children: PropTypes.arrayOf(PropTypes.element).isRequired
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  selected: PropTypes.bool
 }
 
 Tabs.defaultProps = {

--- a/src/components/molecules/tabs/index.js
+++ b/src/components/molecules/tabs/index.js
@@ -68,7 +68,7 @@ class Tabs extends React.Component {
 Tabs.Tab = props => <TabContent>{props.children}</TabContent>
 
 Tabs.propTypes = {
-  /** Children should be an array of React elements */
+  /** Children should be an array of Tabs.Tab */
   children: PropTypes.arrayOf(PropTypes.element).isRequired
 }
 

--- a/src/components/molecules/tabs/tabs.md
+++ b/src/components/molecules/tabs/tabs.md
@@ -1,31 +1,28 @@
 ```meta
   category: Layout
+  description: Tabs are great for splitting information into sections to make them easy to consume.
 ```
 
-Tabs are great for splitting information into sections to make them easy to consume.
-
-## Examples
-
-### Simple tabs
-
-```js
+```jsx
 <Tabs>
-  <Tabs.Tab label="Tab 1">this is tab 1</Tabs.Tab>
-  <Tabs.Tab label="Tab 2">you can render anything you want here</Tabs.Tab>
-  <Tabs.Tab label="Tab 3">third tab!</Tabs.Tab>
+  <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
+  <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
+  <Tabs.Tab label="Tab 3">Third tab's the charm!</Tabs.Tab>
 </Tabs>
 ```
 
+## Examples
+
 ### Default selected tab
 
-By default the first tab is selected, you can change this behaviour attaching the `selected` prop to a `Tab`.
+By default, the first tab is selected but you can change this behavior attaching the `selected` prop to a `Tab`.
 
 ```js
 <Tabs>
-  <Tabs.Tab label="Tab 1">this is tab 1</Tabs.Tab>
-  <Tabs.Tab label="Tab 2">you can render anything you want here</Tabs.Tab>
+  <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
+  <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
   <Tabs.Tab label="Tab 3" selected>
-    look, third tab is selected by default!
+    Look, third tab is selected by default!
   </Tabs.Tab>
 </Tabs>
 ```


### PR DESCRIPTION
- [x] Added Playground
- [x] Document `selected` prop (manually)

I got stuck documenting the `selected` prop. I added the `boolean` type but it looks weird as the switch doesn't do anything as it can't know which tab to activate. That made me look into other implementations where the selected tab is a `string` passed to **Tabs** (not to the single Tab) and each Tab has an `ID`. Just throwing this to see if we can solve this now, or we sit on this.

Check the deployment docs look like this:
<img width="899" alt="screen shot 2018-02-07 at 20 28 51" src="https://user-images.githubusercontent.com/239215/35947320-1e7049b4-0c46-11e8-9151-0c2e0dd28692.png">
  