### PR TITLE
Updated import statements in docs to reflect the current package name in npm

### DIFF
--- a/src/components/atoms/_box/index.js
+++ b/src/components/atoms/_box/index.js
@@ -77,10 +77,10 @@ export default Box
   Bonus step: Add your component to component/index.js
   so that it can be imported from accross the system
 
-  import {Box} from 'src/components'
+  import { Box } from 'src/components'
 
   This is a step only for convenience while developing the system,
   it will be replaced with a more explicit syntax
 
-  import Box from 'cosmos/box'
+  import { Box } from 'auth0-cosmos'
 */

--- a/src/components/atoms/avatar/avatar.md
+++ b/src/components/atoms/avatar/avatar.md
@@ -3,7 +3,7 @@
   description: Avatar component contains images or symbols.
 ```
 
-`import Avatar from 'cosmos/avatar'`
+`import { Avatar } from 'auth0-cosmos'`
 
 ```jsx
 <Avatar image={<Logo />} {props} />

--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -3,7 +3,7 @@
   description: Buttons are great to ask users for action
 ```
 
-`import Button from 'cosmos/button'`
+`import { Button } from 'auth0-cosmos'`
 
 ```jsx
 <Button {props}>Button</Button>

--- a/src/components/atoms/code/code.md
+++ b/src/components/atoms/code/code.md
@@ -2,7 +2,7 @@
   category: Text
 ```
 
-`import Code from 'cosmos/code'`
+`import { Code } from 'auth0-cosmos'`
 
 ## Examples
 

--- a/src/components/atoms/heading/heading.md
+++ b/src/components/atoms/heading/heading.md
@@ -2,7 +2,7 @@
   category: Text
 ```
 
-`import Heading from 'cosmos/heading'`
+`import { Heading } from 'auth0-cosmos'`
 
 ```jsx
 <Heading {props}>Heading</Heading>

--- a/src/components/atoms/icon/icon.md
+++ b/src/components/atoms/icon/icon.md
@@ -3,7 +3,7 @@
   description: The Icon component displays an icon glyph as an <svg> element
 ```
 
-`import Icon from 'cosmos/icon'`
+`import { Icon } from 'auth0-cosmos'`
 
 ---
 

--- a/src/components/atoms/link/link.md
+++ b/src/components/atoms/link/link.md
@@ -3,7 +3,7 @@
   description: Use Links to connect pages with each other
 ```
 
-`import Button from 'cosmos/button'`
+`import { Button } from 'auth0-cosmos'`
 
 ---
 

--- a/src/components/atoms/logo/logo.md
+++ b/src/components/atoms/logo/logo.md
@@ -2,7 +2,7 @@
   category: Images
 ```
 
-`import Logo from 'cosmos/logo'`
+`import { Logo } from 'auth0-cosmos'`
 
 ## Examples
 

--- a/src/components/atoms/overlay/overlay.md
+++ b/src/components/atoms/overlay/overlay.md
@@ -3,7 +3,7 @@
   description: Low-level component that can be used to render any content on top of the regular viewport
 ```
 
-`import Overlay from 'cosmos/overlay'`
+`import { Overlay } from 'auth0-cosmos'`
 
 ---
 

--- a/src/components/atoms/paragraph/paragraph.md
+++ b/src/components/atoms/paragraph/paragraph.md
@@ -2,7 +2,7 @@
   category: Text
 ```
 
-`import Paragraph from 'cosmos/paragraph'`
+`import { Paragraph } from 'auth0-cosmos'`
 
 ## Examples
 

--- a/src/components/atoms/switch/switch.md
+++ b/src/components/atoms/switch/switch.md
@@ -2,7 +2,7 @@
   category: Forms
 ```
 
-`import Switch from 'cosmos/switch'`
+`import { Switch } from 'auth0-cosmos'`
 
 ```jsx
 <Switch {props} onToggle={value => console.log(value)} />

--- a/src/components/atoms/text-input/text-input.md
+++ b/src/components/atoms/text-input/text-input.md
@@ -3,7 +3,7 @@
   description: Use TextInput to ask for input from the user
 ```
 
-`import TextInput from 'cosmos/text-input'`
+`import { TextInput } from 'auth0-cosmos'`
 
 ```jsx
 <TextInput placeholder="Placeholder text" {props} />

--- a/src/components/atoms/textarea/textarea.md
+++ b/src/components/atoms/textarea/textarea.md
@@ -2,7 +2,7 @@
   category: Forms
 ```
 
-`import TextArea from 'cosmos/textarea'`
+`import { TextArea } from 'auth0-cosmos'`
 
 Note: `TextArea` is camelcased, it's not `Textarea`.
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,7 @@
 /*
   This file is an aggregator, to make it easier for folks to import components that they need
 
-  example: `import {Input} from 'components'`
+  example: `import { Input } from 'components'`
   instead of  `import Input from 'components/input'`
 */
 

--- a/src/components/molecules/button-group/button-group.md
+++ b/src/components/molecules/button-group/button-group.md
@@ -3,7 +3,7 @@
   description: Use a ButtonGroup to put related buttons together
 ```
 
-`import ButtonGroup from 'cosmos/button-group'`
+`import { ButtonGroup } from 'auth0-cosmos'`
 
 ---
 

--- a/src/components/molecules/form-group/form-group.md
+++ b/src/components/molecules/form-group/form-group.md
@@ -3,7 +3,7 @@ category: forms
 description: If a page has multiple forms, you can use FormGroup to separate them out.
 ```
 
-`import FormGroup from 'cosmos/form-group'`
+`import { FormGroup } from 'auth0-cosmos'`
 
 ---
 

--- a/src/components/molecules/form/form.md
+++ b/src/components/molecules/form/form.md
@@ -2,7 +2,7 @@
   category: Forms
 ```
 
-`import Form from 'cosmos/form'`
+`import { Form } from 'auth0-cosmos'`
 
 ---
 

--- a/src/components/molecules/list/list.md
+++ b/src/components/molecules/list/list.md
@@ -3,7 +3,7 @@
   description: "Use this component to layout a list of components vertically"
 ```
 
-`import List from 'cosmos/list'`
+`import { List } from 'auth0-cosmos'`
 
 ---
 

--- a/src/components/molecules/page-header/page-header.md
+++ b/src/components/molecules/page-header/page-header.md
@@ -3,7 +3,7 @@
   description: "Use to add a title, description and main actions to pages."
 ```
 
-`import PageHeader from 'cosmos/page-header'`
+`import { PageHeader } from 'auth0-cosmos'`
 
 ```jsx
 <PageHeader

--- a/src/components/molecules/stack/stack.md
+++ b/src/components/molecules/stack/stack.md
@@ -3,7 +3,7 @@
   description: "Use this component to horizontally layout children"
 ```
 
-`import Stack from 'cosmos/stack'`
+`import { Stack } from 'auth0-cosmos'`
 
 ```jsx
 <Stack {props}>


### PR DESCRIPTION
Closes #382.

We may want to change this in the future, but this updates the docs to (I believe?) the correct import syntax.