### PR TITLE
Page Header: show secondary action when primary is missing.

### DIFF
--- a/src/components/molecules/page-header/page-header.js
+++ b/src/components/molecules/page-header/page-header.js
@@ -27,18 +27,18 @@ const StyledPageHeader = styled.div`
 const PageHeader = props => {
   return (
     <StyledPageHeader>
-      {props.primaryAction && (
-        <ButtonGroup align="right">
-          {props.secondaryAction && (
-            <Button
-              size="large"
-              appearance="secondary"
-              icon={props.secondaryAction.icon}
-              onClick={props.secondaryAction.handler}
-            >
-              {props.secondaryAction.label}
-            </Button>
-          )}
+      <ButtonGroup align="right">
+        {props.secondaryAction && (
+          <Button
+            size="large"
+            appearance="secondary"
+            icon={props.secondaryAction.icon}
+            onClick={props.secondaryAction.handler}
+          >
+            {props.secondaryAction.label}
+          </Button>
+        )}
+        {props.primaryAction && (
           <Button
             size="large"
             appearance="cta"
@@ -47,8 +47,8 @@ const PageHeader = props => {
           >
             {props.primaryAction.label}
           </Button>
-        </ButtonGroup>
-      )}
+        )}
+      </ButtonGroup>
 
       <Heading size={1}>{props.title}</Heading>
 

--- a/src/components/molecules/page-header/page-header.md
+++ b/src/components/molecules/page-header/page-header.md
@@ -25,7 +25,9 @@
 />
 ```
 
-## Single actions
+## Examples
+
+### Single actions
 
 A Page header can have a single primary action:
 
@@ -44,7 +46,7 @@ A Page header can have a single primary action:
 />
 ```
 
-A Page header can have a single secondary action:
+A Page header can also have a single secondary action:
 
 ```js
 <PageHeader

--- a/src/components/molecules/page-header/page-header.md
+++ b/src/components/molecules/page-header/page-header.md
@@ -24,3 +24,33 @@
   }}
 />
 ```
+
+```js
+<PageHeader
+  title="Clients"
+  description={{
+    text: 'Setup a mobile, web or IoT application to use Auth0 for Authentication.',
+    learnMore: '/clients'
+  }}
+  primaryAction={{
+    label: 'Create Client',
+    icon: 'plus',
+    handler: () => {}
+  }}
+/>
+```
+
+```js
+<PageHeader
+  title="Clients"
+  description={{
+    text: 'Setup a mobile, web or IoT application to use Auth0 for Authentication.',
+    learnMore: '/clients'
+  }}
+  secondaryAction={{
+    label: 'Tutorial',
+    icon: 'play-circle',
+    handler: () => {}
+  }}
+/>
+```

--- a/src/components/molecules/page-header/page-header.md
+++ b/src/components/molecules/page-header/page-header.md
@@ -25,6 +25,10 @@
 />
 ```
 
+## Single actions
+
+A Page header can have a single primary action:
+
 ```js
 <PageHeader
   title="Clients"
@@ -39,6 +43,8 @@
   }}
 />
 ```
+
+A Page header can have a single secondary action:
 
 ```js
 <PageHeader

--- a/src/components/molecules/page-header/page-header.story.js
+++ b/src/components/molecules/page-header/page-header.story.js
@@ -25,3 +25,37 @@ storiesOf('Page Header').add('default', () => (
     />
   </Example>
 ))
+
+storiesOf('Page Header').add('only primary action', () => (
+  <Example title="default">
+    <PageHeader
+      title="Clients"
+      description={{
+        text: 'Setup a mobile, web or IoT application to use Auth0 for Authentication.',
+        learnMore: '/clients'
+      }}
+      primaryAction={{
+        label: 'Create Client',
+        icon: 'plus',
+        handler: () => {}
+      }}
+    />
+  </Example>
+))
+
+storiesOf('Page Header').add('only secondary action', () => (
+  <Example title="default">
+    <PageHeader
+      title="Clients"
+      description={{
+        text: 'Setup a mobile, web or IoT application to use Auth0 for Authentication.',
+        learnMore: '/clients'
+      }}
+      secondaryAction={{
+        label: 'Tutorial',
+        icon: 'play-circle',
+        handler: () => {}
+      }}
+    />
+  </Example>
+))


### PR DESCRIPTION
We now display the secondary action even if the primary one is missing.

Added two new stories:
- just renders the primary button in the Page Header to test this use case
- just renders the secondary button in the Page Header to test this use case

Resolves #589 