### PR TITLE
Proptable clean strings

### DIFF
--- a/src/components/molecules/empty-state/empty-state.md
+++ b/src/components/molecules/empty-state/empty-state.md
@@ -7,6 +7,7 @@ Empty states are displayed when a page has no content.
 
 ```jsx
 <EmptyState
+  {props}
   title="Clients"
   icon="clients"
   action={{

--- a/src/components/molecules/empty-state/empty-state.md
+++ b/src/components/molecules/empty-state/empty-state.md
@@ -7,7 +7,6 @@ Empty states are displayed when a page has no content.
 
 ```jsx
 <EmptyState
-  {props}
   title="Clients"
   icon="clients"
   action={{

--- a/src/docs/spec/default-props.js
+++ b/src/docs/spec/default-props.js
@@ -1,0 +1,12 @@
+const addDefaultValues = propData => {
+  /* filter out internal props, they start with _underscore */
+  const propNames = Object.keys(propData).filter(key => key[0] !== '_')
+
+  propNames.forEach(name => {
+    const { defaultValue, type } = propData[name]
+    propData[name].value = defaultValue ? defaultValue.value : 'null'
+  })
+  return propData
+}
+
+export default addDefaultValues

--- a/src/docs/spec/playground.js
+++ b/src/docs/spec/playground.js
@@ -7,6 +7,7 @@ import * as Components from '../../components'
 import { fonts, colors, spacing } from '../../tokens'
 import uniqueId from '../../components/_helpers/uniqueId'
 import Props from './props'
+import getPropString from './prop-string'
 
 const Container = styled.div`
   margin: ${spacing.medium} 0;
@@ -90,22 +91,7 @@ class Playground extends React.Component {
     document.execCommand('copy')
   }
   onPropsChange(propData) {
-    // TODO: Refactor this block when less sleepy
-
-    let propString = ''
-
-    const propNames = Object.keys(propData).filter(key => key[0] !== '_')
-
-    propNames.forEach(name => {
-      if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
-        propString += ` ${name}`
-      } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
-        propString += ` ${name}="${propData[name].value}"`
-      } else if (propData[name].value !== 'null') {
-        propString += ` ${name}={${propData[name].value}}`
-      }
-    })
-
+    const propString = getPropString(propData)
     this.setState({ code: this.props.code.replace(' {props}', propString) })
   }
   render() {

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -9,7 +9,7 @@ const getPropString = propData => {
       propString += ` ${name}`
     } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
       propString += ` ${name}="${propData[name].value}"`
-    } else if (propData[name].type.name === 'number' && propData[name].value !== 'null') {
+    } else if (!['null', 'false'].includes(propData[name].value)) {
       propString += ` ${name}={${propData[name].value}}`
     }
   })

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -5,7 +5,6 @@ const getPropString = propData => {
   const propNames = Object.keys(propData).filter(key => key[0] !== '_')
 
   propNames.forEach(name => {
-    console.log(propData[name])
     if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
       propString += ` ${name}`
     } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -1,16 +1,16 @@
 const getPropString = propData => {
-  // TODO: Refactor this block when less sleepy
-
   let propString = ''
 
+  /* filter out internal props, they start with _underscore */
   const propNames = Object.keys(propData).filter(key => key[0] !== '_')
 
   propNames.forEach(name => {
+    console.log(propData[name])
     if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
       propString += ` ${name}`
     } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
       propString += ` ${name}="${propData[name].value}"`
-    } else if (propData[name].value !== 'null') {
+    } else if (propData[name].type.name === 'number' && propData[name].value !== 'null') {
       propString += ` ${name}={${propData[name].value}}`
     }
   })

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -1,0 +1,21 @@
+const getPropString = propData => {
+  // TODO: Refactor this block when less sleepy
+
+  let propString = ''
+
+  const propNames = Object.keys(propData).filter(key => key[0] !== '_')
+
+  propNames.forEach(name => {
+    if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
+      propString += ` ${name}`
+    } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
+      propString += ` ${name}="${propData[name].value}"`
+    } else if (propData[name].value !== 'null') {
+      propString += ` ${name}={${propData[name].value}}`
+    }
+  })
+
+  return propString
+}
+
+export default getPropString

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -4,13 +4,59 @@ const getPropString = propData => {
   /* filter out internal props, they start with _underscore */
   const propNames = Object.keys(propData).filter(key => key[0] !== '_')
 
+  /*
+    react-docgen gives us values as string instead of booleans
+    this can lead to strange values getting into props
+
+    we parse these values to decide what to put in
+  */
   propNames.forEach(name => {
+    /*
+      Case 1: Falsy boolean
+      These should be ignored: primary="false" / name="null"
+     */
+    if (['null', 'false'].includes(propData[name].value)) {
+      return false
+    }
+
+    /*
+      Case 2: Truthy boolean
+      We only need to drop the key
+      Example: primary="true" results in <Button primary>
+    */
     if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
       propString += ` ${name}`
-    } else if (propData[name].type.name === 'string' && propData[name].value !== 'null') {
+      return true
+    }
+
+    /*
+      Case 3: Strings
+      They should be printed wrapped in double quotes "string"
+      Example: <Button icon="copy">
+    */
+    if (typeof propData[name].value === 'string') {
       propString += ` ${name}="${propData[name].value}"`
-    } else if (!['null', 'false'].includes(propData[name].value)) {
+      return true
+    }
+
+    /*
+      Case 4: Numbers
+      Numbers are wrapped in in {}
+      Example: <Icon size={20}>
+    */
+    if (typeof propData[name].value === 'number') {
       propString += ` ${name}={${propData[name].value}}`
+      return true
+    }
+
+    /*
+      Default case:
+      If something reaches here, we probably don't know what to do with yet.
+      Wrapping the value in {} is a safe output
+    */
+    if (propData[name].value) {
+      propString += ` ${name}={${propData[name].value}}`
+      return true
     }
   })
 

--- a/src/docs/spec/prop-switcher.js
+++ b/src/docs/spec/prop-switcher.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { TextInput, Switch, Select } from '../../components'
+
+const PropSwitcher = ({ propName, data, onPropsChange }) => {
+  let method = value => onPropsChange(propName, value.toString())
+
+  if (data.type.name === 'bool') {
+    return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={method} />
+  } else if (['string', 'number'].includes(data.type.name)) {
+    return <TextInput defaultValue={data.value} onChange={e => method(e.target.value)} />
+  } else if (data.type.name === 'enum') {
+    const options = data.type.value.map(({ value }) => ({ text: value, value }))
+    return <Select onChange={e => method(e.target.value)} options={options} />
+  }
+  return <div />
+}
+
+export default PropSwitcher

--- a/src/docs/spec/props.js
+++ b/src/docs/spec/props.js
@@ -2,8 +2,10 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { spacing, colors, fonts, misc } from '../../tokens'
-import { TextInput, Switch, Code, Select } from '../../components'
+import { Code } from '../../components'
 import parseType from './prop-type'
+import addDefaultValues from './default-props'
+import PropSwitcher from './prop-switcher'
 
 const Table = styled.table`
   width: 100%;
@@ -44,35 +46,12 @@ const Description = styled.span`
   color: ${colors.base.grayDark};
 `
 
-const PropSwitcher = ({ propName, data, onPropsChange }) => {
-  let method = value => onPropsChange(propName, value.toString())
-
-  if (data.type.name === 'bool') {
-    return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={method} />
-  } else if (['string', 'number'].includes(data.type.name)) {
-    return <TextInput defaultValue={data.value} onChange={e => method(e.target.value)} />
-  } else if (data.type.name === 'enum') {
-    const options = data.type.value.map(({ value }) => ({ text: value, value }))
-    return <Select onChange={e => method(e.target.value)} options={options} />
-  }
-  return <div />
-}
-
 class Props extends React.Component {
   constructor(props) {
     super(props)
-    const propData = this.getDefaultValues(props.propData)
+    const propData = addDefaultValues(props.propData)
     this.state = { propData: propData }
     this.props.onPropsChange(propData)
-  }
-
-  getDefaultValues(propData) {
-    const propNames = Object.keys(propData).filter(key => key[0] !== '_')
-    propNames.forEach(name => {
-      const { defaultValue } = propData[name]
-      propData[name].value = defaultValue ? defaultValue.value : 'null'
-    })
-    return propData
   }
 
   onPropsChange(propName, value) {

--- a/tooling/component-metadata.js
+++ b/tooling/component-metadata.js
@@ -30,6 +30,25 @@ const run = () => {
         /* parse the component code to get metadata */
         const data = docgen.parse(code, null, handlers)
 
+        /* remove redundant quotes from default value of type string */
+        Object.values(data.props).forEach(prop => {
+          if (prop.defaultValue) {
+            if (typeof prop.defaultValue.value === 'string') {
+              prop.defaultValue.value = prop.defaultValue.value.replace(/^'(.*)'$/, '$1')
+            }
+          }
+        })
+
+        /* remove redundant quotes from enum values in prop types */
+
+        Object.values(data.props).forEach(prop => {
+          if (prop.type.name === 'enum') {
+            prop.type.value.forEach(element => {
+              element.value = element.value.replace(/^'(.*)'$/, '$1')
+            })
+          }
+        })
+
         /* add filepath to metadata */
         data.filepath = path
 


### PR DESCRIPTION
**Hard dependency on https://github.com/auth0/cosmos/pull/255** (Review after merging that)

Fixes https://github.com/auth0/cosmos/issues/231

&nbsp;

Part 1:

Because `react-docgen` does not evaluate `propTypes` and `defaultProps`, it results in ugly strings in the metadata

```js
name: "'copy'"
```

Added some string cleaning in `build:docs`. (Not the prettiest code, we can rid of this part after https://github.com/auth0/cosmos/issues/253)

&nbsp;

Part 2: 

Cleaned up potential cases for prop-string generation for playground. The code is now readable 🎉 and handles booleans, numbers and strings cleanly.

This is how it works:


```
Case 1: Falsy booleans:  These should be ignored: primary="false" / name="null"

Case 2: Truthy boolean: We only need to drop the key
Example: primary="true" results in <Button primary>

Case 3: Strings: They should be printed wrapped in double quotes "string"
Example: <Button icon="copy">

Case 4: Numbers: numbers are wrapped in in {}
Example: <Icon size={20}>

Default case: If something reaches here, we probably don't know what to do with yet. Wrapping the value in {} is a safe output
```