### PR TITLE
Polish sections of the PoC

### DIFF
--- a/src/components/molecules/page-header/description.js
+++ b/src/components/molecules/page-header/description.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { colors } from '../../../tokens'
+import { colors, spacing } from '../../../tokens'
 
 import Paragraph from '../../atoms/paragraph'
 import Link from '../../atoms/link'
@@ -17,16 +17,21 @@ const ArrowMore = styled.i`
   border-color: transparent transparent transparent ${colors.link.default};
 `
 
+const StyledParagraph = styled(Paragraph)`
+  margin-top: ${spacing.large};
+  margin-bottom: 0;
+`
+
 const Description = props => {
   return (
-    <Paragraph>
+    <StyledParagraph>
       {props.children.text}{' '}
       {props.children.learnMore ? (
         <Link href={props.children.learnMore}>
           Learn more <ArrowMore />
         </Link>
       ) : null}
-    </Paragraph>
+    </StyledParagraph>
   )
 }
 

--- a/src/components/molecules/page-header/index.js
+++ b/src/components/molecules/page-header/index.js
@@ -128,3 +128,4 @@ PageHeader.defaultProps = {
 }
 
 export default PageHeader
+export { StyledPageHeader }

--- a/src/manage/advanced.js
+++ b/src/manage/advanced.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FormGroup, Form, Code, Paragraph, Link } from '../components'
+import { FormGroup, Form, Link } from '../components'
 
 let dummyFn = () => {}
 
@@ -18,16 +18,6 @@ class Advanced extends React.Component {
     return (
       <div>
         <FormGroup>
-          <Form>
-            <Form.FieldSet label="Application Metadata">
-              <Paragraph>
-                Application metadata are custom string keys and values (max 255 characters each),
-                set on a per application basis. Metadata is exposed in the Client object as{' '}
-                <Code>client_metadata</Code>, and in Rules as <Code>context.clientMetadata</Code>
-              </Paragraph>
-            </Form.FieldSet>
-          </Form>
-
           <Form>
             <Form.FieldSet label="iOS Settings">
               <Form.TextInput
@@ -71,7 +61,7 @@ class Advanced extends React.Component {
                 label="Allowed APPs / APIs"
                 placeholder=""
                 length="3"
-                description="Allowed Applications / APIs are clients that will be allowed to make delegation request. By default, all your clients will be allowed. This field allows you to enter specific client ids. You can specify multiple IDs by comma-separating them or one by line."
+                description="Allowed Applications / APIs are clients that will be allowed to make delegation request. By default, all your clients will be allowed. This field allows you to enter specific Client IDs. You can specify multiple IDs by comma-separating them or one by line."
               />
 
               <Form.Select
@@ -104,24 +94,6 @@ class Advanced extends React.Component {
                 placeholder="https://domain.tld/path"
                 description="Location URL for the page that will be rendered inside an iframe to perform the token verification when third party cookies are not enabled in the browser. Must be in the same domain where the embedded login form is hosted and must have a `https` scheme."
               />
-            </Form.FieldSet>
-            <Form.Actions primaryAction={{ label: 'Save Changes', method: this.save }} />
-          </Form>
-
-          <Form>
-            <Form.FieldSet label="Grant Types">
-              <Paragraph>
-                [Notification] Using Password or MFA grant types with public clients is not
-                recommended. To use the Client Credentials grant you have to set a Token Endpoint
-                Auth Method other than "none". See our documentation for more information.
-              </Paragraph>
-              <Paragraph>Grants go here... </Paragraph>
-            </Form.FieldSet>
-          </Form>
-
-          <Form>
-            <Form.FieldSet label="WS-Federation">
-              <p>cer goes here...</p>
             </Form.FieldSet>
             <Form.Actions primaryAction={{ label: 'Save Changes', method: this.save }} />
           </Form>

--- a/src/manage/client-list.js
+++ b/src/manage/client-list.js
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { PageHeader, List, Stack, Code, Button, Link, ButtonGroup } from '../components'
+import { StyledPageHeader } from '../components/molecules/page-header'
+
 import { colors, spacing } from '../tokens'
 import Avatar from './client-avatar'
 import CreateClientDialog from './create-client-dialog'
@@ -37,6 +39,13 @@ const Type = styled.div`
   line-height: normal;
   margin-top: ${spacing.xsmall};
   text-transform: uppercase;
+`
+
+/* TODO: Remove this override */
+const ClientsContent = styled.div`
+  ${StyledPageHeader} {
+    margin-bottom: ${spacing.xxlarge};
+  }
 `
 
 const clients = [
@@ -90,7 +99,7 @@ class ClientList extends React.Component {
 
   render() {
     return (
-      <div>
+      <ClientsContent>
         <PageHeader
           title="Clients"
           description={{
@@ -136,7 +145,7 @@ class ClientList extends React.Component {
           ))}
         </List>
         <CreateClientDialog open={this.state.dialogOpen} onClose={this.setDialogOpen(false)} />
-      </div>
+      </ClientsContent>
     )
   }
 }

--- a/src/manage/connections.js
+++ b/src/manage/connections.js
@@ -1,14 +1,22 @@
 import React from 'react'
+import styled from 'styled-components'
+
 import { Paragraph, Switch, List, Stack } from '../components'
+
+// TODO: Need to figure out how to make the first Paragraph have no margin top. We could add a prop?
+// TODO: Remove and solve this override!
+const FirstParagraph = styled(Paragraph)`
+  margin-top: 0;
+`
 
 class Connections extends React.Component {
   render() {
     return (
       <div>
-        <Paragraph>
+        <FirstParagraph>
           Connections are sources of users. They are categorized into Database, Social and
           Enterprise and can be shared among different applications.
-        </Paragraph>
+        </FirstParagraph>
 
         <List label="Database">
           <Stack widths={[41, 41, 18]}>

--- a/src/manage/connections.js
+++ b/src/manage/connections.js
@@ -14,7 +14,9 @@ class Connections extends React.Component {
           <Stack widths={[41, 41, 18]}>
             <div>Username-Password-Authentication</div>
             <div>Database</div>
-            <Switch />
+            <Stack align="right">
+              <Switch accessibleLabels={[]} />
+            </Stack>
           </Stack>
         </List>
 
@@ -22,12 +24,16 @@ class Connections extends React.Component {
           <Stack widths={[41, 41, 18]}>
             <div>github</div>
             <div>GitHub</div>
-            <Switch on />
+            <Stack align="right">
+              <Switch on accessibleLabels={[]} />
+            </Stack>
           </Stack>
           <Stack widths={[41, 41, 18]}>
             <div>google-oauth2</div>
             <div>Google</div>
-            <Switch off />
+            <Stack align="right">
+              <Switch off accessibleLabels={[]} />
+            </Stack>
           </Stack>
         </List>
 

--- a/src/manage/index.js
+++ b/src/manage/index.js
@@ -14,7 +14,7 @@ const App = () => (
       <div
         style={{
           display: 'flexbox',
-          paddingTop: '100px'
+          paddingTop: '110px'
         }}
       >
         <SideNavigation />

--- a/src/manage/settings.js
+++ b/src/manage/settings.js
@@ -33,6 +33,7 @@ class Settings extends React.Component {
         <Form.TextInput
           label="Client ID"
           type="text"
+          code
           readOnly
           defaultValue={this.state.clientID}
           actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}


### PR DESCRIPTION
Did a quick check and fixed a few visual bugs to match the original Manage design. Some will need to be reworked to avoid doing overrides on the components. But it's a good template to know what we need to enhance in the PoC via components. 

On Manage PoC:
- Fixed the Page `margin-top` to keep the Sidebar and Page Header aligned
- Removed empty form groups from the **Advanced tab** 
- Changed **Client ID** field to a code input field in **Settings**
- Adjusted **Connections table** to match original design by removing Switch Labels
- Added a quick override on the **Connections tab** for the first Paragraph -> _We need to find a better solution_
- Added margin override on the **Clients Page** for the Page Header -> _We need to find a better solution to avoid the override_

On the Page Header component:
- Changed styles of Page header to override Paragraph spacing