### PR TITLE
Stable points to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
 cache: yarn
 after_success:
   - cp tooling/deployment-package.json build/package.json
-  - cd build && npx now-cd --team=auth0-design
+  - cd build && npx now-cd --team=auth0-design --alias "stable=auth0-cosmos.now.sh"
 notifications:
   email: false


### PR DESCRIPTION
now-cd now supports aliases: https://github.com/siddharthkp/now-cd/pull/10

With our new release process, `stable` should point to production instead of master