### PR TITLE
Add size prop to Button

### DIFF
--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -13,18 +13,20 @@
 
 ### Basic button
 
-Buttons are great to ask users for action
-
 ```js
 <Button>Save</Button>
 ```
 
-### Button types
+### Button appearance
 
-* Primary actions help attract attention to the main action
-* Use secondary actions for actions that are not as important
-* Link button for linky stuff, idk?
-* Destructive buttons warn the user about it's effects. Proceed with caution.
+The `appearance` prop defines the overall visual style of the Button. You can use
+this prop to indicate to the user the purpose or importance of the button, or call
+their attention to it.
+
+* Primary buttons can help attract attention to the main call-to-action.
+* Secondary buttons can be used for actions which are less important, or for general purpose.
+* Link buttons can be used to make the button appear more as a hyperlink rather than a button.
+* Destructive buttons indicate that the user should be cautious when triggering it.
 
 ```js
 <div>
@@ -34,6 +36,26 @@ Buttons are great to ask users for action
     <Button appearance="transparent">secondary</Button>
     <Button appearance="link">Clear</Button>
     <Button appearance="destructive">Delete</Button>
+  </Stack>
+</div>
+```
+
+### Button sizes
+
+You can create buttons of various sizes.
+
+* Large buttons are used for calls to action and in empty page states.
+* Small buttons are used inside tables, editable rows, or in row actions.
+* Compressed buttons are used for filters or inline forms.
+* Default-sized buttons are used everywhere else.
+
+```js
+<div>
+  <Stack>
+    <Button>default</Button>
+    <Button size="large">large</Button>
+    <Button size="small">small</Button>
+    <Button size="compressed">compressed</Button>
   </Stack>
 </div>
 ```
@@ -54,7 +76,7 @@ saved successfully.
 </div>
 ```
 
-### Icons in Buttons
+### Icon buttons
 
 Icon buttons work well in compact spaces. You can pick name of `icon` from [docs/Icon](/docs/Icon)
 
@@ -67,10 +89,11 @@ Icon buttons work well in compact spaces. You can pick name of `icon` from [docs
 </div>
 ```
 
-### Label/Tooltips
+### Adding tooltips
 
-Especially with buttons that only have an icon and no text, it might be helpful to add a label
-which appear when a user hovers over a button.
+You can set the `label` property to add a tooltip that will appear when the user hovers over
+the button. This can help clarify the purpose of the button, and is especially useful with
+buttons that only have an icon and no text.
 
 ```js
 <Button icon="copy" label="Copy to clipboard" />

--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -45,17 +45,17 @@ their attention to it.
 You can create buttons of various sizes.
 
 * Large buttons are used for calls to action and in empty page states.
-* Small buttons are used inside tables, editable rows, or in row actions.
+* Default-sized buttons are used in most situations, like in Form Actions and Dialogs.
 * Compressed buttons are used for filters or inline forms.
-* Default-sized buttons are used everywhere else.
+* Small buttons are used inside tables: in editable rows, or row actions.
 
 ```js
 <div>
   <Stack>
-    <Button>default</Button>
     <Button size="large">large</Button>
-    <Button size="small">small</Button>
+    <Button>default</Button>
     <Button size="compressed">compressed</Button>
+    <Button size="small">small</Button>
   </Stack>
 </div>
 ```

--- a/src/components/atoms/button/button.md
+++ b/src/components/atoms/button/button.md
@@ -40,7 +40,9 @@ Buttons are great to ask users for action
 
 ### Button states
 
-Disable a button if you don't want the user isn't allowed to click on it
+You can disable a button if you don't want the user to be able to click it. You can also add a spinner
+to indicate that data is loading, or a success checkmark to indicate (for example) that data has been
+saved successfully.
 
 ```js
 <div>

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -84,7 +84,7 @@ const sizes = {
   large: {
     height: '48px',
     minWidth: '96px',
-    padding: spacing.medium
+    padding: spacing.small
   },
   small: {
     height: '32px',

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -99,7 +99,7 @@ const sizes = {
 }
 
 const getAttributes = props => {
-  // Get the styles for the button's selected appearance
+  // Get the styles for the button's selected appearance.
   const appearanceStyles = appearances[props.appearance]
     ? appearances[props.appearance]
     : appearances.default
@@ -123,8 +123,8 @@ const getAttributes = props => {
     styles.focusBorder = styles.hoverBorder
   }
 
-  // If onlyIcon is set, override some of the styles.
-  if (props.onlyIcon) {
+  // If the button contains only an icon and no text, override some of the styles.
+  if (props.icon && !props.text) {
     styles.padding = 0
     styles.minWidth = '36px'
   }
@@ -132,52 +132,44 @@ const getAttributes = props => {
   return styles
 }
 
-const ButtonWithIcon = ({ children, ...props }) => (
-  <Button.Element {...props} onlyIcon>
-    <Icon size={16} name={props.icon} color={colors.button.linkIcon} />
-  </Button.Element>
-)
+const ButtonContent = props => {
+  let content
 
-const ButtonWithText = ({ children, ...props }) => (
-  <Button.Element {...props}>
-    <Button.Content>{children}</Button.Content>
-  </Button.Element>
-)
-
-const ButtonWithIconAndText = ({ children, ...props }) => (
-  <Button.Element {...props}>
-    <Icon size={16} name={props.icon} color={getAttributes(props).icon} />
-    <Button.Content>{children}</Button.Content>
-  </Button.Element>
-)
-
-const ButtonContent = ({ children, ...props }) => {
-  if (props.icon && children) {
-    return <ButtonWithIconAndText {...props}>{children}</ButtonWithIconAndText>
-  } else if (props.icon && !children) {
-    return <ButtonWithIcon {...props}>{children}</ButtonWithIcon>
+  if (props.icon && props.text) {
+    // The button contains both an icon and text.
+    content = [
+      <Icon size={16} name={props.icon} color={getAttributes(props).icon} />,
+      <Button.Text>{props.text}</Button.Text>
+    ]
+  } else if (props.icon && !props.text) {
+    // The button contains just an icon.
+    content = <Icon size={16} name={props.icon} color={colors.button.linkIcon} />
   } else {
-    return <ButtonWithText {...props}>{children}</ButtonWithText>
+    // The button contains just text.
+    content = <Button.Text>{props.text}</Button.Text>
   }
+
+  return <Button.Element {...props}>{props.override || content}</Button.Element>
 }
 
 const Button = ({ children, ...props }) => {
-  let content
+  let override
 
-  if (props.success)
-    content = <Icon size={16} color={colors.base.white} name="check" type="success" />
-  else if (props.loading) content = <Spinner inverse={props.primary} />
-  else content = children
-
-  if (props.label) {
-    return (
-      <Tooltip content={props.label}>
-        <ButtonContent {...props}>{content}</ButtonContent>
-      </Tooltip>
-    )
+  // Some of the state properties will override the content of the button.
+  if (props.success) {
+    override = <Icon size={16} color={colors.base.white} name="check" type="success" />
+  } else if (props.loading) {
+    override = <Spinner inverse={props.primary} />
   }
 
-  return <ButtonContent {...props}>{content}</ButtonContent>
+  let button = <ButtonContent {...props} text={children} override={override} />
+
+  // If a label was specified, wrap the Button in a Tooltip.
+  if (props.label) {
+    return <Tooltip content={props.label}>{button}</Tooltip>
+  }
+
+  return button
 }
 
 Button.Element = styled.button`
@@ -220,7 +212,7 @@ Button.Element = styled.button`
   }
 `
 
-Button.Content = styled.span`
+Button.Text = styled.span`
   display: inline-block;
   vertical-align: middle;
 `

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -75,20 +75,58 @@ const states = {
   }
 }
 
-const getAttributes = props => {
-  if (props.success) return { ...states.success }
+const sizes = {
+  default: {
+    height: '40px',
+    minWidth: '96px',
+    padding: spacing.small
+  },
+  large: {
+    height: '48px',
+    minWidth: '96px',
+    padding: spacing.medium
+  },
+  small: {
+    height: '32px',
+    minWidth: 'auto',
+    padding: spacing.xsmall
+  },
+  compressed: {
+    height: '36px',
+    minWidth: 'auto',
+    padding: spacing.small
+  }
+}
 
-  const baseStyles = appearances[props.appearance]
+const getAttributes = props => {
+  // Get the styles for the button's selected appearance
+  const appearanceStyles = appearances[props.appearance]
     ? appearances[props.appearance]
     : appearances.default
-  const styles = { ...baseStyles }
 
-  /* overwrite for loading state */
+  // Get the styles for the button's selected size.
+  const sizeStyles = sizes[props.size] ? sizes[props.size] : sizes.default
+
+  // Merge the two style hashes together to create the base styles.
+  let styles = { ...appearanceStyles, ...sizeStyles }
+
+  // If the success state is set, override some of the styles.
+  if (props.success) {
+    styles = { ...styles, ...states.success }
+  }
+
+  // If the loading state is set, override some of the styles.
   if (props.loading) {
     styles.background = styles.hoverBackground
     styles.focusBackground = styles.hoverBackground
     styles.border = styles.hoverBorder
     styles.focusBorder = styles.hoverBorder
+  }
+
+  // If onlyIcon is set, override some of the styles.
+  if (props.onlyIcon) {
+    styles.padding = 0
+    styles.minWidth = '36px'
   }
 
   return styles
@@ -116,8 +154,11 @@ const ButtonWithIconAndText = ({ children, ...props }) => (
 const ButtonContent = ({ children, ...props }) => {
   if (props.icon && children) {
     return <ButtonWithIconAndText {...props}>{children}</ButtonWithIconAndText>
-  } else if (props.icon && !children) return <ButtonWithIcon {...props}>{children}</ButtonWithIcon>
-  else return <ButtonWithText {...props}>{children}</ButtonWithText>
+  } else if (props.icon && !children) {
+    return <ButtonWithIcon {...props}>{children}</ButtonWithIcon>
+  } else {
+    return <ButtonWithText {...props}>{children}</ButtonWithText>
+  }
 }
 
 const Button = ({ children, ...props }) => {
@@ -140,7 +181,8 @@ const Button = ({ children, ...props }) => {
 }
 
 Button.Element = styled.button`
-  min-width: ${props => (props.onlyIcon ? '36px' : '96px')};
+  height: ${props => getAttributes(props).height};
+  min-width: ${props => getAttributes(props).minWidth};
   box-sizing: border-box;
 
   text-transform: uppercase;
@@ -155,7 +197,7 @@ Button.Element = styled.button`
 
   color: ${props => getAttributes(props).text};
 
-  padding: ${spacing.xsmall} ${props => (props.onlyIcon ? 0 : spacing.small)};
+  padding: 0 ${props => getAttributes(props).padding};
 
   opacity: ${props => (props.disabled ? 0.5 : 1)};
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
@@ -184,6 +226,9 @@ Button.Content = styled.span`
 `
 
 Button.propTypes = {
+  /** The size of the button */
+  size: PropTypes.oneOf(['default', 'large', 'small', 'compressed']),
+
   /** The visual style used to convey the button's purpose */
   appearance: PropTypes.oneOf(['default', 'primary', 'transparent', 'destructive', 'link']),
 
@@ -204,6 +249,7 @@ Button.propTypes = {
 }
 
 Button.defaultProps = {
+  size: 'default',
   appearance: 'default',
   icon: null,
   disabled: false,

--- a/src/components/molecules/empty-state/index.js
+++ b/src/components/molecules/empty-state/index.js
@@ -22,7 +22,12 @@ const EmptyState = props => {
       <Heading size={1}>{props.title}</Heading>
       <Icon name={props.icon} size={100} color={colors.base.blue} />
       <Paragraph>{props.text}</Paragraph> {helpLink}
-      <Button appearance="primary" icon={props.action.icon} onClick={props.action.method}>
+      <Button
+        size="large"
+        appearance="primary"
+        icon={props.action.icon}
+        onClick={props.action.method}
+      >
         {props.action.text}
       </Button>
     </EmptyState.Wrapper>

--- a/src/components/molecules/page-header/index.js
+++ b/src/components/molecules/page-header/index.js
@@ -30,6 +30,7 @@ const PageHeader = props => {
         <ButtonGroup align="right">
           {props.secondaryAction && (
             <Button
+              size="large"
               appearance="transparent"
               icon={props.secondaryAction.icon}
               onClick={props.secondaryAction.method}
@@ -38,6 +39,7 @@ const PageHeader = props => {
             </Button>
           )}
           <Button
+            size="large"
             appearance="primary"
             icon={props.primaryAction.icon}
             onClick={props.primaryAction.method}


### PR DESCRIPTION
Closes #417.

This patch adds a `size` prop to `Button`, which controls the vertical height and horizontal padding of the button. Also, the branching logic in `Button` was quickly turning to spaghetti so I took a stab at simplifying it. In addition to (hopefully) making the code easier to understand, this should also fix some bugs with edge cases; for example, previously setting a button with only an icon to `success` would cause it to gain a minimum width and horizontal padding.

I also added the new large button to `PageHeader` and `EmptyState`. I think we probably want the `small` button inside of the clients table in the example app, but I wasn't sure.