### PR TITLE
Select: Fix readonly and default selection

### DIFF
--- a/src/components/atoms/select/index.js
+++ b/src/components/atoms/select/index.js
@@ -37,7 +37,9 @@ Select.propTypes = {
   /** Make input readOnly if it does not validate constraint */
   readOnly: PropTypes.bool,
   /** Value selected by default */
-  value: PropTypes.any
+  value: PropTypes.any,
+  /** onChange transparently passed to select */
+  onChange: PropTypes.func
 }
 
 Select.defaultProps = {

--- a/src/components/atoms/select/index.js
+++ b/src/components/atoms/select/index.js
@@ -18,7 +18,7 @@ const Select = ({ options, ...props }) => {
   return (
     <StyledSelect {...props}>
       {options.map((option, index) => (
-        <option key={index} value={option.value} selected={option.defaultSelected}>
+        <option key={index} value={option.value}>
           {option.text}
         </option>
       ))}
@@ -31,12 +31,13 @@ Select.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string.isRequired,
-      value: PropTypes.any.isRequired,
-      defaultSelected: PropTypes.bool
+      value: PropTypes.any.isRequired
     })
   ).isRequired,
   /** Make input readOnly if it does not validate constraint */
-  readOnly: PropTypes.bool
+  readOnly: PropTypes.bool,
+  /** Value selected by default */
+  value: PropTypes.any
 }
 
 Select.defaultProps = {

--- a/src/components/atoms/select/select.md
+++ b/src/components/atoms/select/select.md
@@ -7,6 +7,7 @@ The `<Select>` component renders a styled drop-down selector.
     { text: 'Two', value: 2 },
     { text: 'Three', value: 3 }
   ]}
+  onChange={ event => console.log(event) }
 />
 ```
 
@@ -17,6 +18,7 @@ to match a value from options
 <Select
   value={2}
   options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
+  onChange={event => console.log(event)}
 />
 ```
 
@@ -26,5 +28,6 @@ You can also indicate that a `<Select>` should be read-only by setting the `read
 <Select
   readOnly
   options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
+  onChange={event => console.log(event)}
 />
 ```

--- a/src/components/atoms/select/select.md
+++ b/src/components/atoms/select/select.md
@@ -1,21 +1,22 @@
 The `<Select>` component renders a styled drop-down selector.
 
 ```jsx
-<Select
-  options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
+<Select {props}
+  options={[
+    { text: 'One', value: 1 },
+    { text: 'Two', value: 2 },
+    { text: 'Three', value: 3 }
+  ]}
 />
 ```
 
-By default, the first option will be selected. To override this, you can set `defaultSelected`
-to `true` on another option:
+By default, the first option will be selected. To override this, you can set `value`
+to match a value from options
 
 ```js
 <Select
-  options={[
-    { text: 'One', value: 1 },
-    { text: 'Two', value: 2, defaultSelected: true },
-    { text: 'Three', value: 3 }
-  ]}
+  value={2}
+  options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
 />
 ```
 

--- a/src/docs/spec/props.js
+++ b/src/docs/spec/props.js
@@ -49,7 +49,7 @@ const PropSwitcher = ({ propName, data, onPropsChange }) => {
 
   if (data.type.name === 'bool') {
     return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={method} />
-  } else if (['string', 'number'].includes(data.type.name)) {
+  } else if (['string', 'number', 'any'].includes(data.type.name)) {
     return <TextInput defaultValue={data.value} onChange={e => method(e.target.value)} />
   } else if (data.type.name === 'enum') {
     const options = data.type.value.map(({ value }) => ({ text: value, value }))


### PR DESCRIPTION
1. readOnly was not working because `{props}` was missing.
2. React was throwing a few errors at us

```
Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
```

- [x] Fixed readOnly toggle in docs
- [x] Fixed React error about defaultSelected.
- [x] Added onChange prop