### PR TITLE
Align tooltip on button groups.

### DIFF
--- a/src/components/atoms/tooltip/tooltip.js
+++ b/src/components/atoms/tooltip/tooltip.js
@@ -104,7 +104,9 @@ const TooltipWrapper = styled.div`
 const Tooltip = ({ content, ...props }) => {
   return (
     <TooltipWrapper>
-      <StyledTooltip {...props}>{content}</StyledTooltip>
+      <StyledTooltip className="cosmos-tooltip" {...props}>
+        {content}
+      </StyledTooltip>
       {props.children}
     </TooltipWrapper>
   )

--- a/src/components/molecules/button-group/button-group.js
+++ b/src/components/molecules/button-group/button-group.js
@@ -28,13 +28,14 @@ const StyledButtonGroup = styled.div`
   display: flex;
   justify-content: ${props => justifyContent[props.align]};
 
+  // Adjust tooltip offset when used inside button groups
+  & .cosmos-tooltip {
+    left: ${props => (props.align === 'left' ? '40%' : '58%')};
+  }
+
   ${Button.Element} {
     ${props => (props.align === 'left' ? 'margin-right' : 'margin-left')}: ${props =>
       props.compressed ? 0 : spacing.xsmall};
-
-    &: ${props => (props.align === 'left' ? 'last-child' : 'first-child')} {
-      margin: 0;
-    }
   }
 
   ${props => (props.compressed ? groupRadiusStyles : null)};


### PR DESCRIPTION
Temporally disabling last/first child margin reduction until better solution is found.
Resolves #517 

![screen shot 2018-06-15 at 2 20 50 pm](https://user-images.githubusercontent.com/4152942/41482564-5f5bbd9e-70ac-11e8-89b1-55e3ce15664d.png) ![screen shot 2018-06-15 at 2 20 28 pm](https://user-images.githubusercontent.com/4152942/41482565-5f81e6a4-70ac-11e8-9de2-4a79b503eb0b.png)
