### PR TITLE
Fix button vertical spacing in Firefox

### DIFF
--- a/src/components/atoms/button/button.js
+++ b/src/components/atoms/button/button.js
@@ -255,7 +255,6 @@ Button.LinkElement = Button.Element.withComponent('a')
 
 Button.Text = styled.span`
   display: inline-block;
-  vertical-align: middle;
 `
 
 Button.propTypes = {


### PR DESCRIPTION
Just removes `vertical-align: middle;` from the button text.
 
![firefox button vertical align](https://user-images.githubusercontent.com/4152942/41117324-17576150-6a63-11e8-9c58-fb39eebf1ba7.gif)
