### PR TITLE
Docs: Make search case insensitive 

### DIFF
--- a/internal/docs/sidebar/index.js
+++ b/internal/docs/sidebar/index.js
@@ -25,7 +25,9 @@ class Sidebar extends React.Component {
   }
   filter(query) {
     /* filter components based on search query */
-    const filteredComponents = components.filter(component => component.displayName.includes(query))
+    const filteredComponents = components.filter(component =>
+      component.displayName.toLowerCase().includes(query.toLowerCase())
+    )
     this.setState({ filteredComponents })
   }
   render() {


### PR DESCRIPTION
Our search was slightly silly.

I could never find `Form` by typing `form`. Fixed that now.

```diff
- component.displayName.includes(query)
+ component.displayName.toLowerCase().includes(query.toLowerCase())
```

