### PR TITLE
Add ability to add defaults for prop table example

### DIFF
--- a/src/components/atoms/tooltip/tooltip.md
+++ b/src/components/atoms/tooltip/tooltip.md
@@ -6,7 +6,7 @@ description: Use tooltips for giving extra context AND to make visual cues acces
 ---
 
 ```jsx
-<Tooltip content="Here is some text" {props}>Hover me</Tooltip>
+<Tooltip defaults={{content: "Here is some text"}} {props}>Hover me</Tooltip>
 ```
 
 ## Examples

--- a/src/docs/spec/get-defaults-from-code.js
+++ b/src/docs/spec/get-defaults-from-code.js
@@ -1,0 +1,43 @@
+const getDefaultString = code => {
+  const string = code
+    .split('defaults={{')[1]
+    .split('}}>')[0]
+    .split('}} ')[0]
+
+  return string
+}
+
+const getDefaultsFromCode = code => {
+  let values = {}
+
+  // code ~ <Component defaults={{key1: "value1", key2: "value2"}}/>
+
+  if (!code.includes('defaults')) return values
+
+  const string = getDefaultString(code)
+  // string ~ key1: "value1", key2: "value2"
+
+  string.split(',').forEach(pair => {
+    const [key, value] = pair.split(':')
+    values[key.trim()] = JSON.parse(value.trim())
+  })
+  // values ~ { key1: "value1", key2: "value2" }
+
+  return values
+}
+
+const stripDefaultsFromDocs = code => {
+  // code ~ <Component defaults={{key1: "value1", key2: "value2"}}/>
+
+  if (!code.includes('defaults')) return code
+
+  const string = getDefaultString(code)
+  // string ~ key1: "value1", key2: "value2"
+
+  const strippedCode = code.replace(` defaults={{${string}}}`, '')
+  // strippedCode ~ <Component />
+
+  return strippedCode
+}
+
+export { getDefaultsFromCode, stripDefaultsFromDocs }

--- a/src/docs/spec/playground.js
+++ b/src/docs/spec/playground.js
@@ -8,6 +8,7 @@ import { fonts, colors, spacing } from '@auth0/cosmos/tokens'
 import Props from './props'
 import getPropString from './prop-string'
 import CopyButton from './copy-button'
+import { getDefaultsFromCode, stripDefaultsFromDocs } from './get-defaults-from-code'
 
 const Container = styled.div`
   margin: ${spacing.medium} 0;
@@ -61,12 +62,16 @@ const CodeToggle = styled.div`
 class Playground extends React.Component {
   constructor(props) {
     super(props)
-    let showProps = props.language === 'lang-jsx'
+    const showProps = props.language === 'lang-jsx'
+
+    const defaultsFromDocs = getDefaultsFromCode(props.code)
+    const code = stripDefaultsFromDocs(props.code)
 
     this.state = {
       showProps,
       codeVisible: showProps,
-      code: this.props.code
+      code,
+      defaultsFromDocs
     }
   }
   toggleCode() {
@@ -74,18 +79,16 @@ class Playground extends React.Component {
   }
   onPropsChange(propData) {
     const propString = getPropString(propData)
-    this.setState({ code: this.props.code.replace(' {props}', propString) })
+    const code = stripDefaultsFromDocs(this.props.code)
+    this.setState({ code: code.replace(' {props}', propString) })
   }
   render() {
-    const code = this.state.code
-
     return (
       <Container codeVisible={this.state.codeVisible}>
-        <LiveProvider code={code} scope={Components}>
+        <LiveProvider code={this.state.code} scope={Components}>
           <LivePreview />
           <LiveError />
-          {/* {this.state.codeVisible ? <LiveEditor /> : null} */}
-          <CodeWrapper className={!this.state.codeVisible && 'hide'} code={code}>
+          <CodeWrapper className={!this.state.codeVisible && 'hide'} code={this.state.code}>
             <LiveEditor />
           </CodeWrapper>
           {this.state.codeVisible ? <CopyButton code={this.state.code} /> : null}
@@ -96,6 +99,8 @@ class Playground extends React.Component {
         {this.state.showProps && (
           <Props
             propData={this.props.component.props}
+            code={this.state.code}
+            defaultsFromDocs={this.state.defaultsFromDocs}
             onPropsChange={this.onPropsChange.bind(this)}
           />
         )}

--- a/src/docs/spec/props.js
+++ b/src/docs/spec/props.js
@@ -50,7 +50,14 @@ const Description = styled.span`
 class Props extends React.Component {
   constructor(props) {
     super(props)
-    const propData = addDefaultValues(props.propData)
+    let propData = addDefaultValues(props.propData)
+
+    /* over ride with defaults from documentation */
+    const defaultsFromDocs = props.defaultsFromDocs
+    Object.keys(defaultsFromDocs).forEach(key => {
+      if (propData[key]) propData[key].value = defaultsFromDocs[key]
+    })
+
     this.state = { propData: propData }
     this.props.onPropsChange(propData)
   }


### PR DESCRIPTION
Fixes: https://github.com/auth0/cosmos/issues/259 and https://github.com/auth0/cosmos/pull/491

Syntax:

```jsx
<Tooltip {props} defaults={{content: "Here is some text"}}>Hover me</Tooltip>
```

The code is mostly garbage. I wouldn't suggest reviewing it, we need a rewrite of playground section of the docs

With some magic, it pulls it from the code and passes it to props.