### PR TITLE
Fix radio bugs

### DIFF
--- a/src/components/atoms/radio/radio.js
+++ b/src/components/atoms/radio/radio.js
@@ -108,14 +108,12 @@ const RadioOption = props => (
 const Radio = props => (
   <StyledRadio {...props}>
     {React.Children.map(props.children, child => {
-      if (child.type === RadioOption)
-        return React.cloneElement(child, {
-          name: props.name,
-          checked: props.selected === child.props.value,
-          readOnly: props.readOnly || child.props.readOnly,
-          onChange: props.onChange
-        })
-      return child
+      return React.cloneElement(child, {
+        name: props.name,
+        checked: props.selected === child.props.value,
+        readOnly: props.readOnly || child.props.readOnly,
+        onChange: props.onChange
+      })
     })}
   </StyledRadio>
 )

--- a/src/components/molecules/form/form.md
+++ b/src/components/molecules/form/form.md
@@ -52,7 +52,6 @@ Form is composed of Form Fields, read more about them [here](/docs/Form%20Field)
     <Form.Radio.Option value="React">React</Form.Radio.Option>
     <Form.Radio.Option value="html">HTML + Liquid</Form.Radio.Option>
   </Form.Radio>
-  </Form.RadioGroup>
   <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
 </Form>
 ```


### PR DESCRIPTION
- Fixes https://github.com/auth0/cosmos/issues/580

	`child.type === RadioOption` only works in dev, because `RadioOption` gets compiled to `React.createElement`. This check seems to be a validation on the children and we probably don't need it there. @beneliflo @nkohari can confirm?

- Fixes https://github.com/auth0/cosmos/issues/578

	fixed syntax error