### PR TITLE
Replaced colliding Booleans with enums in Button and Tooltip

### DIFF
--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -30,10 +30,10 @@ Buttons are great to ask users for action
 <div>
   <Stack>
     <Button>default</Button>
-    <Button primary>primary</Button>
-    <Button transparent>secondary</Button>
-    <Button link>Clear</Button>
-    <Button destructive>Delete</Button>
+    <Button intent="primary">primary</Button>
+    <Button intent="transparent">secondary</Button>
+    <Button intent="link">Clear</Button>
+    <Button intent="destructive">Delete</Button>
   </Stack>
 </div>
 ```
@@ -59,7 +59,7 @@ Icon buttons work well in compact spaces. You can pick name of `icon` from [docs
 ```js
 <div>
   <Stack>
-    <Button link icon="copy" />
+    <Button intent="link" icon="copy" />
     <Button icon="copy" />
   </Stack>
 </div>

--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -30,10 +30,10 @@ Buttons are great to ask users for action
 <div>
   <Stack>
     <Button>default</Button>
-    <Button intent="primary">primary</Button>
-    <Button intent="transparent">secondary</Button>
-    <Button intent="link">Clear</Button>
-    <Button intent="destructive">Delete</Button>
+    <Button appearance="primary">primary</Button>
+    <Button appearance="transparent">secondary</Button>
+    <Button appearance="link">Clear</Button>
+    <Button appearance="destructive">Delete</Button>
   </Stack>
 </div>
 ```
@@ -59,7 +59,7 @@ Icon buttons work well in compact spaces. You can pick name of `icon` from [docs
 ```js
 <div>
   <Stack>
-    <Button intent="link" icon="copy" />
+    <Button appearance="link" icon="copy" />
     <Button icon="copy" />
   </Stack>
 </div>

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -7,7 +7,7 @@ import Icon from '../icon'
 import Spinner from '../spinner'
 import Tooltip from '../tooltip'
 
-const intents = {
+const appearances = {
   default: {
     text: colors.button.defaultText,
     icon: colors.button.defaultIcon,
@@ -78,7 +78,9 @@ const states = {
 const getAttributes = props => {
   if (props.success) return { ...states.success }
 
-  const baseStyles = intents[props.intent] ? intents[props.intent] : intents.default
+  const baseStyles = appearances[props.appearance]
+    ? appearances[props.appearance]
+    : appearances.default
   const styles = { ...baseStyles }
 
   /* overwrite for loading state */
@@ -183,7 +185,7 @@ Button.Content = styled.span`
 
 Button.propTypes = {
   /** The visual style used to convey the button's purpose */
-  intent: PropTypes.oneOf(['default', 'primary', 'transparent', 'destructive', 'link']),
+  appearance: PropTypes.oneOf(['default', 'primary', 'transparent', 'destructive', 'link']),
 
   /** Name of icon */
   icon: PropTypes.string,
@@ -202,7 +204,7 @@ Button.propTypes = {
 }
 
 Button.defaultProps = {
-  intent: 'default',
+  appearance: 'default',
   icon: null,
   disabled: false,
   loading: false,

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -3,12 +3,11 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
 import { colors, spacing, fonts, misc } from 'auth0-cosmos-tokens'
-import { onlyOneOf } from '../../_helpers/custom-validations'
 import Icon from '../icon'
 import Spinner from '../spinner'
 import Tooltip from '../tooltip'
 
-const config = {
+const intents = {
   default: {
     text: colors.button.defaultText,
     icon: colors.button.defaultIcon,
@@ -51,16 +50,6 @@ const config = {
     focusBackground: 'transparent',
     focusBorder: 'transparent'
   },
-  disabled: {
-    text: colors.button.disabledText,
-    icon: colors.button.disabledIcon,
-    background: colors.button.disabledBackground,
-    border: colors.button.disabledBorder,
-    hoverBackground: colors.button.disabledBackgroundHover,
-    hoverBorder: colors.button.disabledBorderHover,
-    focusBackground: colors.button.disabledBackgroundFocus,
-    focusBorder: colors.button.disabledBorderFocus
-  },
   destructive: {
     text: colors.button.destructiveText,
     icon: colors.button.destructiveIcon,
@@ -70,16 +59,10 @@ const config = {
     hoverBorder: colors.button.destructiveBorderHover,
     focusBackground: colors.button.destructiveBackgroundFocus,
     focusBorder: colors.button.destructiveBorderFocus
-  },
-  loading: {
-    text: colors.base.white,
-    background: colors.base.green,
-    border: colors.base.green,
-    hoverBackground: colors.base.green,
-    hoverBorder: colors.base.green,
-    focusBackground: colors.base.green,
-    focusBorder: colors.base.green
-  },
+  }
+}
+
+const states = {
   success: {
     text: colors.button.successText,
     icon: colors.button.successIcon,
@@ -93,15 +76,10 @@ const config = {
 }
 
 const getAttributes = props => {
-  let styles = {}
+  if (props.success) return { ...states.success }
 
-  /* copy relevant styles into styles */
-  if (props.success) styles = { ...config.success }
-  else if (props.primary) styles = { ...config.primary }
-  else if (props.transparent) styles = { ...config.transparent }
-  else if (props.link) styles = { ...config.link }
-  else if (props.destructive) styles = { ...config.destructive }
-  else styles = { ...config.default }
+  const baseStyles = intents[props.intent] ? intents[props.intent] : intents.default
+  const styles = { ...baseStyles }
 
   /* overwrite for loading state */
   if (props.loading) {
@@ -204,16 +182,8 @@ Button.Content = styled.span`
 `
 
 Button.propTypes = {
-  /** Use for primary call to action */
-  primary: PropTypes.bool,
-  /** Use for secondary call to action */
-  transparent: PropTypes.bool,
-  /** Disable button that does not validate constraint */
-  disabled: PropTypes.bool,
-  /** Use for destructive actions like delete */
-  destructive: PropTypes.bool,
-  /** Use for subtle actions */
-  link: PropTypes.bool,
+  /** The visual style used to convey the button's purpose */
+  intent: PropTypes.oneOf(['default', 'primary', 'transparent', 'destructive', 'link']),
 
   /** Name of icon */
   icon: PropTypes.string,
@@ -221,27 +191,22 @@ Button.propTypes = {
   /** Tooltip to show when the user hovers over the button */
   label: PropTypes.string,
 
+  /** Disables the button, changing the visual style and make it unable to be pressed */
+  disabled: PropTypes.bool,
+
   /** Loading state when waiting for an action to complete */
   loading: PropTypes.bool,
-  /** Successful state when action is completed successfuly */
-  success: PropTypes.bool,
 
-  /** internal props only used for transition, start with _ */
-  _type: props => onlyOneOf(props, ['primary', 'transparent', 'destructive', 'link']),
-  _state: props => onlyOneOf(props, ['disabled', 'loading', 'success'])
+  /** Successful state when action is completed successfuly */
+  success: PropTypes.bool
 }
 
 Button.defaultProps = {
-  primary: false,
-  transparent: false,
-  destructive: false,
-  link: false,
+  intent: 'default',
   icon: null,
   disabled: false,
   loading: false,
   success: false
 }
-
-Button.meta = {}
 
 export default Button

--- a/src/components/atoms/tooltip/index.js
+++ b/src/components/atoms/tooltip/index.js
@@ -20,7 +20,7 @@ const StyledTooltip = styled.div`
   pointer-events: none;
   opacity: 0;
   ${props =>
-    props.bottom
+    props.position === 'bottom'
       ? css`
           top: 100%;
         `
@@ -38,7 +38,7 @@ const StyledTooltip = styled.div`
     margin-left: -5px;
 
     ${props =>
-      props.bottom
+      props.position === 'bottom'
         ? css`
             border-width: 0 5.5px 6px 5.5px;
             border-color: transparent transparent ${colors.tooltip.background} transparent;
@@ -75,16 +75,13 @@ const Tooltip = ({ content, ...props }) => {
 Tooltip.propTypes = {
   /** Content to show in the tooltip */
   content: PropTypes.string.isRequired,
-  /** Use to show tooltip on top */
-  top: PropTypes.bool,
-  /** Use to show tooltip on bottom */
-  bottom: PropTypes.bool
+  /** Where to place the tooltip */
+  position: PropTypes.oneOf(['top', 'bottom'])
 }
 
 Tooltip.defaultProps = {
   content: null,
-  top: true,
-  bottom: false
+  position: 'top'
 }
 
 export default Tooltip

--- a/src/components/atoms/tooltip/tooltip.md
+++ b/src/components/atoms/tooltip/tooltip.md
@@ -14,7 +14,7 @@ description: Use tooltips for giving extra context AND to make visual cues acces
 ### Tooltip top:
 
 ```js
-<Tooltip top content="Copy">
+<Tooltip position="top" content="Copy">
   <Icon name="copy" />
 </Tooltip>
 ```
@@ -22,7 +22,7 @@ description: Use tooltips for giving extra context AND to make visual cues acces
 ### Tooltip bottom:
 
 ```js
-<Tooltip bottom content="Notifications">
+<Tooltip position="bottom" content="Notifications">
   <Icon name="notifications" />
 </Tooltip>
 ```

--- a/src/components/molecules/button-group/button-group.md
+++ b/src/components/molecules/button-group/button-group.md
@@ -9,7 +9,7 @@
 
 ```jsx
 <ButtonGroup {props}>
-  <Button primary>Save changes</Button>
+  <Button intent="primary">Save changes</Button>
   <Button>Clear</Button>
 </ButtonGroup>
 ```
@@ -19,7 +19,7 @@
 ```js
 <Stack>
   <ButtonGroup>
-    <Button primary>Save changes</Button>
+    <Button intent="primary">Save changes</Button>
     <Button>Clear</Button>
   </ButtonGroup>
   <ButtonGroup>

--- a/src/components/molecules/button-group/button-group.md
+++ b/src/components/molecules/button-group/button-group.md
@@ -9,7 +9,7 @@
 
 ```jsx
 <ButtonGroup {props}>
-  <Button intent="primary">Save changes</Button>
+  <Button appearance="primary">Save changes</Button>
   <Button>Clear</Button>
 </ButtonGroup>
 ```
@@ -19,7 +19,7 @@
 ```js
 <Stack>
   <ButtonGroup>
-    <Button intent="primary">Save changes</Button>
+    <Button appearance="primary">Save changes</Button>
     <Button>Clear</Button>
   </ButtonGroup>
   <ButtonGroup>

--- a/src/components/molecules/dialog/index.js
+++ b/src/components/molecules/dialog/index.js
@@ -12,7 +12,7 @@ import { colors, fonts, spacing } from 'auth0-cosmos-tokens'
 const createButtonForAction = (action, index) => {
   const buttonProps = {
     onClick: action.method,
-    intent: action.appearance
+    appearance: action.appearance
   }
   return (
     <Button key={index} {...buttonProps}>

--- a/src/components/molecules/dialog/index.js
+++ b/src/components/molecules/dialog/index.js
@@ -12,7 +12,7 @@ import { colors, fonts, spacing } from 'auth0-cosmos-tokens'
 const createButtonForAction = (action, index) => {
   const buttonProps = {
     onClick: action.method,
-    [action.appearance]: true
+    intent: action.appearance
   }
   return (
     <Button key={index} {...buttonProps}>

--- a/src/components/molecules/empty-state/index.js
+++ b/src/components/molecules/empty-state/index.js
@@ -22,7 +22,7 @@ const EmptyState = props => {
       <Heading size={1}>{props.title}</Heading>
       <Icon name={props.icon} size={100} color={colors.base.blue} />
       <Paragraph>{props.text}</Paragraph> {helpLink}
-      <Button intent="primary" icon={props.action.icon} onClick={props.action.method}>
+      <Button appearance="primary" icon={props.action.icon} onClick={props.action.method}>
         {props.action.text}
       </Button>
     </EmptyState.Wrapper>

--- a/src/components/molecules/empty-state/index.js
+++ b/src/components/molecules/empty-state/index.js
@@ -22,7 +22,7 @@ const EmptyState = props => {
       <Heading size={1}>{props.title}</Heading>
       <Icon name={props.icon} size={100} color={colors.base.blue} />
       <Paragraph>{props.text}</Paragraph> {helpLink}
-      <Button primary icon={props.action.icon} onClick={props.action.method}>
+      <Button intent="primary" icon={props.action.icon} onClick={props.action.method}>
         {props.action.text}
       </Button>
     </EmptyState.Wrapper>

--- a/src/components/molecules/form/actions/index.js
+++ b/src/components/molecules/form/actions/index.js
@@ -24,7 +24,7 @@ const Actions = props => {
     <StyledActions layout={layout}>
       <ButtonGroup>
         {props.primaryAction && (
-          <Button primary onClick={props.primaryAction.method}>
+          <Button intent="primary" onClick={props.primaryAction.method}>
             {props.primaryAction.label}
           </Button>
         )}

--- a/src/components/molecules/form/actions/index.js
+++ b/src/components/molecules/form/actions/index.js
@@ -24,7 +24,7 @@ const Actions = props => {
     <StyledActions layout={layout}>
       <ButtonGroup>
         {props.primaryAction && (
-          <Button intent="primary" onClick={props.primaryAction.method}>
+          <Button appearance="primary" onClick={props.primaryAction.method}>
             {props.primaryAction.label}
           </Button>
         )}

--- a/src/docs/home.js
+++ b/src/docs/home.js
@@ -35,7 +35,7 @@ class Home extends React.Component {
             and use them along with you React components:
             <Pre
               code={`const Actions = () => <div>
-  <Button primary onClick={this.save}>Save changes</Button>
+  <Button intent="primary" onClick={this.save}>Save changes</Button>
   <Button onClick={this.clear}>Clear</Button>
 </div>`}
             />

--- a/src/docs/home.js
+++ b/src/docs/home.js
@@ -35,7 +35,7 @@ class Home extends React.Component {
             and use them along with you React components:
             <Pre
               code={`const Actions = () => <div>
-  <Button intent="primary" onClick={this.save}>Save changes</Button>
+  <Button appearance="primary" onClick={this.save}>Save changes</Button>
   <Button onClick={this.clear}>Clear</Button>
 </div>`}
             />

--- a/src/docs/spec/prop-string.js
+++ b/src/docs/spec/prop-string.js
@@ -22,7 +22,7 @@ const getPropString = propData => {
     /*
       Case 2: Truthy boolean
       We only need to drop the key
-      Example: primary="true" results in <Button primary>
+      Example: disabled="true" results in <Button disabled>
     */
     if (propData[name].type.name === 'bool' && propData[name].value === 'true') {
       propString += ` ${name}`

--- a/src/overview/examples/buttons.js
+++ b/src/overview/examples/buttons.js
@@ -39,19 +39,19 @@ const Buttons = () => (
       </Col>
       <Col>
         <Example title="Primary Button" align="center">
-          <Button primary>Button</Button>
+          <Button intent="primary">Button</Button>
         </Example>
       </Col>
     </Row>
     <Row>
       <Col>
         <Example title="Secondary Button" align="center">
-          <Button transparent>Button</Button>
+          <Button intent="transparent">Button</Button>
         </Example>
       </Col>
       <Col>
         <Example title="Link Button" align="center">
-          <Button link>Button</Button>
+          <Button intent="link">Button</Button>
         </Example>
       </Col>
     </Row>
@@ -63,7 +63,7 @@ const Buttons = () => (
       </Col>
       <Col>
         <Example title="Destructive Button" align="center">
-          <Button destructive>Button</Button>
+          <Button intent="destructive">Button</Button>
         </Example>
       </Col>
     </Row>

--- a/src/overview/examples/buttons.js
+++ b/src/overview/examples/buttons.js
@@ -82,13 +82,13 @@ const Buttons = () => (
       <Col>
         <Example title="Button with icon" align="center">
           <Stack>
-            <Button primary icon="plus">
+            <Button intent="primary" icon="plus">
               Create Client
             </Button>
-            <Button transparent icon="play-circle">
+            <Button intent="transparent" icon="play-circle">
               Tutorial
             </Button>
-            <Button link icon="copy" />
+            <Button intent="link" icon="copy" />
             <Button icon="copy" label="Copy to Clipboard" />
           </Stack>
         </Example>
@@ -99,10 +99,10 @@ const Buttons = () => (
         <Example title="Button Group">
           <Stack>
             <ButtonGroup>
-              <Button transparent icon="play-circle">
+              <Button intent="transparent" icon="play-circle">
                 Tutorial
               </Button>
-              <Button primary icon="plus">
+              <Button intent="primary" icon="plus">
                 Create Client
               </Button>
             </ButtonGroup>

--- a/src/overview/src/buttons.js
+++ b/src/overview/src/buttons.js
@@ -8,34 +8,34 @@ const Buttons = () => (
     <Container title="Buttons">
       <Stack>
         <Button label="An Action">default</Button>
-        <Button primary label="Main call to action">
+        <Button intent="primary" label="Main call to action">
           primary
         </Button>
-        <Button transparent label="Secondary action">
+        <Button intent="transparent" label="Secondary action">
           secondary
         </Button>
       </Stack>
       <br />
       <br />
       <Stack>
-        <Button destructive label="Destructive action">
+        <Button intent="destructive" label="Destructive action">
           Delete
         </Button>
-        <Button link label="Subtle action">
+        <Button intent="link" label="Subtle action">
           Clear
         </Button>
-        <Button link icon="copy" label="Subtle action">
+        <Button intent="link" icon="copy" label="Subtle action">
           Copy
         </Button>
       </Stack>
       <br />
       <br />
       <Stack>
-        <Button primary icon="plus">
+        <Button intent="primary" icon="plus">
           Create Client
         </Button>
 
-        <Button transparent icon="play-circle">
+        <Button intent="transparent" icon="play-circle">
           Tutorial
         </Button>
 


### PR DESCRIPTION
Closes #364.
Related to #88.

This patch combines the `default`, `primary`, `transparent`, `link`, and `destructive` props on `Button` into a single enumeration called `intent`. The name of this prop is debatable; there were several suggestions, so I just picked one that was more descriptive than `type`. 😄 

The `disabled`, `loading`, and `success` props are left as Booleans, and they influence (or override) the styles set by intents. It's still technically possible for these state-oriented properties to collide, but it's reasonable to have a combination of two. For example, you might want to disable a button while a form is saving, so you might set it both `disabled` and `loading`.

In `Tooltip`, the `top` and `bottom` props are combined into a `position` enum. We could just eliminate the `top` prop and keep the `bottom` prop as a Boolean. However, if we decided to add more positions in the future, it would either end up as a breaking change or result in an inconsistent API.