### PR TITLE
Fix avatar props in docs issue (via @francocorreasosa)

### DIFF
--- a/internal/docs/spec/prop-string.js
+++ b/internal/docs/spec/prop-string.js
@@ -57,7 +57,7 @@ const getPropString = propData => {
       Example: <Button icon="copy">
     */
 
-    if (propData[name].type.name === 'string') {
+    if (propData[name].type.name === 'string' && propData[name].value.length > 0) {
       propString += ` ${name}="${propData[name].value}"`
       return true
     }
@@ -70,11 +70,10 @@ const getPropString = propData => {
     */
 
     if (propData[name].type.name === 'enum') {
-      /* !isNaN === number */
-      if (!isNaN(propData[name].value)) {
+      if (propData[name].value === 'number') {
         propString += ` ${name}={${propData[name].value}}`
         return true
-      } else if (typeof propData[name].value === 'string') {
+      } else if (typeof propData[name].value === 'string' && propData[name].value.length > 0) {
         propString += ` ${name}="${propData[name].value}"`
         return true
       }


### PR DESCRIPTION
Supercedes #633. Since I did an interactive rebase and squashed the commits from the `avatar-block` branch, it was easier just to cherry-pick the single commit (e1ebff49e2616e8a6f9438bb7b2bf7c861f5e8d6) from the original PR branch.