### PR TITLE
[WIP] Change `Client Type` anchors to radio on dialog

### DIFF
--- a/src/manage/pages/clients/create-client-dialog.js
+++ b/src/manage/pages/clients/create-client-dialog.js
@@ -8,17 +8,23 @@ import { StyledHeading } from 'auth0-cosmos/atoms/heading'
 import ClientTypeImages from '../../components/client-types-images'
 
 const ClientType = props => (
-  <ClientType.Element onClick={props.onClick} selected={props.selected}>
+  <ClientType.RadioElement onClick={props.onClick} selected={props.selected}>
+    <ClientType.Radio
+      type="radio"
+      value={props.name}
+      checked={props.checked}
+      onChange={props.onChange}
+    />
     <ClientType.Image size={64} image={props.image} />
     <ClientType.Title>{props.name}</ClientType.Title>
     <ClientType.Description>{props.description}</ClientType.Description>
     <ClientType.Example>eg: {props.example}</ClientType.Example>
-  </ClientType.Element>
+  </ClientType.RadioElement>
 )
 
 const ClientStack = styled(Stack)``
 
-ClientType.Element = styled.a`
+ClientType.RadioElement = styled.label`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -46,6 +52,12 @@ const SelectedStyles = css`
   }
 `
 
+ClientType.Radio = styled.input`
+  visibility: hidden;
+  position: absolute;
+  z-index: -999;
+`
+
 ClientType.Image = styled(Avatar)``
 
 ClientType.Title = styled(StyledHeading[4])`
@@ -66,7 +78,13 @@ ClientType.Example = styled.div`
 class CreateClientDialog extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { name: 'My App', type: 'native' }
+    this.state = { name: 'My App', type: 'native', isChecked: false }
+  }
+
+  toggleChange = () => {
+    this.setState({
+      isChecked: !this.state.isChecked
+    })
   }
 
   setValue = (name, value) => () => {
@@ -97,6 +115,8 @@ class CreateClientDialog extends React.Component {
                 example="iOS SDK"
                 onClick={this.setValue('type', 'native')}
                 selected={type === 'native'}
+                checked={this.state.isChecked}
+                onChange={this.toggleChange}
               />
               <ClientType
                 image={ClientTypeImages.spa}
@@ -105,6 +125,8 @@ class CreateClientDialog extends React.Component {
                 example="Angular.JS + NodeJS"
                 onClick={this.setValue('type', 'spa')}
                 selected={type === 'spa'}
+                checked={this.state.isChecked}
+                onChange={this.toggleChange}
               />
               <ClientType
                 image={ClientTypeImages.regular_web}
@@ -113,6 +135,8 @@ class CreateClientDialog extends React.Component {
                 example="Java ASP.NET"
                 onClick={this.setValue('type', 'regular_web')}
                 selected={type === 'regular_web'}
+                checked={this.state.isChecked}
+                onChange={this.toggleChange}
               />
               <ClientType
                 image={ClientTypeImages.non_interactive}
@@ -121,6 +145,8 @@ class CreateClientDialog extends React.Component {
                 example="Shell Script"
                 onClick={this.setValue('type', 'non_interactive')}
                 selected={type === 'non_interactive'}
+                checked={this.state.isChecked}
+                onChange={this.toggleChange}
               />
             </ClientStack>
           </Form.FieldSet>

--- a/src/manage/pages/clients/create-client-dialog.js
+++ b/src/manage/pages/clients/create-client-dialog.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import { Dialog, Form, Paragraph, Stack } from 'auth0-cosmos'
-import { colors, fonts, misc, spacing } from 'auth0-cosmos/tokens'
+import { colors, misc, spacing } from 'auth0-cosmos/tokens'
 import { StyledHeading } from 'auth0-cosmos/atoms/heading'
 
 import ClientTypeImages from '../../components/client-types-images'

--- a/src/manage/pages/clients/create-client-dialog.js
+++ b/src/manage/pages/clients/create-client-dialog.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { Dialog, Form, Paragraph, Stack } from 'auth0-cosmos'
+import { Dialog, Form, Paragraph, Stack, Avatar } from 'auth0-cosmos'
 import { colors, misc, spacing } from 'auth0-cosmos/tokens'
 import { StyledHeading } from 'auth0-cosmos/atoms/heading'
 
@@ -9,7 +9,9 @@ import ClientTypeImages from '../../components/client-types-images'
 
 const ClientType = props => (
   <ClientType.Element onClick={props.onClick} selected={props.selected}>
-    <ClientType.Image>{props.image}</ClientType.Image>
+    <ClientType.Image>
+      <Avatar size={64} image={props.image} />
+    </ClientType.Image>
     <ClientType.Title>{props.name}</ClientType.Title>
     <ClientType.Description>{props.description}</ClientType.Description>
     <ClientType.Example>eg: {props.example}</ClientType.Example>
@@ -53,20 +55,7 @@ const SelectedStyles = css`
   }
 `
 
-ClientType.Image = styled.div`
-  width: 64px;
-  height: 64px;
-  background: #f1f1f1;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: none;
-  svg {
-    height: 36px;
-    width: 36px;
-  }
-`
+ClientType.Image = styled.div``
 
 ClientType.Title = styled(StyledHeading[4])`
   margin: ${spacing.small} 0;

--- a/src/manage/pages/clients/create-client-dialog.js
+++ b/src/manage/pages/clients/create-client-dialog.js
@@ -16,14 +16,7 @@ const ClientType = props => (
   </ClientType.Element>
 )
 
-const ClientStack = styled(Stack)`
-  > * {
-    margin-right: ${spacing.small};
-  }
-  > *:last-child {
-    margin-right: 0;
-  }
-`
+const ClientStack = styled(Stack)``
 
 ClientType.Element = styled.a`
   display: flex;

--- a/src/manage/pages/clients/create-client-dialog.js
+++ b/src/manage/pages/clients/create-client-dialog.js
@@ -9,9 +9,7 @@ import ClientTypeImages from '../../components/client-types-images'
 
 const ClientType = props => (
   <ClientType.Element onClick={props.onClick} selected={props.selected}>
-    <ClientType.Image>
-      <Avatar size={64} image={props.image} />
-    </ClientType.Image>
+    <ClientType.Image size={64} image={props.image} />
     <ClientType.Title>{props.name}</ClientType.Title>
     <ClientType.Description>{props.description}</ClientType.Description>
     <ClientType.Example>eg: {props.example}</ClientType.Example>
@@ -55,7 +53,7 @@ const SelectedStyles = css`
   }
 `
 
-ClientType.Image = styled.div``
+ClientType.Image = styled(Avatar)``
 
 ClientType.Title = styled(StyledHeading[4])`
   margin: ${spacing.small} 0;


### PR DESCRIPTION
Tracking https://github.com/auth0/cosmos/issues/376

The principal idea what we talk with @landitus is change `anchors` to `radio` option in the selection of the `Client Type`. This is more effective in the use and the right semantic to this kind of options.
Maybe the engineering isn't my strong but is good to have to @siddharthkp 😄

This is an approach. Now this escalates and we have to build a component for this. 😅 

WDYT?