### PR TITLE
Add props + example for form field actiosn

### DIFF
--- a/src/components/molecules/_action-input/index.js
+++ b/src/components/molecules/_action-input/index.js
@@ -2,11 +2,20 @@ import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
-import TextInput from '../../atoms/text-input'
+import TextInput, { StyledInput } from '../../atoms/text-input'
 import Button from '../../atoms/button'
+import { multiply } from '../../_helpers/pixel-calc'
+
+/* TODO: width of button should be exported by button component */
+const widthOfButton = '62px'
 
 const Wrapper = styled.div`
   position: relative;
+  ${StyledInput} {
+    ${props => {
+      if (!props.actions) return
+      return `padding-right: ${multiply(widthOfButton, props.actions.length)}`
+    }}
 `
 
 const ButtonGroup = styled.div`
@@ -25,7 +34,7 @@ const ButtonGroup = styled.div`
 const ActionInput = props => {
   if (props.actions) {
     return (
-      <Wrapper>
+      <Wrapper actions={props.actions}>
         <TextInput {...props} />
         <ButtonGroup>
           {props.actions.map((action, index) => (

--- a/src/components/molecules/form/field/field.md
+++ b/src/components/molecules/form/field/field.md
@@ -71,6 +71,8 @@ Here's a secret: `description` has not matured to support links yet. You can how
 
 ### Actions
 
+You can add actions to a field by passing an array of `{ icon, method }`:
+
 ```js
 <Form>
   <Form.TextInput

--- a/src/components/molecules/form/field/field.md
+++ b/src/components/molecules/form/field/field.md
@@ -69,6 +69,22 @@ Here's a secret: `description` has not matured to support links yet. You can how
 </Form>
 ```
 
+### Actions
+
+```js
+<Form>
+  <Form.TextInput
+    label="Allowed URLs"
+    type="text"
+    placeholder="Enter something"
+    actions={[
+      { icon: 'copy', method: e => console.log(e) },
+      { icon: 'delete', method: e => console.log(e) }
+    ]}
+  />
+</Form>
+```
+
 ### Validation
 
 We leave the logic part of validation to you the developer, you can pass `error` back to the field and it will take care of the presentation.

--- a/src/components/molecules/form/field/index.js
+++ b/src/components/molecules/form/field/index.js
@@ -65,7 +65,14 @@ Field.propTypes = {
   /** Description to give users some context */
   description: PropTypes.string,
   /** Error message to show in case of failed validation */
-  error: PropTypes.string
+  error: PropTypes.string,
+  /** Actions to be attached to input */
+  actions: PropTypes.arrayOf(
+    PropTypes.shape({
+      icon: PropTypes.string.isRequired,
+      method: PropTypes.func.isRequired
+    })
+  )
 }
 
 Field.defaultProps = {


### PR DESCRIPTION
- [x] Add docs for actions in `Form.Actions`
- [x] Add padding to avoid text overlap https://github.com/auth0/cosmos/issues/245

Note: The separation between icons is way too big, being handled in https://github.com/auth0/cosmos/pull/213