### PR TITLE
Remove sideEffects from package.json

### DIFF
--- a/src/components/package.json
+++ b/src/components/package.json
@@ -4,7 +4,6 @@
   "version": "0.2.3",
   "repository": "auth0/cosmos",
   "main": "index.js",
-  "sideEffects": "false",
   "scripts": {},
   "keywords": [],
   "author": "auth0",


### PR DESCRIPTION
`sideEffects: false` helps webpack 4 to tree shake the output

Right now, we do have side effects in the form of global resets. This means we can't enable tree shaking right away.