### PR TITLE
Reduce redundancy for applying Icon in Button

### DIFF
--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -158,21 +158,18 @@ const getAttributes = props => {
 }
 
 const ButtonContent = props => {
-  let content
-
-  if (props.icon && props.text) {
-    // The button contains both an icon and text.
-    content = [
-      <Icon key="icon" size={16} name={props.icon} color={getAttributes(props).icon} />,
-      <Button.Text key="text">{props.text}</Button.Text>
-    ]
-  } else if (props.icon && !props.text) {
-    // The button contains just an icon.
-    content = <Icon size={16} name={props.icon} color={colors.button.link.icon} />
-  } else {
-    // The button contains just text.
-    content = <Button.Text>{props.text}</Button.Text>
-  }
+  const content = (
+    <Fragment>
+      {props.icon
+         ? <Icon
+             size={16}
+             name={props.icon}
+             color={props.text ? getAttributes(props).icon : colors.button.link.icon} />
+         : null
+      }
+      <Button.Text>{props.text}</Button.Text>
+    </Fragment>
+  )
 
   const Element = props.href ? Button.LinkElement : Button.Element
 

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -160,13 +160,13 @@ const getAttributes = props => {
 const ButtonContent = props => {
   const content = (
     <Fragment>
-      {props.icon
-         ? <Icon
-             size={16}
-             name={props.icon}
-             color={props.text ? getAttributes(props).icon : colors.button.link.icon} />
-         : null
-      }
+      {props.icon ? (
+        <Icon
+          size={16}
+          name={props.icon}
+          color={props.text ? getAttributes(props).icon : colors.button.link.icon}
+        />
+      ) : null}
       <Button.Text>{props.text}</Button.Text>
     </Fragment>
   )

--- a/src/components/atoms/button/index.js
+++ b/src/components/atoms/button/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 


### PR DESCRIPTION
In current code, Icon and Button are being listed two times each. If we need to alter one thing in say the Icon then I need to make changes at two places. This is a pain. My PR intends to fix that