### PR TITLE
Fix persistent warning in Form.Actions

### DIFF
--- a/src/components/molecules/button-group/index.js
+++ b/src/components/molecules/button-group/index.js
@@ -50,7 +50,7 @@ ButtonGroup.propTypes = {
   /** Should container only Buttons */
   children: PropTypes.oneOfType([
     PropTypes.element, // just one button for dynamic cases like Form Actions
-    PropTypes.arrayOf(PropTypes.element)
+    PropTypes.array
   ])
 }
 

--- a/src/components/molecules/button-group/index.js
+++ b/src/components/molecules/button-group/index.js
@@ -48,10 +48,7 @@ ButtonGroup.propTypes = {
   /** Make Buttons stick to each other */
   compressed: PropTypes.bool,
   /** Should container only Buttons */
-  children: PropTypes.oneOfType([
-    PropTypes.element, // just one button for dynamic cases like Form Actions
-    PropTypes.array
-  ])
+  children: PropTypes.node
 }
 
 ButtonGroup.defaultProps = {


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/525

Story time

`Form.Actions` uses `ButtonGroup`

`ButtonGroup` likes it's children to be a React element or an array of them

```js
ButtonGroup.propTypes = {
  children: PropTypes.oneOfType([
    PropTypes.element, // just one button for dynamic cases like Form Actions
    PropTypes.arrayOf(PropTypes.element)
  ])
}
```

Bad things happen when we have nothing to render, short version:

```jsx
<ButtonGroup>
	{ props.primaryAction && <Button/> }
	{ props.secondaryActions && <Button/> }
	{ props.destructiveActions && <Button/> }
</ButtonGroup>
```

In some cases, this can result in `children` to be `[React.element, undefined, undefined]` and it throws a warning because `undefined != PropTypes.element`

The ideal fix for me would be to replace undefined with [`React.Fragment`](https://reactjs.org/docs/fragments.html), but that's only available in React 16+

The other solutions are to 
- polyfill fragments
- make the prop type rules more flexible to accept `undefined`

```diff
- PropTypes.arrayOf(PropTypes.element)
+ PropTypes.array
```

I chose the latter.

