### PR TITLE
Tabs: Add tab controlled state mode

### DIFF
--- a/src/components/molecules/tabs/tabs.js
+++ b/src/components/molecules/tabs/tabs.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
+import makeId from '../../_helpers/uniqueId'
 
 const Wrapper = styled.div``
 
@@ -30,11 +31,24 @@ const TabContent = styled.div`
   padding-top: ${spacing.large};
 `
 
+/* Used to keep selected tab on uncontrolled Tabs instances */
+const tabStore = {}
+
 class Tabs extends React.Component {
   constructor(props) {
     super(props)
     this.tabs = React.Children.toArray(props.children)
     this.state = { selectedIndex: this.getSelectedTabFromChildProps(this.tabs) }
+  }
+
+  componentDidUpdate() {
+    const { cosmosKey } = this.props
+    if (!cosmosKey) return
+
+    const storedIndex = tabStore[cosmosKey]
+    if (storedIndex && storedIndex !== this.state.selectedIndex) {
+      this.setState({ selectedIndex: tabStore[cosmosKey] })
+    }
   }
 
   componentWillReceiveProps(newProps) {
@@ -55,10 +69,16 @@ class Tabs extends React.Component {
 
   changeTab(nextIndex) {
     const currentIndex = this.getSelectedTabFromPropsOrState()
+
     if (currentIndex !== nextIndex) {
       if (this.props.onSelect) {
         this.props.onSelect(nextIndex)
       } else {
+        const { cosmosKey } = this.props
+        if (cosmosKey) {
+          tabStore[cosmosKey] = nextIndex
+        }
+
         this.setState({ selectedIndex: nextIndex })
       }
     }
@@ -110,4 +130,28 @@ Tabs.defaultProps = {
   children: []
 }
 
-export default Tabs
+const generateKey = WrappedComponent =>
+  class Tabs extends React.Component {
+    displayName = `KeyWrapper(${WrappedComponent.displayName})`
+
+    shouldComponentUpdate(nextProps) {
+      const { selected } = this.props
+      if (typeof selected === 'undefined') return false
+
+      return selected !== nextProps.selected
+    }
+
+    render() {
+      const key = makeId('tab')
+      return this.props.selected ? (
+        <WrappedComponent {...this.props} />
+      ) : (
+        <WrappedComponent {...this.props} cosmosKey={key} />
+      )
+    }
+  }
+
+const TabWithKey = generateKey(Tabs)
+TabWithKey.Tab = TabContent
+
+export default TabWithKey

--- a/src/components/molecules/tabs/tabs.js
+++ b/src/components/molecules/tabs/tabs.js
@@ -131,9 +131,7 @@ Tabs.defaultProps = {
 }
 
 const generateKey = WrappedComponent =>
-  class Tabs extends React.Component {
-    displayName = `KeyWrapper(${WrappedComponent.displayName})`
-
+  class KeyWrapper extends React.Component {
     shouldComponentUpdate(nextProps) {
       const { selected } = this.props
       if (typeof selected === 'undefined') return false

--- a/src/components/molecules/tabs/tabs.js
+++ b/src/components/molecules/tabs/tabs.js
@@ -43,6 +43,9 @@ class Tabs extends React.Component {
   }
 
   getSelectedTabFromChildProps(tabs) {
+    const { selected } = this.props
+    if (selected) return selected
+
     for (let index = 0; index < tabs.length; index++) {
       if (tabs[index].props.selected) return index
     }
@@ -50,14 +53,28 @@ class Tabs extends React.Component {
     return 0
   }
 
-  changeTab(index) {
-    if (this.state.selectedIndex !== index) {
-      this.setState({ selectedIndex: index })
+  changeTab(nextIndex) {
+    const currentIndex = this.getSelectedTabFromPropsOrState()
+    if (currentIndex !== nextIndex) {
+      if (this.props.onSelect) {
+        this.props.onSelect(nextIndex)
+      } else {
+        this.setState({ selectedIndex: nextIndex })
+      }
     }
   }
 
+  getSelectedTabFromPropsOrState() {
+    const stateSelectedIndex = this.state.selectedIndex
+    const propsSelectedIndex = this.props.selected
+    const selectedIndex =
+      typeof propsSelectedIndex !== 'undefined' ? propsSelectedIndex : stateSelectedIndex
+
+    return selectedIndex
+  }
+
   render() {
-    const { selectedIndex } = this.state
+    const selectedIndex = this.getSelectedTabFromPropsOrState()
 
     return (
       <Wrapper>
@@ -82,7 +99,11 @@ Tabs.Tab = TabContent
 
 Tabs.propTypes = {
   /** Children should be an array of Tabs.Tab */
-  children: PropTypes.arrayOf(PropTypes.element).isRequired
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  /** Selected should be the index of the desired selected tab */
+  selected: PropTypes.number,
+  /** onSelect will be called with the new index when a new tab is selected by the user */
+  onSelect: PropTypes.func
 }
 
 Tabs.defaultProps = {

--- a/src/components/molecules/tabs/tabs.md
+++ b/src/components/molecules/tabs/tabs.md
@@ -26,3 +26,45 @@ By default, the first tab is selected but you can change this behavior attaching
   </Tabs.Tab>
 </Tabs>
 ```
+
+### Controlled tab state
+
+Sometimes you need to have control on what tab is selected anytime. So you can pass the current selected tab index in the `selected` prop, as well as a callback function in the `onSelect` prop, and Cosmos will notify you when the user tries to change the tab so you can act accordingly.
+
+```jsx
+class TabContainer extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { selected: 0 }
+  }
+
+  handleSelected(selected) {
+    this.setState({ selected })
+  }
+
+  handleInputChange(ev) {
+    const selected = parseInt(ev.target.value)
+    this.setState({ selected })
+  }
+
+  render() {
+    return (
+      <div>
+        <span>
+          Selected tab index:{' '}
+          <input
+            value={this.state.selected}
+            type="number"
+            onChange={ev => this.handleInputChange(ev)}
+          />
+        </span>
+        <Tabs onSelect={nextIndex => this.handleSelected(nextIndex)} selected={this.state.selected}>
+          <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
+          <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
+          <Tabs.Tab label="Tab 3">Third tab's the charm!</Tabs.Tab>
+        </Tabs>
+      </div>
+    )
+  }
+}
+```

--- a/src/components/molecules/tabs/tabs.md
+++ b/src/components/molecules/tabs/tabs.md
@@ -31,7 +31,7 @@ By default, the first tab is selected but you can change this behavior attaching
 
 Sometimes you need to have control on what tab is selected anytime. So you can pass the current selected tab index in the `selected` prop, as well as a callback function in the `onSelect` prop, and Cosmos will notify you when the user tries to change the tab so you can act accordingly.
 
-```jsx
+```js
 class TabContainer extends React.Component {
   constructor(props) {
     super(props)
@@ -61,7 +61,35 @@ class TabContainer extends React.Component {
         <Tabs onSelect={nextIndex => this.handleSelected(nextIndex)} selected={this.state.selected}>
           <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
           <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
-          <Tabs.Tab label="Tab 3">Third tab's the charm!</Tabs.Tab>
+          <Tabs.Tab label="Tab 3">Third tabs the charm!</Tabs.Tab>
+        </Tabs>
+      </div>
+    )
+  }
+}
+```
+
+```js
+class App extends React.Component {
+  constructor() {
+    super()
+    this.state = { enabled: false }
+  }
+  onToggle(enabled) {
+    this.setState({ enabled })
+  }
+  render() {
+    return (
+      <div>
+        Select a tab and then use the switch. Because the state of the component changes, the
+        selected tab is reset
+        <br />
+        <br />
+        <Switch on={this.state.enabled} onToggle={this.onToggle.bind(this)} />
+        <Tabs>
+          <Tabs.Tab label="one">First tab</Tabs.Tab>
+          <Tabs.Tab label="two">Second tab</Tabs.Tab>
+          <Tabs.Tab label="three">Third tab</Tabs.Tab>
         </Tabs>
       </div>
     )

--- a/src/components/molecules/tabs/tabs.md
+++ b/src/components/molecules/tabs/tabs.md
@@ -68,31 +68,3 @@ class TabContainer extends React.Component {
   }
 }
 ```
-
-```js
-class App extends React.Component {
-  constructor() {
-    super()
-    this.state = { enabled: false }
-  }
-  onToggle(enabled) {
-    this.setState({ enabled })
-  }
-  render() {
-    return (
-      <div>
-        Select a tab and then use the switch. Because the state of the component changes, the
-        selected tab is reset
-        <br />
-        <br />
-        <Switch on={this.state.enabled} onToggle={this.onToggle.bind(this)} />
-        <Tabs>
-          <Tabs.Tab label="one">First tab</Tabs.Tab>
-          <Tabs.Tab label="two">Second tab</Tabs.Tab>
-          <Tabs.Tab label="three">Third tab</Tabs.Tab>
-        </Tabs>
-      </div>
-    )
-  }
-}
-```


### PR DESCRIPTION
This PR enables a controlled state mode in `Tab`. It will enable the users to enforce a selected index by passing a `selected` prop and subscribe to tab change intents from the user with the `onSelect` prop.

Resolves #579.