### PR TITLE
Allow form field description (helper text) to accept React components

### DIFF
--- a/src/components/_helpers/reset.js
+++ b/src/components/_helpers/reset.js
@@ -1,4 +1,5 @@
 import { injectGlobal } from 'styled-components'
+import { fonts } from '../../tokens'
 
 const reset = () => injectGlobal`
   html, body, div, span, applet, object, iframe,
@@ -49,6 +50,10 @@ table {
 /* Our resets */
 * {
   box-sizing: border-box;
+}
+
+strong, em {
+	font-weight: ${fonts.weight.bold};
 }
 `
 

--- a/src/components/molecules/form/description.js
+++ b/src/components/molecules/form/description.js
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { spacing, colors } from 'auth0-cosmos-tokens'
-import Code from '../../atoms/code'
 
 const StyledDescription = styled.div`
   font-size: 13px;
@@ -12,33 +11,6 @@ const StyledDescription = styled.div`
   margin-bottom: ${spacing.xsmall};
 `
 
-const Description = props => {
-  if (typeof props.children === 'string') {
-    /*
-      if children is a string, replace instances of
-      `hash` with <Code>hash</Code>
-    */
-
-    /*
-      split the string into parts
-      example: 'use the `copy` prop'
-      becomes: ['use the ', 'copy', ' prop']
-    */
-    const parts = props.children.split('`')
-
-    /*
-      loop through and add <Code>...</Code> wrapper around
-      the correct elements
-    */
-    for (let i = 1; i < parts.length; i += 2) {
-      parts[i] = <Code key={i}>{parts[i]}</Code>
-    }
-
-    return <StyledDescription>{parts}</StyledDescription>
-  } else {
-    // if children is not a string, proxy it through
-    return <StyledDescription>{props.children}</StyledDescription>
-  }
-}
+const Description = props => <StyledDescription>{props.children}</StyledDescription>
 
 export default Description

--- a/src/components/molecules/form/field/field.md
+++ b/src/components/molecules/form/field/field.md
@@ -56,7 +56,8 @@ Here's an example of providing some context to the user with `description`. It s
 </Form>
 ```
 
-Here's a secret: `description` has not matured to support links yet. You can however take more control and pass a React component instead. It will show get a warning, but we'll let it slide 😉
+If you need more control, `description` also accepts a React component. You can use this to add links
+or other rich formatting to displayed text.
 
 ```js
 <Form>
@@ -66,8 +67,8 @@ Here's a secret: `description` has not matured to support links yet. You can how
     placeholder="Enter something"
     description={
       <span>
-        Notice that querystrings are not taking into account when validating these URLs. <br />
-        Read more about this at <Link href="https://auth0.com">here</Link>
+        Note that querystrings <strong>are not</strong> taken into account when validating these
+        URLs. Read more about this <Link href="https://auth0.com">here</Link>.
       </span>
     }
   />

--- a/src/components/molecules/form/field/field.md
+++ b/src/components/molecules/form/field/field.md
@@ -41,9 +41,9 @@ In addition to their own [native props](/docs/TextInput), we add a few more prop
 </Form>
 ```
 
-### Helper text
+### Help text
 
-Here's an example of providing some context to the user with `description`. It supports adding `backticks`.
+Here's an example of providing some context to the user with `helpText`.
 
 ```js
 <Form>
@@ -51,12 +51,12 @@ Here's an example of providing some context to the user with `description`. It s
     label="Callback URL"
     type="text"
     placeholder="Enter something"
-    description="Make sure to specify the protocol, `http://` or `https://`"
+    helpText="Make sure to specify the protocol, http:// or https://"
   />
 </Form>
 ```
 
-If you need more control, `description` also accepts a React component. You can use this to add links
+If you need more control, `helpText` also accepts a React component. You can use this to add links
 or other rich formatting to displayed text.
 
 ```js
@@ -65,7 +65,7 @@ or other rich formatting to displayed text.
     label="Allowed URLs"
     type="text"
     placeholder="Enter something"
-    description={
+    helpText={
       <span>
         Note that querystrings <strong>are not</strong> taken into account when validating these
         URLs. Read more about this <Link href="https://auth0.com">here</Link>.
@@ -105,7 +105,7 @@ We leave the logic part of validation to you the developer, you can pass `error`
     placeholder="Enter something"
     defaultValue="auth0.com"
     error="This is not a valid URL"
-    description="Make sure to specify the protocol, `http://` or `https://`"
+    helpText="Make sure to specify the protocol, http:// or https://"
   />
 </Form>
 ```

--- a/src/components/molecules/form/field/index.js
+++ b/src/components/molecules/form/field/index.js
@@ -8,7 +8,7 @@ import uniqueId from '../../../_helpers/uniqueId'
 
 import StyledLabel from '../label'
 import StyledError from '../error'
-import Description from '../description'
+import HelpText from '../help-text'
 import { StyledTextArea } from '../../../atoms/textarea'
 import { StyledSwitch } from '../../../atoms/switch'
 
@@ -55,7 +55,7 @@ const Field = props => {
       <ContentLayout layout={layout}>
         <props.fieldComponent id={id} {...props} />
         {props.error ? <StyledError>{props.error}</StyledError> : null}
-        {props.description ? <Description>{props.description}</Description> : null}
+        {props.helpText ? <HelpText>{props.helpText}</HelpText> : null}
       </ContentLayout>
     </StyledField>
   )
@@ -66,8 +66,8 @@ Field.displayName = 'Form Field'
 Field.propTypes = {
   /** Form Label */
   label: PropTypes.string.isRequired,
-  /** Description to give users some context */
-  description: PropTypes.node,
+  /** Text that further explains the purpose of the field, or provides more detail */
+  helpText: PropTypes.node,
   /** Error message to show in case of failed validation */
   error: PropTypes.string,
   /** Actions to be attached to input */
@@ -81,7 +81,7 @@ Field.propTypes = {
 
 Field.defaultProps = {
   label: 'Form label',
-  description: null,
+  helpText: null,
   error: null
 }
 

--- a/src/components/molecules/form/field/index.js
+++ b/src/components/molecules/form/field/index.js
@@ -67,7 +67,7 @@ Field.propTypes = {
   /** Form Label */
   label: PropTypes.string.isRequired,
   /** Description to give users some context */
-  description: PropTypes.string,
+  description: PropTypes.node,
   /** Error message to show in case of failed validation */
   error: PropTypes.string,
   /** Actions to be attached to input */

--- a/src/components/molecules/form/form.md
+++ b/src/components/molecules/form/form.md
@@ -31,7 +31,7 @@ Form is composed of Form Fields, read more about them [here](/docs/Form%20Field)
     label="Field label"
     type="text"
     placeholder="Enter something"
-    description="This is some helper `text`"
+    helpText="This is some helper text"
   />
   <Form.TextArea
     label="Long input"

--- a/src/components/molecules/form/help-text.js
+++ b/src/components/molecules/form/help-text.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { spacing, colors } from 'auth0-cosmos-tokens'
 
-const StyledDescription = styled.div`
+const StyledHelpText = styled.div`
   font-size: 13px;
   line-height: 1.8;
   color: ${colors.text.secondary};
@@ -11,6 +11,6 @@ const StyledDescription = styled.div`
   margin-bottom: ${spacing.xsmall};
 `
 
-const Description = props => <StyledDescription>{props.children}</StyledDescription>
+const HelpText = props => <StyledHelpText>{props.children}</StyledHelpText>
 
-export default Description
+export default HelpText

--- a/src/manage/pages/client-detail/advanced.js
+++ b/src/manage/pages/client-detail/advanced.js
@@ -25,7 +25,7 @@ class Advanced extends React.Component {
                 type="text"
                 code
                 placeholder="9JA89QQLNQ"
-                description={
+                helpText={
                   <span>
                     <Link
                       target="_blank"
@@ -49,7 +49,7 @@ class Advanced extends React.Component {
                 code
                 placeholder="D8:A0:83:..., D9:C1:B2:..."
                 length="3"
-                description="The SHA256 fingerprints of your app’s signing certificate. You can specify multiple key hashes by comma-separating them or one by line."
+                helpText="The SHA256 fingerprints of your app’s signing certificate. You can specify multiple key hashes by comma-separating them or one by line."
               />
             </Form.FieldSet>
             <Form.Actions primaryAction={{ label: 'Save Changes', method: this.save }} />
@@ -61,7 +61,7 @@ class Advanced extends React.Component {
                 label="Allowed APPs / APIs"
                 placeholder=""
                 length="3"
-                description="Allowed Applications / APIs are clients that will be allowed to make delegation request. By default, all your clients will be allowed. This field allows you to enter specific Client IDs. You can specify multiple IDs by comma-separating them or one by line."
+                helpText="Allowed Applications / APIs are clients that will be allowed to make delegation request. By default, all your clients will be allowed. This field allows you to enter specific Client IDs. You can specify multiple IDs by comma-separating them or one by line."
               />
 
               <Form.Select
@@ -77,7 +77,7 @@ class Advanced extends React.Component {
               <Form.Switch
                 label="OIDC Conformant"
                 on
-                description={
+                helpText={
                   <span>
                     Clients flagged as OIDC Conformant will strictly follow the OIDC specification.
                     Turning on this flag can introduce breaking changes to this client. If you have

--- a/src/manage/pages/client-detail/settings.js
+++ b/src/manage/pages/client-detail/settings.js
@@ -47,20 +47,20 @@ class Settings extends React.Component {
             { icon: 'copy', method: dummyFn, label: 'Copy to clipboard' },
             { icon: 'rotate', method: dummyFn, label: 'Rotate secret' }
           ]}
-          description="The Client Secret is not base64 encoded."
+          helpText="The Client Secret is not base64 encoded."
         />
 
         <Form.TextArea
           label="Description"
           placeholder="Add a description in less than 140 characters"
-          description="A free text description of the client. Max character count is 140."
+          helpText="A free text description of the client. Max character count is 140."
           length={5}
         />
         <Form.TextInput
           label="Client Logo"
           type="text"
           placeholder="http://path.to/my_logo.png"
-          description="The URL of the logo to display for the client, if none is set the default badge for this type of client will be shown. Recommended size is 150x150 pixels."
+          helpText="The URL of the logo to display for the client, if none is set the default badge for this type of client will be shown. Recommended size is 150x150 pixels."
         />
         <Form.Select
           label="Client Type"
@@ -70,7 +70,7 @@ class Settings extends React.Component {
             { text: 'Regular Web Application', value: 'regular' },
             { text: 'Single Page Application', value: 'spa' }
           ]}
-          description="The type of client will determine which settings you can configure from the dashboard."
+          helpText="The type of client will determine which settings you can configure from the dashboard."
         />
 
         <Form.Select
@@ -80,24 +80,37 @@ class Settings extends React.Component {
             { text: 'Basic', value: 'basic' },
             { text: 'Post', value: 'post', defaultSelected: true }
           ]}
-          description="Defines the requested authentication method for the token endpoint. Possible values are 'None' (public client without a client secret), 'Post' (client uses HTTP POST parameters) or 'Basic' (client uses HTTP Basic)."
+          helpText="Defines the requested authentication method for the token endpoint. Possible values are 'None' (public client without a client secret), 'Post' (client uses HTTP POST parameters) or 'Basic' (client uses HTTP Basic)."
         />
 
         <Form.TextArea
           label="Allowed Callback URLs"
-          description="After the user authenticates we will only call back to any of these URLs. You can specify multiple valid URLs by comma-separating them (typically to handle different environments like QA or testing). Make sure to specify the protocol, `http://` or `https://`, otherwise the callback may fail in some cases."
           length={3}
+          helpText={
+            <span>
+              After the user authenticates we will only call back to any of these URLs. You can
+              specify multiple valid URLs by comma-separating them (typically to handle different
+              environments like QA or testing). Make sure to specify the protocol,{' '}
+              <Code>http://</Code> or <Code>https://</Code>, otherwise the callback may fail in some
+              cases.
+            </span>
+          }
         />
         <Form.TextArea
           label="Allowed Callback URLs"
-          description={
-            'Comma-separated list of allowed origins for use with Cross-Origin Authentication and web message response mode, in the form of `<scheme> "://" <host> [ ":" <port> ]`, such as `https://login.mydomain.com` or `http://localhost:3000`.'
+          helpText={
+            <span>
+              Comma-separated list of allowed origins for use with Cross-Origin Authentication and
+              web message response mode, in the form of{' '}
+              <Code>&lt;scheme> "://" &lt;host> [ ":" &lt;port> ]</Code>, such as{' '}
+              <Code>https://login.mydomain.com</Code> or <Code>http://localhost:3000</Code>.
+            </span>
           }
           length={3}
         />
         <Form.TextArea
           label="Allowed Logout URLs"
-          description={
+          helpText={
             <span>
               A set of URLs that are valid to redirect to after logout from Auth0. After a user logs
               out from Auth0 you can redirect them with the <Code>returnTo</Code> query parameter.
@@ -115,20 +128,30 @@ class Settings extends React.Component {
         />
         <Form.TextArea
           label="Allowed Origins (CORS)"
-          description="Allowed Origins are URLs that will be allowed to make requests from JavaScript to Auth0 API (typically used with CORS). By default, all your callback URLs will be allowed. This field allows you to enter other origins if you need to. You can specify multiple valid URLs by comma-separating them or one by line, and also use wildcards at the subdomain level (e.g.: `https://*.contoso.com`). Notice that querystrings and hash information are not taking into account when validating these URLs."
           length={3}
+          helpText={
+            <span>
+              Allowed Origins are URLs that will be allowed to make requests from JavaScript to
+              Auth0 API (typically used with CORS). By default, all your callback URLs will be
+              allowed. This field allows you to enter other origins if you need to. You can specify
+              multiple valid URLs by comma-separating them or one by line, and also use wildcards at
+              the subdomain level (e.g.: <Code>https://*.contoso.com</Code>). Notice that
+              querystrings and hash information are not taking into account when validating these
+              URLs.
+            </span>
+          }
         />
 
         <Form.TextInput
           label="JWT Expiration"
           type="number"
           defaultValue="3600"
-          description="Control the expiration of the id tokens (in seconds)"
+          helpText="Control the expiration of the id tokens (in seconds)"
         />
 
         <Form.Switch
           label="Use Auth0 instead of the IdP to do Single Sign On"
-          description="If this setting is enabled, Auth0
+          helpText="If this setting is enabled, Auth0
             will handle Single Sign On instead of the Identity Provider (e.g.: No redirect to Facebook
             to log the user in if they have already logged in before)."
         />

--- a/src/manage/pages/clients/create-client-dialog.js
+++ b/src/manage/pages/clients/create-client-dialog.js
@@ -104,7 +104,7 @@ class CreateClientDialog extends React.Component {
         <Form layout="label-on-top">
           <Form.TextInput
             label="Name"
-            description="You can change the client name later in the client settings."
+            helpText="You can change the client name later in the client settings."
             value={name}
           />
 

--- a/src/overview/examples/forms.js
+++ b/src/overview/examples/forms.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Example from '../ov-components/example'
 import Section from '../ov-components/section'
-import { Form, FormGroup } from 'auth0-cosmos'
+import { Code, Form, FormGroup } from 'auth0-cosmos'
 
 const fakeMethod = e => {
   e.preventDefault()
@@ -17,8 +17,13 @@ const Forms = () => (
           label="Field with helper text"
           defaultValue="This is the field value"
           placeholder="Placeholder text"
-          description="Name of the connection to be use for Password Grant exchanges. The `default_directory` value
-        should be the exact name of an existing connections of one of the following."
+          helpText={
+            <span>
+              Name of the connection to be use for Password Grant exchanges. The{' '}
+              <Code>default_directory</Code>
+              value should be the exact name of an existing connections of one of the following.
+            </span>
+          }
         />
         <Form.TextInput
           label="Text input with actions"
@@ -58,8 +63,13 @@ const Forms = () => (
           label="Field with helper text"
           defaultValue="This is the field value"
           placeholder="Placeholder text"
-          description="Name of the connection to be use for Password Grant exchanges. The `default_directory` value
-        should be the exact name of an existing connections of one of the following."
+          helpText={
+            <span>
+              Name of the connection to be use for Password Grant exchanges. The{' '}
+              <Code>default_directory</Code>
+              value should be the exact name of an existing connections of one of the following.
+            </span>
+          }
         />
         <Form.TextInput
           label="Text input with actions"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6344,7 +6344,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@15.6.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:


### PR DESCRIPTION
Closes #365.

This was already unofficially supported, so this patch just removes the warning and updates the docs. There's still an unanswered question on the issue regarding whether we want to continue supporting backticks in strings, but this can be merged either way.