### PR TITLE
Fixes for inputs

### DIFF
--- a/src/components/atoms/text-input/index.js
+++ b/src/components/atoms/text-input/index.js
@@ -8,10 +8,14 @@ const TextInput = props => {
     const { value } = props
     const length = value && value.length > 0 ? value.length : 8
     const maskedValue = new Array(length).join('•')
-    return <StyledInput {...props} defaultValue="" placeholder={maskedValue} readOnly />
+    return <TextInput.Element {...props} defaultValue="" placeholder={maskedValue} readOnly />
   }
-  return <StyledInput {...props} />
+  return <TextInput.Element {...props} />
 }
+
+TextInput.Element = StyledInput.extend`
+  height: 44px;
+`
 
 TextInput.propTypes = {
   /** Hide input, similar to passwords but for other private information. Implies readOnly. */

--- a/src/components/atoms/text-input/index.js
+++ b/src/components/atoms/text-input/index.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types'
 
 import { StyledInput } from '../_styled-input'
 
-const TextInput = props => {
+const TextInput = ({ defaultValue, ...props }) => {
   if (props.masked) {
-    const { value } = props
-    const length = value && value.length > 0 ? value.length : 8
+    const length = defaultValue ? defaultValue.length : 8
     const maskedValue = new Array(length).join('•')
-    return <TextInput.Element {...props} defaultValue="" placeholder={maskedValue} readOnly />
+    return <TextInput.Element {...props} placeholder={maskedValue} readOnly />
   }
-  return <TextInput.Element {...props} />
+  return <TextInput.Element defaultValue={defaultValue} {...props} />
 }
 
 TextInput.Element = StyledInput.extend`


### PR DESCRIPTION
Closes #308 and #320.

Looks like the fixed height style got lost when the masked input mode was merged. This patch also makes the masked input mode use `defaultValue` for consistency's sake, but as discussed in Slack we may want to consider using `value` across the board if our goal is to work with controlled components.