### PR TITLE
Replace method with handler

### DIFF
--- a/src/components/molecules/_action-input/_action-input.js
+++ b/src/components/molecules/_action-input/_action-input.js
@@ -46,7 +46,7 @@ const ActionInput = props => {
               size="small"
               key={index}
               icon={action.icon}
-              onClick={action.method}
+              onClick={action.handler}
               label={action.label}
             />
           ))}
@@ -64,7 +64,7 @@ ActionInput.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-      method: PropTypes.func.isRequired,
+      handler: PropTypes.func.isRequired,
       label: PropTypes.string.isRequired
     })
   )

--- a/src/components/molecules/dialog/dialog-action.js
+++ b/src/components/molecules/dialog/dialog-action.js
@@ -1,7 +1,7 @@
 class DialogAction {
-  constructor(label, method, appearance = 'default') {
+  constructor(label, handler, appearance = 'default') {
     this.label = label
-    this.method = method
+    this.handler = handler
     this.appearance = appearance
   }
 }

--- a/src/components/molecules/dialog/dialog.js
+++ b/src/components/molecules/dialog/dialog.js
@@ -11,7 +11,7 @@ import { colors, fonts, spacing } from '@auth0/cosmos-tokens'
 
 const createButtonForAction = (action, index) => {
   const buttonProps = {
-    onClick: action.method,
+    onClick: action.handler,
     appearance: action.appearance
   }
   return (

--- a/src/components/molecules/empty-state/empty-state.js
+++ b/src/components/molecules/empty-state/empty-state.js
@@ -27,7 +27,7 @@ const EmptyState = props => {
         <Text>{props.text}</Text>
         {helpLink}
       </Body>
-      <Button size="large" appearance="cta" icon={props.action.icon} onClick={props.action.method}>
+      <Button size="large" appearance="cta" icon={props.action.icon} onClick={props.action.handler}>
         {props.action.text}
       </Button>
     </Wrapper>
@@ -77,7 +77,7 @@ EmptyState.displayName = 'EmptyState'
 EmptyState.propTypes = {
   action: PropTypes.shape({
     icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-    method: PropTypes.func.isRequired,
+    handler: PropTypes.func.isRequired,
     text: PropTypes.string.isRequired
   }).isRequired,
   helpUrl: PropTypes.string,

--- a/src/components/molecules/empty-state/empty-state.md
+++ b/src/components/molecules/empty-state/empty-state.md
@@ -12,7 +12,7 @@ Empty states are displayed when a page has no content.
   action={{
     icon: 'plus',
     text: 'Create Client',
-    method: function() { /*...*/ }
+    handler: function() { /*...*/ }
   }}
 />
 ```

--- a/src/components/molecules/empty-state/empty-state.story.js
+++ b/src/components/molecules/empty-state/empty-state.story.js
@@ -14,7 +14,7 @@ storiesOf('EmptyState').add('default', () => (
       action={{
         icon: 'plus',
         text: 'Create Client',
-        method: () => {}
+        handler: () => {}
       }}
     />
   </Example>

--- a/src/components/molecules/form-group/form-group.md
+++ b/src/components/molecules/form-group/form-group.md
@@ -16,14 +16,14 @@ Use a `Form.FieldSet` to add meaningful titles.
       <Form.FieldSet label="iOS Settings">
         <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
       </Form.FieldSet>
-      <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+      <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
     </Form>
 
     <Form>
       <Form.FieldSet label="Android Settings">
         <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
       </Form.FieldSet>
-      <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+      <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
     </Form>
   </FormGroup>
 </div>

--- a/src/components/molecules/form-group/form-group.story.js
+++ b/src/components/molecules/form-group/form-group.story.js
@@ -11,13 +11,13 @@ storiesOf('Form Group').add('default', () => (
         <Form.FieldSet label="iOS Settings">
           <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
         </Form.FieldSet>
-        <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+        <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
       </Form>
       <Form layout="label-on-top">
         <Form.FieldSet label="Android Settings">
           <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
         </Form.FieldSet>
-        <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+        <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
       </Form>
     </FormGroup>
   </Example>

--- a/src/components/molecules/form/actions/actions.js
+++ b/src/components/molecules/form/actions/actions.js
@@ -29,7 +29,7 @@ const Actions = props => {
           <Button
             appearance="primary"
             icon={props.primaryAction.icon}
-            onClick={props.primaryAction.method}
+            onClick={props.primaryAction.handler}
           >
             {props.primaryAction.label}
           </Button>
@@ -38,7 +38,12 @@ const Actions = props => {
         {props.secondaryActions &&
           props.secondaryActions.map((action, index) => {
             return (
-              <Button appearance="secondary" icon={action.icon} key={index} onClick={action.method}>
+              <Button
+                appearance="secondary"
+                icon={action.icon}
+                key={index}
+                onClick={action.handler}
+              >
                 {action.label}
               </Button>
             )
@@ -51,7 +56,7 @@ const Actions = props => {
                 appearance="destructive"
                 icon={action.icon}
                 key={index}
-                onClick={action.method}
+                onClick={action.handler}
               >
                 {action.label}
               </Button>
@@ -69,7 +74,7 @@ Actions.displayName = 'Form Actions'
 const actionShape = {
   label: PropTypes.string.isRequired,
   icon: PropTypes.oneOf(__ICONNAMES__),
-  method: PropTypes.func.isRequired
+  handler: PropTypes.func.isRequired
 }
 
 Actions.propTypes = {

--- a/src/components/molecules/form/actions/actions.md
+++ b/src/components/molecules/form/actions/actions.md
@@ -6,19 +6,19 @@ At the end of the forms, you need actions that the user can take.
 
 ```jsx
 <Form.Actions
-  primaryAction={{ label: 'Save Changes', method: () => {} }}
-  secondaryActions={[{ label: 'Try', icon: 'play', method: () => {} }]}
+  primaryAction={{ label: 'Save Changes', handler: () => {} }}
+  secondaryActions={[{ label: 'Try', icon: 'play', handler: () => {} }]}
 />
 ```
 
 ## Examples
 
-Pass a `primaryAction` with the label and method to call.
+Pass a `primaryAction` with the label and handler to call.
 
 ```js
 <Form>
   <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
-  <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+  <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
 </Form>
 ```
 
@@ -30,10 +30,10 @@ You can also pass an `array` of `secondaryActions`
 <Form>
   <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
   <Form.Actions
-    primaryAction={{ label: 'Save Changes', method: () => {} }}
+    primaryAction={{ label: 'Save Changes', handler: () => {} }}
     secondaryActions={[
-      { label: 'Try', icon: 'play', method: () => {} },
-      { label: 'Debug', method: () => {} }
+      { label: 'Try', icon: 'play', handler: () => {} },
+      { label: 'Debug', handler: () => {} }
     ]}
   />
 </Form>

--- a/src/components/molecules/form/actions/actions.story.js
+++ b/src/components/molecules/form/actions/actions.story.js
@@ -7,7 +7,7 @@ import { Form } from '@auth0/cosmos'
 storiesOf('Form').add('actions: primary', () => (
   <Example title="primary">
     <Form>
-      <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+      <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
     </Form>
   </Example>
 ))
@@ -16,10 +16,10 @@ storiesOf('Form').add('actions: primary + secondary', () => (
   <Example title="primary + secondary">
     <Form>
       <Form.Actions
-        primaryAction={{ label: 'Save Changes', method: () => {} }}
+        primaryAction={{ label: 'Save Changes', handler: () => {} }}
         secondaryActions={[
-          { label: 'Try', icon: 'play', method: () => {} },
-          { label: 'Debug', method: () => {} }
+          { label: 'Try', icon: 'play', handler: () => {} },
+          { label: 'Debug', handler: () => {} }
         ]}
       />
     </Form>

--- a/src/components/molecules/form/field/field.js
+++ b/src/components/molecules/form/field/field.js
@@ -78,7 +78,7 @@ Field.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-      method: PropTypes.func.isRequired
+      handler: PropTypes.func.isRequired
     })
   )
 }

--- a/src/components/molecules/form/field/field.md
+++ b/src/components/molecules/form/field/field.md
@@ -28,7 +28,7 @@ In addition to their own [native props](/docs/TextInput), we add a few more prop
     label="Field label"
     type="text"
     placeholder="Enter something"
-    actions={[{ icon: 'copy', method: () => {}, label: 'Copy to clipboard' }]}
+    actions={[{ icon: 'copy', handler: () => {}, label: 'Copy to clipboard' }]}
   />
   <Form.TextArea label="Long input" placeholder="Add a lot of text here" />
   <Form.Select
@@ -84,7 +84,7 @@ or other rich formatting to displayed text.
 
 ### Actions
 
-You can add actions to a field by passing an array of `{ icon, method }`:
+You can add actions to a field by passing an array of `{ icon, handler }`:
 
 ```js
 <Form>
@@ -93,8 +93,8 @@ You can add actions to a field by passing an array of `{ icon, method }`:
     type="text"
     placeholder="Enter something"
     actions={[
-      { icon: 'copy', label: 'Copy URL', method: e => console.log(e) },
-      { icon: 'delete', label: 'Delete URL', method: e => console.log(e) }
+      { icon: 'copy', label: 'Copy URL', handler: e => console.log(e) },
+      { icon: 'delete', label: 'Delete URL', handler: e => console.log(e) }
     ]}
   />
 </Form>

--- a/src/components/molecules/form/field/stories/text-field.story.js
+++ b/src/components/molecules/form/field/stories/text-field.story.js
@@ -33,8 +33,8 @@ storiesOf('Form').add('text field + actions', () => (
         type="text"
         placeholder="Enter something"
         actions={[
-          { icon: 'copy', method: () => {}, label: 'Copy to clipboard' },
-          { icon: 'delete', method: () => {}, label: 'Delete' }
+          { icon: 'copy', handler: () => {}, label: 'Copy to clipboard' },
+          { icon: 'delete', handler: () => {}, label: 'Delete' }
         ]}
       />
     </Form>

--- a/src/components/molecules/form/form.md
+++ b/src/components/molecules/form/form.md
@@ -15,7 +15,7 @@ Form is a compound component that ships with extra props for elements that take 
     type="text"
     placeholder="Enter something"
   />
-  <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+  <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
 </Form>
 ```
 
@@ -53,7 +53,7 @@ Form is composed of Form Fields, read more about them [here](/docs/Form%20Field)
     <Form.Radio.Option value="html">HTML + Liquid</Form.Radio.Option>
   </Form.Radio>
   </Form.RadioGroup>
-  <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+  <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
 </Form>
 ```
 
@@ -72,7 +72,7 @@ Long forms should be divided into smaller groups using a `Form.FieldSet`. Read t
     <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
     <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
   </Form.FieldSet>
-  <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+  <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
 </Form>
 ```
 
@@ -87,7 +87,7 @@ At the end of the forms, you need actions that the user can take. Read how to ad
 ```js
 <Form>
   <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
-  <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+  <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
 </Form>
 ```
 
@@ -98,6 +98,6 @@ At the end of the forms, you need actions that the user can take. Read how to ad
 ```js
 <Form layout="label-on-top">
   <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
-  <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+  <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
 </Form>
 ```

--- a/src/components/molecules/form/form.story.js
+++ b/src/components/molecules/form/form.story.js
@@ -9,13 +9,13 @@ storiesOf('Form').add('layouts', () => (
     <Example title="label-on-left">
       <Form>
         <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
-        <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+        <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
       </Form>
     </Example>
     <Example title="label-on-top">
       <Form layout="label-on-top">
         <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
-        <Form.Actions primaryAction={{ label: 'Save Changes', method: () => {} }} />
+        <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
       </Form>
     </Example>
   </div>

--- a/src/components/molecules/page-header/page-header.js
+++ b/src/components/molecules/page-header/page-header.js
@@ -34,7 +34,7 @@ const PageHeader = props => {
               size="large"
               appearance="secondary"
               icon={props.secondaryAction.icon}
-              onClick={props.secondaryAction.method}
+              onClick={props.secondaryAction.handler}
             >
               {props.secondaryAction.label}
             </Button>
@@ -43,7 +43,7 @@ const PageHeader = props => {
             size="large"
             appearance="cta"
             icon={props.primaryAction.icon}
-            onClick={props.primaryAction.method}
+            onClick={props.primaryAction.handler}
           >
             {props.primaryAction.label}
           </Button>
@@ -71,7 +71,7 @@ PageHeader.propTypes = {
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-      method: PropTypes.func.isRequired
+      handler: PropTypes.func.isRequired
     })
   )
 }

--- a/src/components/molecules/page-header/page-header.md
+++ b/src/components/molecules/page-header/page-header.md
@@ -15,12 +15,12 @@
   primaryAction={{
     label: 'Create Client',
     icon: 'plus',
-    method: () => {}
+    handler: () => {}
   }}
   secondaryAction={{
     label: 'Tutorial',
     icon: 'play-circle',
-    method: () => {}
+    handler: () => {}
   }}
 />
 ```

--- a/src/components/molecules/page-header/page-header.story.js
+++ b/src/components/molecules/page-header/page-header.story.js
@@ -15,12 +15,12 @@ storiesOf('Page Header').add('default', () => (
       primaryAction={{
         label: 'Create Client',
         icon: 'plus',
-        method: () => {}
+        handler: () => {}
       }}
       secondaryAction={{
         label: 'Tutorial',
         icon: 'play-circle',
-        method: () => {}
+        handler: () => {}
       }}
     />
   </Example>

--- a/src/components/molecules/resource-list/item/item.js
+++ b/src/components/molecules/resource-list/item/item.js
@@ -85,7 +85,7 @@ const ResourceListItem = props => {
           <Button
             key={index}
             icon={action.icon}
-            onClick={handleActionClick(action.method)}
+            onClick={handleActionClick(action.handler)}
             label={action.label}
           />
         ))}
@@ -121,7 +121,7 @@ ResourceListItem.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-      method: PropTypes.func.isRequired,
+      handler: PropTypes.func.isRequired,
       label: PropTypes.string.isRequired
     })
   )

--- a/src/components/molecules/resource-list/item/item.md
+++ b/src/components/molecules/resource-list/item/item.md
@@ -12,8 +12,8 @@ A `ResourceList.Item` is a single item that is displayed in a [ResourceList](/do
   href="https://auth0.com/"
   image={<Icon name="clients" />}
   actions={[
-    { icon: 'settings', label: 'Settings', method: function(){} },
-    { icon: 'delete', label: 'Delete', method: function(){} }
+    { icon: 'settings', label: 'Settings', handler: function(){} },
+    { icon: 'delete', label: 'Delete', handler: function(){} }
   ]} {props} />
 ```
 
@@ -94,8 +94,8 @@ between the header (title, subtitle, etc.) and the actions. This is the main rea
   subtitle="Example Subtitle"
   thumbnail={<Icon name="clients" />}
   actions={[
-    { icon: 'settings', label: 'Settings', method: function() {} },
-    { icon: 'delete', label: 'Delete', method: function() {} }
+    { icon: 'settings', label: 'Settings', handler: function() {} },
+    { icon: 'delete', label: 'Delete', handler: function() {} }
   ]}
 >
   This is the list item's body

--- a/src/components/molecules/resource-list/resource-list.js
+++ b/src/components/molecules/resource-list/resource-list.js
@@ -34,7 +34,7 @@ ResourceList.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-      method: PropTypes.func.isRequired,
+      handler: PropTypes.func.isRequired,
       label: PropTypes.string.isRequired
     })
   ),

--- a/src/components/molecules/resource-list/resource-list.md
+++ b/src/components/molecules/resource-list/resource-list.md
@@ -33,15 +33,15 @@ The only required prop is `items`, which should be a list of items to display.
     }
   ]}
   actions={[
-    { icon: 'settings', method: function() {}, label: 'Settings' },
-    { icon: 'delete', method: function() {}, label: 'Delete' }
+    { icon: 'settings', handler: function() {}, label: 'Settings' },
+    { icon: 'delete', handler: function() {}, label: 'Delete' }
   ]}
 />
 ```
 
 ## Actions
 
-If you pass an array of `actions` to the `ResourceList`, each item in the list will be given the same set of actions. When the user activates one of these actions, the function specified by `method` will be called with the click event and the entry in the `items` array corresponding to the item that was clicked.
+If you pass an array of `actions` to the `ResourceList`, each item in the list will be given the same set of actions. When the user activates one of these actions, the function specified by `handler` will be called with the click event and the entry in the `items` array corresponding to the item that was clicked.
 
 Here's an example of an action handler:
 
@@ -61,12 +61,12 @@ If necessary, you can override the actions for a specific list item by giving th
     {
       title: 'Item 3',
       subtitle: 'Example item',
-      actions: [{ icon: 'settings', method: function() {}, label: 'Settings' }]
+      actions: [{ icon: 'settings', handler: function() {}, label: 'Settings' }]
     }
   ]}
   actions={[
-    { icon: 'settings', method: function() {}, label: 'Settings' },
-    { icon: 'delete', method: function() {}, label: 'Delete' }
+    { icon: 'settings', handler: function() {}, label: 'Settings' },
+    { icon: 'delete', handler: function() {}, label: 'Delete' }
   ]}
 />
 ```
@@ -88,8 +88,8 @@ If you need more control over the rendering of list items, you can pass a `rende
     </ResourceList.Item>
   )}
   actions={[
-    { icon: 'settings', method: function() {}, label: 'Settings' },
-    { icon: 'delete', method: function() {}, label: 'Delete' }
+    { icon: 'settings', handler: function() {}, label: 'Settings' },
+    { icon: 'delete', handler: function() {}, label: 'Delete' }
   ]}
 />
 ```

--- a/src/components/molecules/resource-list/resource-list.story.js
+++ b/src/components/molecules/resource-list/resource-list.story.js
@@ -136,8 +136,8 @@ storiesOf('Resource List').add('actions', () => (
         </ResourceList.Item>
       )}
       actions={[
-        { label: 'Delete', icon: 'delete', method: function() {} },
-        { label: 'Settings', icon: 'settings', method: function() {} }
+        { label: 'Delete', icon: 'delete', handler: function() {} },
+        { label: 'Settings', icon: 'settings', handler: function() {} }
       ]}
     />
   </Example>
@@ -154,7 +154,7 @@ storiesOf('Resource List').add('action overrides', () => (
           subtitle: 'Subtitle Three',
           image: IMAGE_URLS[2],
           id: 'ghi789',
-          actions: [{ label: 'Settings', icon: 'settings', method: function() {} }]
+          actions: [{ label: 'Settings', icon: 'settings', handler: function() {} }]
         }
       ]}
       renderItem={item => (
@@ -163,8 +163,8 @@ storiesOf('Resource List').add('action overrides', () => (
         </ResourceList.Item>
       )}
       actions={[
-        { label: 'Delete', icon: 'delete', method: function() {} },
-        { label: 'Settings', icon: 'settings', method: function() {} }
+        { label: 'Delete', icon: 'delete', handler: function() {} },
+        { label: 'Settings', icon: 'settings', handler: function() {} }
       ]}
     />
   </Example>

--- a/src/docs/spec/prop-switcher.js
+++ b/src/docs/spec/prop-switcher.js
@@ -2,17 +2,17 @@ import React from 'react'
 import { TextInput, Switch, Select } from '@auth0/cosmos'
 
 const PropSwitcher = ({ propName, data, onPropsChange }) => {
-  let method = value => onPropsChange(propName, value.toString())
+  let handler = value => onPropsChange(propName, value.toString())
 
   if (data.type.name === 'bool') {
-    return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={method} />
+    return <Switch accessibleLabels={[]} on={data.value === 'true'} onToggle={handler} />
   } else if (['string', 'number'].includes(data.type.name)) {
     if (data.value === 'null') data.value = ''
-    return <TextInput defaultValue={data.value} onChange={e => method(e.target.value)} />
+    return <TextInput defaultValue={data.value} onChange={e => handler(e.target.value)} />
   } else if (data.type.name === 'enum' && Array.isArray(data.type.value)) {
     const options = data.type.value.map(({ value }) => ({ text: value, value }))
     return (
-      <Select defaultValue={data.value} onChange={e => method(e.target.value)} options={options} />
+      <Select defaultValue={data.value} onChange={e => handler(e.target.value)} options={options} />
     )
   }
   return <div />

--- a/src/manage/components/client-list.js
+++ b/src/manage/components/client-list.js
@@ -35,10 +35,10 @@ const ClientList = props => (
       </ResourceList.Item>
     )}
     actions={[
-      { icon: 'quickstarts', label: 'Quickstart', method: noop },
-      { icon: 'settings', label: 'Settings', method: noop },
-      { icon: 'code', label: 'Addons', method: noop },
-      { icon: 'connections', label: 'Connections', method: noop }
+      { icon: 'quickstarts', label: 'Quickstart', handler: noop },
+      { icon: 'settings', label: 'Settings', handler: noop },
+      { icon: 'code', label: 'Addons', handler: noop },
+      { icon: 'connections', label: 'Connections', handler: noop }
     ]}
   />
 )

--- a/src/manage/pages/apis/index.js
+++ b/src/manage/pages/apis/index.js
@@ -15,7 +15,7 @@ class ApisIndex extends React.Component {
           primaryAction={{
             label: 'Create API',
             icon: 'plus',
-            method: null
+            handler: null
           }}
         />
       </div>

--- a/src/manage/pages/client-detail/advanced.js
+++ b/src/manage/pages/client-detail/advanced.js
@@ -52,7 +52,7 @@ class Advanced extends React.Component {
                 helpText="The SHA256 fingerprints of your app’s signing certificate. You can specify multiple key hashes by comma-separating them or one by line."
               />
             </Form.FieldSet>
-            <Form.Actions primaryAction={{ label: 'Save Changes', method: this.save }} />
+            <Form.Actions primaryAction={{ label: 'Save Changes', handler: this.save }} />
           </Form>
 
           <Form>
@@ -95,7 +95,7 @@ class Advanced extends React.Component {
                 description="Location URL for the page that will be rendered inside an iframe to perform the token verification when third party cookies are not enabled in the browser. Must be in the same domain where the embedded login form is hosted and must have a `https` scheme."
               />
             </Form.FieldSet>
-            <Form.Actions primaryAction={{ label: 'Save Changes', method: this.save }} />
+            <Form.Actions primaryAction={{ label: 'Save Changes', handler: this.save }} />
           </Form>
 
           <Form>
@@ -115,7 +115,7 @@ class Advanced extends React.Component {
                 code
                 readOnly
                 value="L0:O8:R8:E6:MB:I5:P2:S4:U1:ME:D5:OC:L1:O5:RD:E1:SD:T7:D9:C9"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
               <Form.TextInput
                 label="Signing Certificate Fingerprint"
@@ -123,13 +123,13 @@ class Advanced extends React.Component {
                 code
                 readOnly
                 value="L0:O8:R8:E6:MB:I5:P2:S4:U1:ME:D5:OC:L1:O5:RD:E1:SD:T7:D9:C9"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
             </Form.FieldSet>
             <Form.Actions
               primaryAction={{
                 label: 'Download Certificate',
-                method: this.save
+                handler: this.save
               }}
             />
           </Form>
@@ -141,35 +141,35 @@ class Advanced extends React.Component {
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/authorize"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
               <Form.TextInput
                 label="OAuth Token URL"
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/oauth/token"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
               <Form.TextInput
                 label="OAuth User Info URL"
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/userinfo"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
               <Form.TextInput
                 label="OpenID Configuration"
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/.FormGroup-known/openid-configuration"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
               <Form.TextInput
                 label="JSON Web Key Set"
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/.FormGroup-known/jwks.json"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
             </Form.FieldSet>
             <Form.FieldSet label="SAML Endpoints">
@@ -178,14 +178,14 @@ class Advanced extends React.Component {
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/samlp/e4esSP93hcGXiuVAmtzSJfKiojt56QJr"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
               <Form.TextInput
                 label="SAML Metadata URL"
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/samlp/metadata/e4esSP93hcGXiuVAmtzSJfKiojt56QJr"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
             </Form.FieldSet>
             <Form.FieldSet label="WS-Federations">
@@ -194,14 +194,14 @@ class Advanced extends React.Component {
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/wsfed/e4esSP93hcGXiuVAmtzSJfKiojt56QJr/FederationMetadata/2007-06/FederationMetadata.xml"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
               <Form.TextInput
                 label="WsFederation Sign-in URL"
                 type="text"
                 readOnly
                 value="https://mydomain.auth0.com/wsfed/e4esSP93hcGXiuVAmtzSJfKiojt56QJr"
-                actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+                actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
               />
             </Form.FieldSet>
           </Form>

--- a/src/manage/pages/client-detail/settings.js
+++ b/src/manage/pages/client-detail/settings.js
@@ -28,7 +28,7 @@ class Settings extends React.Component {
           type="text"
           readOnly
           defaultValue={this.state.domain}
-          actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+          actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
         />
         <Form.TextInput
           label="Client ID"
@@ -36,7 +36,7 @@ class Settings extends React.Component {
           code
           readOnly
           defaultValue={this.state.clientID}
-          actions={[{ icon: 'copy', method: dummyFn, label: 'Copy to clipboard' }]}
+          actions={[{ icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' }]}
         />
         <Form.TextInput
           label="Client Secret"
@@ -44,8 +44,8 @@ class Settings extends React.Component {
           masked
           defaultValue={this.state.secret}
           actions={[
-            { icon: 'copy', method: dummyFn, label: 'Copy to clipboard' },
-            { icon: 'rotate', method: dummyFn, label: 'Rotate secret' }
+            { icon: 'copy', handler: dummyFn, label: 'Copy to clipboard' },
+            { icon: 'rotate', handler: dummyFn, label: 'Rotate secret' }
           ]}
           helpText="The Client Secret is not base64 encoded."
         />
@@ -74,13 +74,13 @@ class Settings extends React.Component {
         />
 
         <Form.Select
-          label="Token Endpoint Authentication Method"
+          label="Token Endpoint Authentication handler"
           options={[
             { text: 'None', value: 'none' },
             { text: 'Basic', value: 'basic' },
             { text: 'Post', value: 'post', defaultSelected: true }
           ]}
-          helpText="Defines the requested authentication method for the token endpoint. Possible values are 'None' (public client without a client secret), 'Post' (client uses HTTP POST parameters) or 'Basic' (client uses HTTP Basic)."
+          helpText="Defines the requested authentication handler for the token endpoint. Possible values are 'None' (public client without a client secret), 'Post' (client uses HTTP POST parameters) or 'Basic' (client uses HTTP Basic)."
         />
 
         <Form.TextArea
@@ -156,7 +156,7 @@ class Settings extends React.Component {
             to log the user in if they have already logged in before)."
         />
 
-        <Form.Actions primaryAction={{ label: 'Save Changes', method: this.save }} />
+        <Form.Actions primaryAction={{ label: 'Save Changes', handler: this.save }} />
       </Form>
     )
   }

--- a/src/manage/pages/clients/index.js
+++ b/src/manage/pages/clients/index.js
@@ -26,12 +26,12 @@ class ClientIndex extends React.Component {
           primaryAction={{
             label: 'Create Client',
             icon: 'plus',
-            method: this.setDialogOpen(true)
+            handler: this.setDialogOpen(true)
           }}
           secondaryAction={{
             label: 'Tutorial',
             icon: 'play-circle',
-            method: () => {}
+            handler: () => {}
           }}
         />
 

--- a/src/manage/pages/rules/index.js
+++ b/src/manage/pages/rules/index.js
@@ -16,12 +16,12 @@ class RulesIndex extends React.Component {
           primaryAction={{
             label: 'Create Rule',
             icon: 'plus',
-            method: null
+            handler: null
           }}
           secondaryAction={{
             label: 'Tutorial',
             icon: 'play-circle',
-            method: () => {}
+            handler: () => {}
           }}
         />
       </div>

--- a/src/manage/pages/users/index.js
+++ b/src/manage/pages/users/index.js
@@ -16,7 +16,7 @@ class UsersIndex extends React.Component {
           primaryAction={{
             label: 'Create User',
             icon: 'plus',
-            method: null
+            handler: null
           }}
         />
       </div>

--- a/src/overview/examples/empty-states.js
+++ b/src/overview/examples/empty-states.js
@@ -15,7 +15,7 @@ const EmptyStates = () => (
         action={{
           icon: 'plus',
           text: 'Create Client',
-          method: function() {
+          handler: function() {
             /*...*/
           }
         }}

--- a/src/overview/examples/forms.js
+++ b/src/overview/examples/forms.js
@@ -30,8 +30,8 @@ const Forms = () => (
           code
           defaultValue="DUq0xuJZAD7RvezvqCrA6hpJVb6iDUipe"
           actions={[
-            { icon: 'reveal', method: fakeMethod, label: 'Reveal' },
-            { icon: 'copy', method: fakeMethod, label: 'Copy to clipboard' }
+            { icon: 'reveal', handler: fakeMethod, label: 'Reveal' },
+            { icon: 'copy', handler: fakeMethod, label: 'Copy to clipboard' }
           ]}
         />
         <Form.TextInput
@@ -84,8 +84,8 @@ const Forms = () => (
           code
           defaultValue="DUq0xuJZAD7RvezvqCrA6hpJVb6iDUipe"
           actions={[
-            { icon: 'reveal', method: fakeMethod, label: 'Reveal' },
-            { icon: 'copy', method: fakeMethod, label: 'Copy to clipboard' }
+            { icon: 'reveal', handler: fakeMethod, label: 'Reveal' },
+            { icon: 'copy', handler: fakeMethod, label: 'Copy to clipboard' }
           ]}
         />
         <Form.TextInput

--- a/src/overview/examples/page-headers.js
+++ b/src/overview/examples/page-headers.js
@@ -19,12 +19,12 @@ const PageHeaders = () => (
         primaryAction={{
           label: 'Create Client',
           icon: 'plus',
-          method: () => {}
+          handler: () => {}
         }}
         secondaryAction={{
           label: 'Tutorial',
           icon: 'play-circle',
-          method: () => {}
+          handler: () => {}
         }}
       />
     </Example>

--- a/src/overview/examples/resource-lists.js
+++ b/src/overview/examples/resource-lists.js
@@ -42,9 +42,9 @@ const ResourceLists = () => (
           {
             icon: 'settings',
             label: 'Settings',
-            method: clickHandler('Settings')
+            handler: clickHandler('Settings')
           },
-          { icon: 'delete', label: 'Delete', method: clickHandler('Delete') }
+          { icon: 'delete', label: 'Delete', handler: clickHandler('Delete') }
         ]}
       />
     </Example>


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/515

This is a breaking change. Should we support both `handler` and `method` until `1.0.0` or can we get away with it?