### PR TITLE
Add ButtonGroup component

### DIFF
--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -109,7 +109,7 @@ const getAttributes = props => {
 }
 
 const ButtonWithIcon = ({ children, ...props }) => (
-  <Button.Element {...props}>
+  <Button.Element {...props} onlyIcon>
     <Icon name={props.icon} />
   </Button.Element>
 )
@@ -153,7 +153,7 @@ const Button = ({ children, ...props }) => {
 }
 
 Button.Element = styled.button`
-  min-width: ${props => (props.icon ? '36px' : '96px')};
+  min-width: ${props => (props.onlyIcon ? '36px' : '96px')};
   box-sizing: border-box;
 
   text-transform: uppercase;
@@ -168,7 +168,7 @@ Button.Element = styled.button`
 
   color: ${props => getAttributes(props).text};
 
-  padding: ${spacing.xsmall} ${props => (!props.children ? 0 : spacing.small)};
+  padding: ${spacing.xsmall} ${props => (props.onlyIcon ? 0 : spacing.small)};
 
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   transition: border-color ${misc.animationDuration}, background ${misc.animationDuration};

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -78,3 +78,6 @@ export { Stack }
 
 import List from './molecules/list'
 export { List }
+
+import ButtonGroup from './molecules/button-group'
+export { ButtonGroup }

--- a/src/components/molecules/_action-input/index.js
+++ b/src/components/molecules/_action-input/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 
 import TextInput, { StyledInput } from '../../atoms/text-input'
 import Button from '../../atoms/button'
+import ButtonGroup, { StyledButtonGroup } from '../../molecules/button-group'
 import { multiply } from '../../_helpers/pixel-calc'
 
 /* TODO: width of button should be exported by button component */
@@ -15,15 +16,13 @@ const Wrapper = styled.div`
     ${props => {
       if (!props.actions) return
       return `padding-right: ${multiply(widthOfButton, props.actions.length)}`
-    }}
-`
+    }};
+  }
 
-const ButtonGroup = styled.div`
-  position: absolute;
-  right: 0;
-  top: 2px;
-  ${Button.Element} {
-    margin: 0;
+  ${StyledButtonGroup} {
+    position: absolute;
+    right: 0;
+    top: 2px;
   }
 `
 

--- a/src/components/molecules/_action-input/index.js
+++ b/src/components/molecules/_action-input/index.js
@@ -35,7 +35,7 @@ const ActionInput = props => {
     return (
       <Wrapper actions={props.actions}>
         <TextInput {...props} />
-        <ButtonGroup>
+        <ButtonGroup compressed>
           {props.actions.map((action, index) => (
             <Button
               key={index}

--- a/src/components/molecules/button-group/button-group.md
+++ b/src/components/molecules/button-group/button-group.md
@@ -33,7 +33,7 @@
 ```js
 <Stack>
   <ButtonGroup compressed>
-    <Button primary>Save changes</Button>
+    <Button>Save changes</Button>
     <Button>Clear</Button>
   </ButtonGroup>
   <ButtonGroup compressed>

--- a/src/components/molecules/button-group/button-group.md
+++ b/src/components/molecules/button-group/button-group.md
@@ -7,26 +7,39 @@
 
 ---
 
-## Examples
-
-```js
-<ButtonGroup>
+```jsx
+<ButtonGroup {props}>
   <Button primary>Save changes</Button>
   <Button>Clear</Button>
 </ButtonGroup>
 ```
 
+## Examples
+
 ```js
 <Stack>
+  <ButtonGroup>
+    <Button primary>Save changes</Button>
+    <Button>Clear</Button>
+  </ButtonGroup>
   <ButtonGroup>
     <Button icon="pencil" />
     <Button icon="copy" />
     <Button icon="trash" />
   </ButtonGroup>
-  <ButtonGroup>
-    <Button link icon="pencil" />
-    <Button link icon="copy" />
-    <Button link icon="trash" />
+</Stack>
+```
+
+```js
+<Stack>
+  <ButtonGroup compressed>
+    <Button primary>Save changes</Button>
+    <Button>Clear</Button>
+  </ButtonGroup>
+  <ButtonGroup compressed>
+    <Button icon="pencil" />
+    <Button icon="copy" />
+    <Button icon="trash" />
   </ButtonGroup>
 </Stack>
 ```

--- a/src/components/molecules/button-group/button-group.md
+++ b/src/components/molecules/button-group/button-group.md
@@ -1,0 +1,32 @@
+```meta
+  category: Layout
+  description: Use a ButtonGroup to put related buttons together
+```
+
+`import ButtonGroup from 'cosmos/button-group'`
+
+---
+
+## Examples
+
+```js
+<ButtonGroup>
+  <Button primary>Save changes</Button>
+  <Button>Clear</Button>
+</ButtonGroup>
+```
+
+```js
+<Stack>
+  <ButtonGroup>
+    <Button icon="pencil" />
+    <Button icon="copy" />
+    <Button icon="trash" />
+  </ButtonGroup>
+  <ButtonGroup>
+    <Button link icon="pencil" />
+    <Button link icon="copy" />
+    <Button link icon="trash" />
+  </ButtonGroup>
+</Stack>
+```

--- a/src/components/molecules/button-group/index.js
+++ b/src/components/molecules/button-group/index.js
@@ -19,7 +19,7 @@ const iconsOnlyStyles = css`
   }
 `
 
-const Wrapper = styled.div`
+const StyledButtonGroup = styled.div`
   display: inline-block;
 
   ${Button.Element} {
@@ -36,7 +36,7 @@ const ButtonGroup = props => {
     if (child.props.children) iconsOnly = false
   })
 
-  return <Wrapper iconsOnly={iconsOnly}>{props.children}</Wrapper>
+  return <StyledButtonGroup iconsOnly={iconsOnly}>{props.children}</StyledButtonGroup>
 }
 
 ButtonGroup.propTypes = {
@@ -46,3 +46,4 @@ ButtonGroup.propTypes = {
 ButtonGroup.defaultProps = {}
 
 export default ButtonGroup
+export { StyledButtonGroup }

--- a/src/components/molecules/button-group/index.js
+++ b/src/components/molecules/button-group/index.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
+
+import Button from '../../atoms/button'
+import { spacing } from '../../../tokens'
+
+const iconsOnlyStyles = css`
+  ${Button.Element}:first-child {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  ${Button.Element}:last-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  ${Button.Element}:not(:first-child):not(:last-child) {
+    border-radius: 0;
+  }
+`
+
+const Wrapper = styled.div`
+  ${Button.Element} {
+    margin-right: ${props => (props.iconsOnly ? 0 : spacing.small)};
+  }
+
+  ${props => (props.iconsOnly ? iconsOnlyStyles : null)};
+`
+
+const ButtonGroup = props => {
+  let iconsOnly = true
+
+  React.Children.forEach(props.children, child => {
+    if (child.props.children) iconsOnly = false
+  })
+
+  return <Wrapper iconsOnly={iconsOnly}>{props.children}</Wrapper>
+}
+
+ButtonGroup.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element)
+}
+
+ButtonGroup.defaultProps = {}
+
+export default ButtonGroup

--- a/src/components/molecules/button-group/index.js
+++ b/src/components/molecules/button-group/index.js
@@ -5,7 +5,7 @@ import styled, { css } from 'styled-components'
 import Button from '../../atoms/button'
 import { spacing } from '../../../tokens'
 
-const iconsOnlyStyles = css`
+const groupRadiusStyles = css`
   ${Button.Element}:first-child {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
@@ -23,27 +23,24 @@ const StyledButtonGroup = styled.div`
   display: inline-block;
 
   ${Button.Element} {
-    margin-right: ${props => (props.iconsOnly ? 0 : spacing.small)};
+    margin-right: ${props => (props.compressed ? 0 : spacing.small)};
   }
 
-  ${props => (props.iconsOnly ? iconsOnlyStyles : null)};
+  ${props => (props.compressed ? groupRadiusStyles : null)};
 `
 
-const ButtonGroup = props => {
-  let iconsOnly = true
-
-  React.Children.forEach(props.children, child => {
-    if (child.props.children) iconsOnly = false
-  })
-
-  return <StyledButtonGroup iconsOnly={iconsOnly}>{props.children}</StyledButtonGroup>
-}
+const ButtonGroup = props => <StyledButtonGroup {...props}>{props.children}</StyledButtonGroup>
 
 ButtonGroup.propTypes = {
+  /** Make Buttons stick to each other */
+  compressed: PropTypes.bool,
+  /** Should container only Buttons */
   children: PropTypes.arrayOf(PropTypes.element)
 }
 
-ButtonGroup.defaultProps = {}
+ButtonGroup.defaultProps = {
+  compressed: false
+}
 
 export default ButtonGroup
 export { StyledButtonGroup }

--- a/src/components/molecules/button-group/index.js
+++ b/src/components/molecules/button-group/index.js
@@ -23,7 +23,7 @@ const StyledButtonGroup = styled.div`
   display: inline-block;
 
   ${Button.Element} {
-    margin-right: ${props => (props.compressed ? 0 : spacing.small)};
+    margin-right: ${props => (props.compressed ? 0 : spacing.xsmall)};
   }
 
   ${props => (props.compressed ? groupRadiusStyles : null)};

--- a/src/components/molecules/button-group/index.js
+++ b/src/components/molecules/button-group/index.js
@@ -20,6 +20,8 @@ const iconsOnlyStyles = css`
 `
 
 const Wrapper = styled.div`
+  display: inline-block;
+
   ${Button.Element} {
     margin-right: ${props => (props.iconsOnly ? 0 : spacing.small)};
   }

--- a/src/components/molecules/form/actions/index.js
+++ b/src/components/molecules/form/actions/index.js
@@ -14,6 +14,10 @@ const StyledActions = styled.div`
     props.layout === 'label-on-left' ? getLayout(props.layout).labelWidth : 0};
   margin-left: ${props => (props.layout === 'label-on-left' ? 0 : 'auto')};
   margin-top: ${spacing.medium};
+
+  ${Button.Element} {
+    margin-right: ${spacing.small};
+  }
 `
 
 const Actions = props => {

--- a/src/components/molecules/form/actions/index.js
+++ b/src/components/molecules/form/actions/index.js
@@ -6,6 +6,7 @@ import { spacing, colors } from '../../../../tokens'
 import getLayout from '../layout'
 
 import Button from '../../../atoms/button'
+import ButtonGroup from '../../../molecules/button-group'
 import { Right, Clear } from '../../../_helpers/float'
 
 const StyledActions = styled.div`
@@ -14,10 +15,6 @@ const StyledActions = styled.div`
     props.layout === 'label-on-left' ? getLayout(props.layout).labelWidth : 0};
   margin-left: ${props => (props.layout === 'label-on-left' ? 0 : 'auto')};
   margin-top: ${spacing.medium};
-
-  ${Button.Element} {
-    margin-right: ${spacing.small};
-  }
 `
 
 const Actions = props => {
@@ -25,11 +22,13 @@ const Actions = props => {
 
   return (
     <StyledActions layout={layout}>
-      {props.primaryAction && (
-        <Button primary onClick={props.primaryAction.method}>
-          {props.primaryAction.label}
-        </Button>
-      )}
+      <ButtonGroup>
+        {props.primaryAction && (
+          <Button primary onClick={props.primaryAction.method}>
+            {props.primaryAction.label}
+          </Button>
+        )}
+      </ButtonGroup>
 
       {props.secondaryActions &&
         props.secondaryActions.map((action, index) => {

--- a/src/manage/client-list.js
+++ b/src/manage/client-list.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Header, List, Stack, Code, Button } from '../components'
+import { Header, List, Stack, Code, Button, ButtonGroup } from '../components'
 import Avatar from './client-avatar'
 
 const Link = styled.a`
@@ -32,7 +32,7 @@ class ClientList extends React.Component {
         <br />
         <List>
           {clients.map(client => (
-            <Stack key={client.id} widths={[7, 25, 38, 30]}>
+            <Stack key={client.id} widths={[7, 25, 40, 28]}>
               <Avatar />
               <div>
                 <Link href={`/clients/${client.id}`}>{client.name}</Link>
@@ -43,12 +43,12 @@ class ClientList extends React.Component {
                 <span>Client Id: </span>
                 <Code>{client.id}</Code>
               </Stack>
-              <Stack align="right">
+              <ButtonGroup>
                 <Button icon="users" />
                 <Button icon="connections" />
                 <Button icon="analytics" />
                 <Button icon="emails" />
-              </Stack>
+              </ButtonGroup>
             </Stack>
           ))}
         </List>

--- a/src/manage/settings.js
+++ b/src/manage/settings.js
@@ -42,11 +42,7 @@ class Settings extends React.Component {
           type="password"
           readOnly
           defaultValue={this.state.secret}
-          actions={[
-            { icon: 'copy', method: dummyFn },
-            { icon: 'copy', method: dummyFn },
-            { icon: 'copy', method: dummyFn }
-          ]}
+          actions={[{ icon: 'copy', method: dummyFn }, { icon: 'delete', method: dummyFn }]}
           description="The Client Secret is not base64 encoded."
         />
 


### PR DESCRIPTION
1. Introduce a new component `ButtonGroup` which supports `compressed` prop
2. Reduced the padding for `ButtonWithIcon` (without text)

Results:

<img width="836" alt="screen shot 2018-02-15 at 6 31 44 pm" src="https://user-images.githubusercontent.com/1863771/36257848-8f7754ca-127e-11e8-8e6d-90ea893f9c1c.png">

Used it in `Form.Field` and `Form.Actions`

<img width="802" alt="screen shot 2018-02-15 at 6 27 30 pm" src="https://user-images.githubusercontent.com/1863771/36257866-9d0f3242-127e-11e8-8bf6-68b38c1c622c.png">

<img width="788" alt="screen shot 2018-02-15 at 6 27 51 pm" src="https://user-images.githubusercontent.com/1863771/36257869-a1326876-127e-11e8-9da6-32d5113bed66.png">

Using it client lists makes it slightly better than the current implementation, the one on production is also weird 😢. Should we use `compressed`  with `<Button link/>`?

<img width="853" alt="screen shot 2018-02-15 at 6 25 48 pm" src="https://user-images.githubusercontent.com/1863771/36257894-bc6067a6-127e-11e8-8ba7-7dcc995c3efb.png">

