### PR TITLE
Added additional pages to the PoC to be able to test components

### DIFF
--- a/src/manage/components/page.js
+++ b/src/manage/components/page.js
@@ -4,6 +4,12 @@ import { BrowserRouter as Router, Route } from 'react-router-dom'
 import ClientIndex from '../pages/clients'
 import ClientDetail from '../pages/client-detail'
 import EmailsIndex from '../pages/emails'
+import RulesIndex from '../pages/rules'
+import SsoIndex from '../pages/sso-integrations'
+import AnomalyDetectionIndex from '../pages/anomaly-detection'
+import LogsIndex from '../pages/slogs'
+import ApisIndex from '../pages/apis'
+import UsersIndex from '../pages/users'
 
 const Page = () => (
   <div
@@ -18,6 +24,12 @@ const Page = () => (
         <Route exact path="/manage/clients" component={ClientIndex} />
         <Route exact path="/manage/clients/:clientId" component={ClientDetail} />
         <Route exact path="/manage/emails" component={EmailsIndex} />
+        <Route exact path="/manage/rules" component={RulesIndex} />
+        <Route exact path="/manage/logs" component={LogsIndex} />
+        <Route exact path="/manage/users" component={UsersIndex} />
+        <Route exact path="/manage/apis" component={ApisIndex} />
+        <Route exact path="/manage/anomaly" component={AnomalyDetectionIndex} />
+        <Route exact path="/manage/sso-integrations" component={SsoIndex} />
       </div>
     </Router>
   </div>

--- a/src/manage/components/side-navigation.js
+++ b/src/manage/components/side-navigation.js
@@ -12,9 +12,13 @@ export default () => (
   >
     <Sidebar>
       <Sidebar.Link icon="dashboard" label="Dashboard" url="/manage" />
-      <Sidebar.Link icon="clients" label="Clients" url="/manage/clients" selected />
+      <Sidebar.Link icon="clients" label="Clients" url="/manage/clients" />
       <Sidebar.Link icon="apis" label="APIs" url="/manage/apis" />
-      <Sidebar.Link icon="sso-integrations" label="SSO Integrations" url="/manage/externalapps" />
+      <Sidebar.Link
+        icon="sso-integrations"
+        label="SSO Integrations"
+        url="/manage/sso-integrations"
+      />
       <Sidebar.LinkGroup icon="connections" label="Connections">
         <Sidebar.Link label="Database" url="/manage/connections/database" />
         <Sidebar.Link label="Social" url="/manage/connections/social" />

--- a/src/manage/pages/anomaly-detection/index.js
+++ b/src/manage/pages/anomaly-detection/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { PageHeader } from '@auth0/cosmos'
+
+class AnomalyDetectionIndex extends React.Component {
+  render() {
+    return (
+      <div>
+        <PageHeader
+          title="Anomaly Detection"
+          description={{
+            text:
+              'Provide extra layer of security to your customers by enabling shields​ that protect you and your users against different types of attacks and user access anomalies.'
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+export default AnomalyDetectionIndex

--- a/src/manage/pages/apis/index.js
+++ b/src/manage/pages/apis/index.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { PageHeader } from '@auth0/cosmos'
+
+class ApisIndex extends React.Component {
+  render() {
+    return (
+      <div>
+        <PageHeader
+          title="APIs"
+          description={{
+            text: 'Define APIs that you can consume from your authorized applications.',
+            learnMore: '/'
+          }}
+          primaryAction={{
+            label: 'Create API',
+            icon: 'plus',
+            method: null
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+export default ApisIndex

--- a/src/manage/pages/clients/index.js
+++ b/src/manage/pages/clients/index.js
@@ -1,12 +1,8 @@
 import React from 'react'
-import styled from 'styled-components'
-
 import { PageHeader } from '@auth0/cosmos'
 
 import CreateClientDialog from './create-client-dialog'
 import ClientList from '../../components/client-list'
-
-const ClientsContent = styled.div``
 
 class ClientIndex extends React.Component {
   constructor(props) {
@@ -20,7 +16,7 @@ class ClientIndex extends React.Component {
 
   render() {
     return (
-      <ClientsContent>
+      <div>
         <PageHeader
           title="Clients"
           description={{
@@ -42,7 +38,7 @@ class ClientIndex extends React.Component {
         <ClientList />
 
         <CreateClientDialog open={this.state.dialogOpen} onClose={this.setDialogOpen(false)} />
-      </ClientsContent>
+      </div>
     )
   }
 }

--- a/src/manage/pages/rules/index.js
+++ b/src/manage/pages/rules/index.js
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { PageHeader } from '@auth0/cosmos'
+
+class RulesIndex extends React.Component {
+  render() {
+    return (
+      <div>
+        <PageHeader
+          title="Rules"
+          description={{
+            text:
+              'Custom Javascript snippets that run in a secure, isolated sandbox in the Auth0 service as part of your authentication pipeline.',
+            learnMore: '/'
+          }}
+          primaryAction={{
+            label: 'Create Rule',
+            icon: 'plus',
+            method: null
+          }}
+          secondaryAction={{
+            label: 'Tutorial',
+            icon: 'play-circle',
+            method: () => {}
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+export default RulesIndex

--- a/src/manage/pages/slogs/index.js
+++ b/src/manage/pages/slogs/index.js
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { PageHeader } from '@auth0/cosmos'
+
+class LogsIndex extends React.Component {
+  render() {
+    return (
+      <div>
+        <PageHeader
+          title="Logs"
+          description={{
+            text:
+              'Storage of log data of both actions taken in the dashboard by the administrators, as well as authentications made by your users.',
+            learnMore: '/'
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+export default LogsIndex

--- a/src/manage/pages/sso-integrations/index.js
+++ b/src/manage/pages/sso-integrations/index.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import { EmptyState } from '@auth0/cosmos'
+
+class SsoIndex extends React.Component {
+  render() {
+    return (
+      <div>
+        <EmptyState
+          title="SSO Integrations"
+          icon="sso-integrations"
+          helpUrl="http://auth0.com"
+          action={{
+            icon: 'plus',
+            text: 'Create SSO Integration'
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+export default SsoIndex

--- a/src/manage/pages/users/index.js
+++ b/src/manage/pages/users/index.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import { PageHeader } from '@auth0/cosmos'
+
+class UsersIndex extends React.Component {
+  render() {
+    return (
+      <div>
+        <PageHeader
+          title="Users"
+          description={{
+            text:
+              'An easy to use UI to help administrators manage user identities including password resets, creating and provisioning, blocking and deleting users.',
+            learnMore: '/'
+          }}
+          primaryAction={{
+            label: 'Create User',
+            icon: 'plus',
+            method: null
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+export default UsersIndex


### PR DESCRIPTION
Added routing and stub pages for many sections of the PoC to test out components will real data and in a product context. This will also allow us to try mix and matching components in different situations. 

At first glance I think we can try and avoid having styled-components included in these pages so we can check the flexibility (or lack of) Cosmos components. Should we need to override something, we need to ack what's the proper way.