### PR TITLE
Sandbox: Deploy *.stories.js not *.sketch.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "catchup": "node tooling/catchup.js && yarn install",
     "deploy": "node tooling/publish.js",
     "codemods": "jscodeshift -t src/codemods src/components/",
-    "build:sandbox": "SKETCH=true build-storybook -o build/sandbox",
+    "build:sandbox": "build-storybook -o build/sandbox",
     "sketch":
       "yarn build:sandbox && story2sketch --input=build/sandbox/iframe.html --output=dist/asketch.json && node tooling/cleanup-sketch.js"
   },


### PR DESCRIPTION
I was accidentally deploying *.sketch.js files to `auth0-cosmos.now.sh/sandbox`

This should fix it