### PR TITLE
Add support for left and right positions to Tooltip, code cleanup

### DIFF
--- a/src/components/atoms/tooltip/tooltip.js
+++ b/src/components/atoms/tooltip/tooltip.js
@@ -4,55 +4,93 @@ import PropTypes from 'prop-types'
 
 import { colors, spacing, misc } from '@auth0/cosmos-tokens'
 
+const tooltipStyles = {
+  top: css`
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: ${spacing.xsmall};
+  `,
+  bottom: css`
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: ${spacing.xsmall};
+  `,
+  left: css`
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    margin-right: ${spacing.xsmall};
+  `,
+  right: css`
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    margin-left: ${spacing.xsmall};
+  `
+}
+
+const arrowStyles = {
+  top: css`
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-top-width: 6px;
+    border-bottom-width: 0;
+    border-top-color: ${colors.tooltip.background};
+  `,
+  bottom: css`
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-bottom-width: 6px;
+    border-top-width: 0;
+    border-bottom-color: ${colors.tooltip.background};
+  `,
+  left: css`
+    left: 100%;
+    top: 50%;
+    margin-top: -5px;
+    border-left-width: 6px;
+    border-right-width: 0;
+    border-left-color: ${colors.tooltip.background};
+  `,
+  right: css`
+    right: 100%;
+    top: 50%;
+    margin-top: -5px;
+    border-right-width: 6px;
+    border-left-width: 0;
+    border-right-color: ${colors.tooltip.background};
+  `
+}
+
 const StyledTooltip = styled.div`
+  position: absolute;
   background: ${colors.tooltip.background};
   color: ${colors.tooltip.text};
   border-radius: ${misc.radius};
   width: max-content;
   text-align: center;
-  position: absolute;
   padding: ${spacing.xsmall};
   line-height: normal;
   font-size: 13px;
-  left: 50%;
-  transform: translateX(-50%);
-  margin: ${spacing.xsmall} 0;
   pointer-events: none;
   opacity: ${props => (props.defaultVisible ? 1 : 0)};
-  ${props =>
-    props.position === 'bottom'
-      ? css`
-          top: 100%;
-        `
-      : css`
-          bottom: 100%;
-        `};
+  ${props => tooltipStyles[props.position]};
 
   &:after {
+    position: absolute;
     content: '';
     width: 0;
     height: 0;
-    border-style: solid;
-    left: 50%;
-    position: absolute;
-    margin-left: -5px;
-
-    ${props =>
-      props.position === 'bottom'
-        ? css`
-            border-width: 0 5.5px 6px 5.5px;
-            border-color: transparent transparent ${colors.tooltip.background} transparent;
-            bottom: 100%;
-          `
-        : css`
-            border-width: 6px 5.5px 0 5.5px;
-            border-color: ${colors.tooltip.background} transparent transparent transparent;
-            top: 100%;
-          `};
+    border: 5.5px solid transparent;
+    ${props => arrowStyles[props.position]};
   }
 `
 
-const ContentTooltip = styled.div`
+const TooltipWrapper = styled.div`
   display: inline-block;
   position: relative;
 
@@ -65,10 +103,10 @@ const ContentTooltip = styled.div`
 
 const Tooltip = ({ content, ...props }) => {
   return (
-    <ContentTooltip>
+    <TooltipWrapper>
       <StyledTooltip {...props}>{content}</StyledTooltip>
       {props.children}
-    </ContentTooltip>
+    </TooltipWrapper>
   )
 }
 
@@ -76,7 +114,7 @@ Tooltip.propTypes = {
   /** Content to show in the tooltip */
   content: PropTypes.string.isRequired,
   /** Where to place the tooltip */
-  position: PropTypes.oneOf(['top', 'bottom']),
+  position: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
   /** Visible by default */
   defaultVisible: PropTypes.bool
 }

--- a/src/components/atoms/tooltip/tooltip.md
+++ b/src/components/atoms/tooltip/tooltip.md
@@ -9,20 +9,23 @@ description: Use tooltips for giving extra context AND to make visual cues acces
 <Tooltip defaults={{content: "Here is some text"}} {props}>Hover me</Tooltip>
 ```
 
-## Examples
+## Tooltip Positions
 
-### Tooltip top:
-
-```js
-<Tooltip position="top" content="Copy">
-  <Icon name="copy" />
-</Tooltip>
-```
-
-### Tooltip bottom:
+Tooltips can be attached to any of the four sides of an element using the `position` prop.
 
 ```js
-<Tooltip position="bottom" content="Notifications">
-  <Icon name="notifications" />
-</Tooltip>
+<Stack>
+  <Tooltip position="top" content="Top">
+    <Icon name="copy" />
+  </Tooltip>
+  <Tooltip position="bottom" content="Bottom">
+    <Icon name="copy" />
+  </Tooltip>
+  <Tooltip position="left" content="Left">
+    <Icon name="copy" />
+  </Tooltip>
+  <Tooltip position="right" content="Right">
+    <Icon name="copy" />
+  </Tooltip>
+</Stack>
 ```


### PR DESCRIPTION
This adds support for the `left` and `right` values to the `position` prop of `Tooltip`.

![screen shot 2018-05-31 at 2 51 42 pm](https://user-images.githubusercontent.com/1576/40801931-3841ae38-64e2-11e8-82f3-46554a86c362.png)

We should consider whether we want to change from `defaultVisible` and the `&:hover` class to a `visible` prop to support a controlled version of the component.
