### PR TITLE
Documentation Tweaks Part 1

### DIFF
--- a/src/components/atoms/text-input/text-input.md
+++ b/src/components/atoms/text-input/text-input.md
@@ -33,15 +33,8 @@ It also ships with a `code` prop that is useful when the input is a hash/code va
 
 The `readOnly` prop can be used for disabling input that do not satisfy constraints.
 
-To show validation errors, use the `error` prop which takes the error message as a string.
-
 ```js
-<div>
-  <TextInput readOnly placeholder="Field is disabled" />
-  <br />
-  <br />
-  <TextInput defaultValue="siddharth@auth..com" error="email id not valid" />
-</div>
+<TextInput readOnly placeholder="Field is disabled" />
 ```
 
 ### Function

--- a/src/components/atoms/textarea/index.js
+++ b/src/components/atoms/textarea/index.js
@@ -20,15 +20,18 @@ TextArea.propTypes = {
   /** Pass error string directly to show error state */
   error: PropTypes.string,
   /** Allow resizing of the textarea */
-  resizable: PropTypes.bool
+  resizable: PropTypes.bool,
+  /** onChange transparently passed to the input */
+  onChange: PropTypes.func
 }
 
 TextArea.defaultProps = {
-  length: 5,
+  length: 3,
   readOnly: false,
   code: false,
   error: null,
-  resizable: true
+  resizable: true,
+  onChange: null
 }
 
 export default TextArea

--- a/src/components/atoms/textarea/textarea.md
+++ b/src/components/atoms/textarea/textarea.md
@@ -40,15 +40,8 @@ You can make the `TextArea` longer by using the `length` prop. By default, it's 
 
 The `readOnly` prop can be used for disabling input that do not satisfy constraints.
 
-To show validation errors, use the `error` prop which takes the error message as a string.
-
 ```js
-<div>
-  <TextArea readOnly placeholder="Field is disabled" />
-  <br />
-  <br />
-  <TextArea defaultValue="siddharth@auth..com" error="email id not valid" />
-</div>
+<TextArea readOnly placeholder="Field is disabled" />
 ```
 
 ### Function

--- a/src/components/atoms/tooltip/index.js
+++ b/src/components/atoms/tooltip/index.js
@@ -73,6 +73,8 @@ const Tooltip = ({ content, ...props }) => {
 }
 
 Tooltip.propTypes = {
+  /** Content to show in the tooltip */
+  content: PropTypes.string.isRequired,
   /** Use to show tooltip on top */
   top: PropTypes.bool,
   /** Use to show tooltip on bottom */
@@ -80,6 +82,7 @@ Tooltip.propTypes = {
 }
 
 Tooltip.defaultProps = {
+  content: null,
   top: true,
   bottom: false
 }

--- a/src/components/atoms/tooltip/tooltip.md
+++ b/src/components/atoms/tooltip/tooltip.md
@@ -1,5 +1,5 @@
 ```jsx
-<Tooltip {props} content="Here is some text">Hover me</Tooltip>
+<Tooltip content="Here is some text" {props}>Hover me</Tooltip>
 ```
 
 ---


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/246 (Rollup: Documentation Tweaks)

↗️ ActionInput: Add documentation about form actions (this was added to TextInput already in #224, is that sufficient?)
- [x] TextArea: Change small textarea to have 3 lines
- [x] TextArea: Remove error example
- [x] TextArea: `onChange` prop doesn't appear in the props table
- [x] TextInput: Remove error example
- [x] Tooltip: Add documentation for `content` property