### PR TITLE
TextInput: should use defaultValue instead of value

### DIFF
--- a/src/components/atoms/text-input/index.js
+++ b/src/components/atoms/text-input/index.js
@@ -12,9 +12,7 @@ const TextInput = props => {
     const { value } = props
     const length = value && value.length > 0 ? value.length : 8
     const maskedValue = new Array(length).join('•')
-    return (
-      <StyledInput {...props} value={null} defaultValue={null} placeholder={maskedValue} readOnly />
-    )
+    return <StyledInput {...props} defaultValue="" placeholder={maskedValue} readOnly />
   }
   return <StyledInput {...props} />
 }
@@ -32,8 +30,8 @@ TextInput.propTypes = {
   onChange: PropTypes.func,
   /** Text to display when the input is empty */
   placeholder: PropTypes.string,
-  /** The value for the field */
-  value: PropTypes.string
+  /** The default value for the field */
+  defaultValue: PropTypes.string
 }
 
 TextInput.defaultProps = {

--- a/src/components/atoms/text-input/text-input.md
+++ b/src/components/atoms/text-input/text-input.md
@@ -44,7 +44,7 @@ in a display similar to password fields, but won't trigger password managers.
 (Note: this is just a visual effect, and doesn't provide any actual additional security!)
 
 ```js
-<TextInput value="secret-client-hash" masked />
+<TextInput defaultValue="secret-client-hash" masked />
 ```
 
 ### Function


### PR DESCRIPTION
Saw a few warnings about using value and defaultValue together after https://github.com/auth0/cosmos/pull/205

We should use just defaultValue here, right?

@nkohari Ideas?