### PR TITLE
First pass at a changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 [March 27, 2016]
+
+### Added
+
+* New `cta` appearance for `Button`, to be used for primary calls to action. [#425]
+* New "link mode" for `Button`. Passing an `href` prop to `Button` will cause it to render as an `<a>` instead of a `<button>`. [#425]
+* _Unstable:_ New `Avatar` and `Thumbnail` components. [#398]
+* _Unstable:_ New `Text` component for styled text. [#392]
+
+### Changed
+
+* **BREAKING:** Colliding Boolean props governing appearance of `Button` were replaced with an `appearance` enum. [#400]

--- a/src/docs/changelog.json
+++ b/src/docs/changelog.json
@@ -1,0 +1,4 @@
+{
+  "changelog":
+    "# Changelog\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)\nand this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).\n\n## 0.1.0 [March 27, 2016]\n\n### Added\n- New `cta` appearance for `Button`, to be used for primary calls to action. [#425]\n- New \"link mode\" for `Button`. Passing an `href` prop to `Button` will cause it to render as an `<a>` instead of a `<button>`. [#425]\n- *Unstable:* New `Avatar` and `Thumbnail` components. [#398]\n- *Unstable:* New `Text` component for styled text. [#392]\n\n### Changed\n- **BREAKING:** Colliding Boolean props governing appearance of `Button` were replaced with an `appearance` enum. [#400]\n"
+}

--- a/src/docs/changes.js
+++ b/src/docs/changes.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import styled from 'styled-components'
+import Helmet from 'react-helmet'
+import Markdown from 'markdown-to-jsx'
+import { changelog } from './changelog'
+
+import {
+  Heading1,
+  Heading2,
+  Heading3,
+  Text,
+  Link,
+  List,
+  ListItem
+} from './docs-components/typography'
+import { Code } from 'auth0-cosmos'
+
+const Container = styled.div``
+
+const content = changelog.replace(
+  /\[#(\d+)\]/g,
+  '<a href="https://github.com/auth0/cosmos/pull/$1" target="_blank">[#$1]</a>'
+)
+
+const options = {
+  overrides: {
+    h1: Heading1,
+    h2: Heading2,
+    h3: Heading3,
+    p: Text,
+    a: Link,
+    li: ListItem,
+    ul: List,
+    code: Code
+  }
+}
+
+class Changes extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Documentation &mdash; Cosmos" />
+        <Container>
+          <Markdown options={options}>{content}</Markdown>
+        </Container>
+      </div>
+    )
+  }
+}
+
+export default Changes

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -8,6 +8,7 @@ import Home from './home'
 import GuidingPrinciples from './guiding-principles'
 import ContributionGuide from './contribution-guide'
 import FAQS from './faqs'
+import Changes from './changes'
 
 const Layout = styled.div`
   position: relative;
@@ -43,6 +44,7 @@ export default () => (
             <Route path="/docs/guiding-principles" component={GuidingPrinciples} />
             <Route path="/docs/contribution-guide" component={ContributionGuide} />
             <Route path="/docs/faqs" component={FAQS} />
+            <Route path="/docs/changes" component={Changes} />
             <Route path="/docs/:componentName" component={Spec} />
             <Route component={Home} />
           </Switch>

--- a/src/docs/sidebar/list.js
+++ b/src/docs/sidebar/list.js
@@ -55,6 +55,11 @@ const List = props => {
             FAQs
           </NavLink>
         </StyledLink>
+        <StyledLink>
+          <NavLink to="/docs/changes" activeClassName="selected">
+            Changelog
+          </NavLink>
+        </StyledLink>
       </Group>
 
       <Group label="Building blocks" open>

--- a/tooling/component-metadata.js
+++ b/tooling/component-metadata.js
@@ -117,6 +117,12 @@ const run = () => {
   */
   fs.writeFileSync('src/docs/metadata.json', JSON.stringify({ metadata }, null, 2), 'utf8')
 
+  // Write a version of the Changelog to a place where we can access it later.
+  // TODO: Consider parsing the Markdown and storing this in a more structured format
+  // so we can display it more intelligently in the docs?
+  const changelog = fs.readFileSync('changelog.md', 'utf8')
+  fs.writeFileSync('src/docs/changelog.json', JSON.stringify({ changelog }, null, 2), 'utf8')
+
   if (warning) {
     warn(`${warning} components could use some docs love, run in --debug mode for more info`)
   }


### PR DESCRIPTION
Closes #361.

This patch adds a `changelog.md` file to the root of the repo, which should be kept up-to-date with important PRs that are merged. If you know you're introducing a significant addition or change (especially breaking changes) it's probably a good idea to update the changelog in the commit itself. Before we ship new versions we should always do a final pass to ensure the changelog contains all the things we want to highlight.

The contents of the changelog is also added to the docs at `/docs/changes`. Right now, I added a (rather hacky) step that reads the contents of `changelog.md` and writes it to `src/docs/markdown.json` so it can later be read by `markdown-to-jsx` -- basically the same thing that the component documentation does now.

I started getting a little too fancy with this, trying to parse the Markdown to improve the styling of the changelog in the docs, but I backed off once I realized how brittle it was going to be. Unfortunately, that means that right now we're also sort of limited in how we can display the content in the docs. I'd like to do things like create anchors on each version, etc. but right now it's not easily possible.

I think there could be some merit to "inverting" the process, and hand-authoring a JSON file of commits and generating the Markdown for `changelog.md`... but I wasn't sure if that would become cumbersome to edit. 😄 