### PR TITLE
Add support for TypeScript generation (via @jcenturion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,4 @@ dist
 # ignore generated files
 src/components/meta
 internal/docs/public/main.js
-
 *.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ dist
 # ignore generated files
 src/components/meta
 internal/docs/public/main.js
+
+*.d.ts

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "nps-utils": "1.5.0",
     "prettier": "1.11.1",
     "prettycli": "1.4.3",
+    "proptypes-to-ts-declarations": "^0.8.3",
     "puppeteer": "1.1.1",
     "react-chromatic": "0.7.11",
     "react-docgen": "2.20.1",

--- a/src/components/package.json
+++ b/src/components/package.json
@@ -8,6 +8,7 @@
   "keywords": [],
   "author": "auth0",
   "license": "MIT",
+  "types": "meta/index.d.ts",
   "dependencies": {
     "@auth0/cosmos-tokens": "0.2.4",
     "prop-types": "15.6.1",

--- a/tooling/publish.js
+++ b/tooling/publish.js
@@ -4,6 +4,12 @@ const path = require('path')
 const readPkg = require('read-pkg')
 const { info, warn, error } = require('prettycli')
 const latestVersion = require('latest-version')
+const propTypesToTS = require('proptypes-to-ts-declarations')
+
+const { icons } = require('../src/components/atoms/icon/icons.json')
+const oneOfResolvers = {
+  __ICONNAMES__: Object.keys(icons)
+}
 
 const { version } = readPkg.sync(path.resolve(__dirname, '../package.json'))
 
@@ -13,6 +19,13 @@ latestVersion('@auth0/cosmos').then(publishedVersion => {
     warn(`This version (${version}) is already published.`)
     process.exit(0)
   }
+
+  info('PUBLISH', 'Generating TypeSscript declarations')
+
+  // Generating index.d.ts file
+  propTypesToTS('@auth0/cosmos', './src/components/**/*.js', './src/components/index.d.ts', {
+    oneOfResolvers
+  })
 
   const directories = ['src/tokens', 'src/babel-preset', 'src/components']
 

--- a/tooling/publish.js
+++ b/tooling/publish.js
@@ -4,12 +4,6 @@ const path = require('path')
 const readPkg = require('read-pkg')
 const { info, warn, error } = require('prettycli')
 const latestVersion = require('latest-version')
-const propTypesToTS = require('proptypes-to-ts-declarations')
-
-const { icons } = require('../src/components/atoms/icon/icons.json')
-const oneOfResolvers = {
-  __ICONNAMES__: Object.keys(icons)
-}
 
 const { version } = readPkg.sync(path.resolve(__dirname, '../package.json'))
 
@@ -19,13 +13,6 @@ latestVersion('@auth0/cosmos').then(publishedVersion => {
     warn(`This version (${version}) is already published.`)
     process.exit(0)
   }
-
-  info('PUBLISH', 'Generating TypeSscript declarations')
-
-  // Generating index.d.ts file
-  propTypesToTS('@auth0/cosmos', './src/components/**/*.js', './src/components/index.d.ts', {
-    oneOfResolvers
-  })
 
   const directories = ['src/tokens', 'src/babel-preset', 'src/components']
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8933,7 +8933,7 @@ prettier@1.11.1:
   version "1.11.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 
-prettier@^1.5.3:
+prettier@^1.13.5, prettier@^1.5.3:
   version "1.13.5"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
 
@@ -9032,6 +9032,15 @@ prop-types@15.6.1, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, 
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+proptypes-to-ts-declarations@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/proptypes-to-ts-declarations/-/proptypes-to-ts-declarations-0.8.3.tgz#86d3ea305324de0599243cb37f1f13538f23fdf2"
+  dependencies:
+    glob "^7.1.2"
+    lodash "^4.17.10"
+    prettier "^1.13.5"
+    react-docgen "2.20.1"
 
 proxy-addr@~2.0.3:
   version "2.0.3"


### PR DESCRIPTION
This takes the work done in #628 and moves it to the component metadata build step, so we can consume the TypeScript defs during development and not have to wait until we publish.