### PR TITLE
Make preset optional

### DIFF
--- a/examples/perf-tests/package.json
+++ b/examples/perf-tests/package.json
@@ -8,7 +8,8 @@
     "start": "serve public"
   },
   "dependencies": {
-    "@auth0/cosmos": "0.0.4",
+    "@auth0/cosmos": "0.1.0",
+    "@auth0/babel-preset-cosmos": "0.1.0",
     "react": "16.2.0",
     "react-dom": "16.2.0"
   },

--- a/examples/perf-tests/webpack.config.js
+++ b/examples/perf-tests/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
         test: /\.js?$/,
         loader: 'babel-loader',
         options: {
-          presets: ['@auth0/cosmos/babel']
+          presets: ['babel-preset-cosmos']
         }
       }
     ]

--- a/examples/webpack-hello-world/package.json
+++ b/examples/webpack-hello-world/package.json
@@ -8,7 +8,8 @@
     "start": "serve public"
   },
   "dependencies": {
-    "@auth0/cosmos": "0.0.4",
+    "@auth0/cosmos": "0.1.0",
+    "@auth0/babel-preset-cosmos": "0.1.0",
     "react": "16.2.0",
     "react-dom": "16.2.0"
   },

--- a/examples/webpack-hello-world/webpack.config.js
+++ b/examples/webpack-hello-world/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
         test: /\.js?$/,
         loader: 'babel-loader',
         options: {
-          presets: ['@auth0/cosmos/babel']
+          presets: ['babel-preset-cosmos']
         }
       }
     ]

--- a/src/components/babel.js
+++ b/src/components/babel.js
@@ -1,3 +1,0 @@
-const config = require('babel-preset-cosmos')
-
-module.exports = config

--- a/src/components/package.json
+++ b/src/components/package.json
@@ -11,7 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "@auth0/cosmos-tokens": "0.1.0",
-    "@auth0/babel-preset-cosmos": "0.1.0",
     "prop-types": "15.6.1",
     "styled-components": "3.1.6"
   }

--- a/tooling/catchup.js
+++ b/tooling/catchup.js
@@ -19,7 +19,6 @@ directories.forEach(directory => {
   /* components should import the same version of tokens and babel-preset */
   if (directory === 'src/components') {
     content.dependencies['@auth0/cosmos-tokens'] = version
-    content.dependencies['@auth0/babel-preset-cosmos'] = version
   }
 
   fs.writeJsonSync(packageJSONPath, content, { spaces: 2 })

--- a/tooling/publish.js
+++ b/tooling/publish.js
@@ -25,7 +25,6 @@ latestVersion('@auth0/cosmos').then(publishedVersion => {
     /* components should import the same version */
     if (directory === 'src/components') {
       content.dependencies['@auth0/cosmos-tokens'] = version
-      content.dependencies['@auth0/babel-preset-cosmos'] = version
     }
 
     fs.writeJsonSync(packageJSONPath, content, { spaces: 2 })


### PR DESCRIPTION
Now that we transpile components by default, we don't need to ship the babel-preset by default.

It will also not end up in the product's lock file, [example](https://github.com/auth0/manage/pull/3769#discussion_r179614332)