### PR TITLE
Badges

### DIFF
--- a/src/components/atoms/badge/badge.js
+++ b/src/components/atoms/badge/badge.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { colors, fonts } from '../../tokens'
+
+const StyledBadge = styled.span`
+  display: inline-block;
+  vertical-align: middle;
+  font-size: 13px;
+  font-weight: ${fonts.weight.medium};
+  line-height: 1;
+  color: #fff;
+  padding: 4px 8px;
+  background: ${props => colors.status[props.appearance]};
+  border-radius: 21px;
+`
+
+const Badge = props => <StyledBadge {...props}>{props.children}</StyledBadge>
+
+Badge.propTypes = {
+  /** The visual style used to convey the label's purpose */
+  appearance: PropTypes.oneOf(['default', 'information', 'success', 'warning', 'danger'])
+}
+
+Badge.defaultProps = {
+  appearance: 'default'
+}
+
+export default Badge
+export { StyledBadge }

--- a/src/components/atoms/badge/badge.md
+++ b/src/components/atoms/badge/badge.md
@@ -1,0 +1,24 @@
+```meta
+  category: Text
+  description: Displays a numeric indicator
+```
+
+`import { Badge } from '@auth0/cosmos'`
+
+---
+
+```jsx
+<Badge {props}>99</Badge>
+```
+
+You can use the `appearance` prop to indicate the importance of the badge to the user. Here are some examples:
+
+```js
+<Stack>
+  <Badge appearance="default">123</Badge>
+  <Badge appearance="information">99</Badge>
+  <Badge appearance="success">345</Badge>
+  <Badge appearance="warning">6</Badge>
+  <Badge appearance="danger">55</Badge>
+</Stack>
+```

--- a/src/components/atoms/badge/badge.story.js
+++ b/src/components/atoms/badge/badge.story.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
+
+import { Badge } from '@auth0/cosmos'
+
+storiesOf('Badge').add('appearances', () => (
+  <Example title="appearances">
+    <Stack>
+      <Badge appearance="default">123</Badge>
+      <Badge appearance="information">99</Badge>
+      <Badge appearance="success">345</Badge>
+      <Badge appearance="warning">6</Badge>
+      <Badge appearance="danger">55</Badge>
+    </Stack>
+  </Example>
+))
+
+storiesOf('Badge').add('no appearance specified', () => (
+  <Example title="no appearance specified">
+    <Badge>99</Badge>
+  </Example>
+))

--- a/src/components/atoms/badge/index.js
+++ b/src/components/atoms/badge/index.js
@@ -1,0 +1,4 @@
+import Badge, { StyledBadge } from './badge'
+
+export default Badge
+export { StyledBadge }

--- a/src/components/atoms/label/label.js
+++ b/src/components/atoms/label/label.js
@@ -6,9 +6,9 @@ import { colors, misc } from '../../tokens'
 
 const StyledLabel = styled(StyledTextAllCaps)`
   font-size: 11px;
-  color: ${props => colors.label[props.appearance]};
+  color: ${props => colors.status[props.appearance]};
   padding: 2px 8px;
-  border: 1px solid ${props => colors.label[props.appearance]};
+  border: 1px solid ${props => colors.status[props.appearance]};
   border-radius: ${misc.radius};
 `
 

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -15,6 +15,7 @@ import Box from './atoms/_box'
 
 /* atoms */
 import Avatar from './atoms/avatar'
+import Badge from './atoms/badge'
 import Breadcrumb from './atoms/breadcrumb'
 import Button from './atoms/button'
 import Code from './atoms/code'
@@ -54,6 +55,7 @@ import Tabs from './molecules/tabs'
 export {
   Alert,
   Avatar,
+  Badge,
   Box,
   Breadcrumb,
   Button,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,7 @@
 import {
   Alert,
   Avatar,
+  Badge,
   Box,
   Breadcrumb,
   Button,
@@ -39,6 +40,7 @@ import {
 export {
   Alert,
   Avatar,
+  Badge,
   Box,
   Breadcrumb,
   Button,

--- a/src/overview/examples/badges.js
+++ b/src/overview/examples/badges.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import Example from '../ov-components/example'
+import { Badge, Stack } from '@auth0/cosmos'
+
+const Badges = () => (
+  <Example title="Badges">
+    <Stack>
+      <Badge appearance="default">123</Badge>
+      <Badge appearance="information">99</Badge>
+      <Badge appearance="success">345</Badge>
+      <Badge appearance="warning">6</Badge>
+      <Badge appearance="danger">55</Badge>
+    </Stack>
+  </Example>
+)
+
+export default Badges

--- a/src/overview/index.js
+++ b/src/overview/index.js
@@ -5,26 +5,27 @@ import Overview from './ov-components/overview'
 import Container from './ov-components/container'
 import Navigation from './ov-components/navigation'
 
-import Colors from './examples/colors'
-import Spacing from './examples/spacing'
-import Icons from './examples/icons'
-import Forms from './examples/forms'
-import EmptyStates from './examples/empty-states'
-import PageHeaders from './examples/page-headers'
-import Overlays from './examples/overlays'
-import Tooltip from './examples/tooltip'
-import Inputs from './examples/inputs'
-import Typography from './examples/typography'
-import TabsExample from './examples/tabs'
+import Avatars from './examples/avatars'
+import Badges from './examples/badges'
 import Buttons from './examples/buttons'
 import ButtonsInputs from './examples/buttons-inputs'
-import Logos from './examples/logos'
-import Avatars from './examples/avatars'
-import Thumbnails from './examples/thumbnails'
-import Lists from './examples/lists'
-import ResourceLists from './examples/resource-lists'
-import Tables from './examples/tables'
+import Colors from './examples/colors'
+import EmptyStates from './examples/empty-states'
+import Forms from './examples/forms'
+import Icons from './examples/icons'
+import Inputs from './examples/inputs'
 import Labels from './examples/labels'
+import Lists from './examples/lists'
+import Logos from './examples/logos'
+import Overlays from './examples/overlays'
+import PageHeaders from './examples/page-headers'
+import ResourceLists from './examples/resource-lists'
+import Spacing from './examples/spacing'
+import Tables from './examples/tables'
+import TabsExample from './examples/tabs'
+import Thumbnails from './examples/thumbnails'
+import Tooltip from './examples/tooltip'
+import Typography from './examples/typography'
 
 export default () => (
   <Overview>
@@ -71,7 +72,9 @@ export default () => (
         <Col>
           <Labels />
         </Col>
-        <Col />
+        <Col>
+          <Badges />
+        </Col>
       </Row>
       <PageHeaders />
       <TabsExample />

--- a/src/tokens/colors.js
+++ b/src/tokens/colors.js
@@ -180,7 +180,7 @@ const colors = {
     shadow: 'rgba(0,0,0,0.20)',
     shadowDisabled: 'rgba(0,0,0,0.10)'
   },
-  label: {
+  status: {
     default: '#7D7D7D',
     information: '#3BC0F2',
     success: '#73CD1F',


### PR DESCRIPTION
Depends on #544, because I wanted to re-use the colors.

This implements a simple `Badge` component. It's almost identical to `Label`, but should be used for numeric values. (However, the API doesn't restrict this in any way, since it just uses `props.children`.)

![screen shot 2018-05-15 at 11 23 38 am](https://user-images.githubusercontent.com/1576/40066574-6caeb1c8-5832-11e8-8607-b8dc03ca3a1a.png)
