### PR TITLE
Docs: Remove false booleans from playground

### DIFF
--- a/src/docs/spec/default-props.js
+++ b/src/docs/spec/default-props.js
@@ -1,0 +1,12 @@
+const addDefaultValues = propData => {
+  /* filter out internal props, they start with _underscore */
+  const propNames = Object.keys(propData).filter(key => key[0] !== '_')
+
+  propNames.forEach(name => {
+    const { defaultValue, type } = propData[name]
+    propData[name].value = defaultValue ? defaultValue.value : 'null'
+  })
+  return propData
+}
+
+export default addDefaultValues

--- a/src/docs/spec/playground.js
+++ b/src/docs/spec/playground.js
@@ -7,6 +7,7 @@ import * as Components from '../../components'
 import { fonts, colors, spacing } from '../../tokens'
 import uniqueId from '../../components/_helpers/uniqueId'
 import Props from './props'
+import getPropString from './prop-string'
 
 const Container = styled.div`
   margin: ${spacing.medium} 0;
@@ -90,22 +91,7 @@ class Playground extends React.Component {
     document.execCommand('copy')
   }
   onPropsChange(propData) {
-    // TODO: Refactor this block when less sleepy
-
-    let propString = ''
-
-    const propNames = Object.keys(propData).filter(key => key[0] !== '_')
-
-    propNames.forEach(name => {
-      if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
-        propString += ` ${name}`
-      } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
-        propString += ` ${name}="${propData[name].value}"`
-      } else if (propData[name].value !== 'null') {
-        propString += ` ${name}={${propData[name].value}}`
-      }
-    })
-
+    const propString = getPropString(propData)
     this.setState({ code: this.props.code.replace(' {props}', propString) })
   }
   render() {

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -9,7 +9,7 @@ const getPropString = propData => {
       propString += ` ${name}`
     } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
       propString += ` ${name}="${propData[name].value}"`
-    } else if (propData[name].type.name === 'number' && propData[name].value !== 'null') {
+    } else if (!['null', 'false'].includes(propData[name].value)) {
       propString += ` ${name}={${propData[name].value}}`
     }
   })

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -5,7 +5,6 @@ const getPropString = propData => {
   const propNames = Object.keys(propData).filter(key => key[0] !== '_')
 
   propNames.forEach(name => {
-    console.log(propData[name])
     if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
       propString += ` ${name}`
     } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -1,16 +1,16 @@
 const getPropString = propData => {
-  // TODO: Refactor this block when less sleepy
-
   let propString = ''
 
+  /* filter out internal props, they start with _underscore */
   const propNames = Object.keys(propData).filter(key => key[0] !== '_')
 
   propNames.forEach(name => {
+    console.log(propData[name])
     if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
       propString += ` ${name}`
     } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
       propString += ` ${name}="${propData[name].value}"`
-    } else if (propData[name].value !== 'null') {
+    } else if (propData[name].type.name === 'number' && propData[name].value !== 'null') {
       propString += ` ${name}={${propData[name].value}}`
     }
   })

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -1,0 +1,21 @@
+const getPropString = propData => {
+  // TODO: Refactor this block when less sleepy
+
+  let propString = ''
+
+  const propNames = Object.keys(propData).filter(key => key[0] !== '_')
+
+  propNames.forEach(name => {
+    if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
+      propString += ` ${name}`
+    } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
+      propString += ` ${name}="${propData[name].value}"`
+    } else if (propData[name].value !== 'null') {
+      propString += ` ${name}={${propData[name].value}}`
+    }
+  })
+
+  return propString
+}
+
+export default getPropString

--- a/src/docs/spec/prop-switcher.js
+++ b/src/docs/spec/prop-switcher.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { TextInput, Switch, Select } from '../../components'
+
+const PropSwitcher = ({ propName, data, onPropsChange }) => {
+  let method = value => onPropsChange(propName, value.toString())
+
+  if (data.type.name === 'bool') {
+    return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={method} />
+  } else if (['string', 'number'].includes(data.type.name)) {
+    return <TextInput defaultValue={data.value} onChange={e => method(e.target.value)} />
+  } else if (data.type.name === 'enum') {
+    const options = data.type.value.map(({ value }) => ({ text: value, value }))
+    return <Select onChange={e => method(e.target.value)} options={options} />
+  }
+  return <div />
+}
+
+export default PropSwitcher

--- a/src/docs/spec/props.js
+++ b/src/docs/spec/props.js
@@ -2,8 +2,10 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { spacing, colors, fonts, misc } from '../../tokens'
-import { TextInput, Switch, Code, Select } from '../../components'
+import { Code } from '../../components'
 import parseType from './prop-type'
+import addDefaultValues from './default-props'
+import PropSwitcher from './prop-switcher'
 
 const Table = styled.table`
   width: 100%;
@@ -44,35 +46,12 @@ const Description = styled.span`
   color: ${colors.base.grayDark};
 `
 
-const PropSwitcher = ({ propName, data, onPropsChange }) => {
-  let method = value => onPropsChange(propName, value.toString())
-
-  if (data.type.name === 'bool') {
-    return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={method} />
-  } else if (['string', 'number'].includes(data.type.name)) {
-    return <TextInput defaultValue={data.value} onChange={e => method(e.target.value)} />
-  } else if (data.type.name === 'enum') {
-    const options = data.type.value.map(({ value }) => ({ text: value, value }))
-    return <Select onChange={e => method(e.target.value)} options={options} />
-  }
-  return <div />
-}
-
 class Props extends React.Component {
   constructor(props) {
     super(props)
-    const propData = this.getDefaultValues(props.propData)
+    const propData = addDefaultValues(props.propData)
     this.state = { propData: propData }
     this.props.onPropsChange(propData)
-  }
-
-  getDefaultValues(propData) {
-    const propNames = Object.keys(propData).filter(key => key[0] !== '_')
-    propNames.forEach(name => {
-      const { defaultValue } = propData[name]
-      propData[name].value = defaultValue ? defaultValue.value : 'null'
-    })
-    return propData
   }
 
   onPropsChange(propName, value) {


### PR DESCRIPTION
This PR sets up some of the groundwork for https://github.com/auth0/cosmos/issues/231.

Thought it's worth merging on it's own as well. 

1. (Enhancement) Removes redundant `transparent={false} disabled={false} destructive={false}...` noise.
2. (Invisible) Pulls out some of the confusing functions related to prop table to their own files, making them easy to refactor

<img width="639" alt="screen shot 2018-02-09 at 11 38 06 am" src="https://user-images.githubusercontent.com/1863771/36014031-bb714784-0d8d-11e8-92a2-0d77a8503a18.png">
