### PR TITLE
Set font size of code input/textareas to 13px, force fixed height, remove white-space pre in textareas

### DIFF
--- a/src/components/atoms/_styled-input/index.js
+++ b/src/components/atoms/_styled-input/index.js
@@ -41,6 +41,7 @@ const StyledInput = styled.input`
   border-radius: ${misc.radius};
 
   font-family: ${props => (props.code ? fonts.family.code : 'inherit')};
+  font-size: ${props => (props.code ? '13px' : 'inherit')};
   color: ${colors.text.inputs};
 
   padding: ${misc.inputs.padding} ${spacing.small};

--- a/src/components/atoms/text-input/index.js
+++ b/src/components/atoms/text-input/index.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types'
 
 import { StyledInput } from '../_styled-input'
 
-const TextInput = props => <StyledInput {...props} />
+const StyledInputElement = StyledInput.extend`
+  height: 44px;
+`
+
+const TextInput = props => <StyledInputElement {...props} />
 
 TextInput.propTypes = {
   /** Make input readOnly if it does not validate constraint */

--- a/src/components/atoms/textarea/index.js
+++ b/src/components/atoms/textarea/index.js
@@ -5,7 +5,7 @@ import { StyledInput } from '../_styled-input'
 
 const StyledTextArea = StyledInput.withComponent('textarea').extend`
   resize: ${props => (props.resizable ? 'vertical' : 'none')};
-  white-space: ${props => (props.code ? 'pre' : 'normal')};
+  font-size: ${props => (props.code ? '13px' : 'inherit')};
 `
 
 const TextArea = props => <StyledTextArea rows={props.length} {...props} />


### PR DESCRIPTION
Closes #243 and #244.

We may want to consider adding tokens for the font size and/or the input height, but this should suffice for now.