### PR TITLE
Replace input error prop with hasError

### DIFF
--- a/core/components/_helpers/custom-validations.js
+++ b/core/components/_helpers/custom-validations.js
@@ -20,4 +20,10 @@ const numberOfValues = (elements, expectedCount) => {
   }
 }
 
-export { onlyOneOf, sumOfElements, numberOfValues }
+const deprecate = (props, { name, replacement }) => {
+  let message = `'${name}' prop has been deprecated.`
+  if (replacement) message += ` Use '${replacement}' instead.`
+  if (props[name]) return new Error(message)
+}
+
+export { onlyOneOf, sumOfElements, numberOfValues, deprecate }

--- a/core/components/atoms/_styled-input/_styled-input.js
+++ b/core/components/atoms/_styled-input/_styled-input.js
@@ -27,7 +27,7 @@ const config = {
 
 const getAttributes = props => {
   if (props.readOnly) return config.readOnly
-  else if (props.error) return config.error
+  else if (props.hasError || props.error) return config.error
   else return config.basic
 }
 

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import { misc } from '@auth0/cosmos-tokens'
 import { StyledInput } from '../_styled-input'
+import { deprecate } from '../../_helpers/custom-validations'
 
 const TextInput = ({ defaultValue, ...props }) => {
   if (props.masked) {
@@ -24,6 +25,8 @@ TextInput.propTypes = {
   readOnly: PropTypes.bool,
   /** Use when the expected input is code */
   code: PropTypes.bool,
+  /** Pass hasError to show error state */
+  hasError: PropTypes.bool,
   /** Pass error string directly to show error state */
   error: PropTypes.string,
   /** onChange transparently passed to the input */
@@ -31,7 +34,10 @@ TextInput.propTypes = {
   /** Text to display when the input is empty */
   placeholder: PropTypes.string,
   /** The default value for the field */
-  defaultValue: PropTypes.string
+  defaultValue: PropTypes.string,
+
+  /** deprecate error string prop */
+  _error: props => deprecate(props, { name: 'error', replacement: 'hasError' })
 }
 
 TextInput.defaultProps = {

--- a/core/components/atoms/textarea/textarea.js
+++ b/core/components/atoms/textarea/textarea.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { StyledInput } from '../_styled-input'
+import { deprecate } from '../../_helpers/custom-validations'
 
 const StyledTextArea = StyledInput.withComponent('textarea').extend`
   resize: ${props => (props.resizable ? 'vertical' : 'none')};
@@ -22,7 +23,10 @@ TextArea.propTypes = {
   /** Allow resizing of the textarea */
   resizable: PropTypes.bool,
   /** onChange transparently passed to the input */
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+
+  /** deprecate error string prop */
+  _error: props => deprecate(props, { name: 'error', replacement: 'hasError' })
 }
 
 TextArea.defaultProps = {

--- a/core/components/molecules/form/field/field.js
+++ b/core/components/molecules/form/field/field.js
@@ -47,6 +47,7 @@ const ContentLayout = styled.div`
 const Field = props => {
   /* Get unique id for label */
   let id = props.id || uniqueId(props.label)
+  const { error, ...fieldProps } = props
 
   return (
     <FormContext.Consumer>
@@ -56,7 +57,11 @@ const Field = props => {
             <StyledLabel htmlFor={id}>{props.label}</StyledLabel>
           </LabelLayout>
           <ContentLayout layout={context.layout}>
-            {props.fieldComponent ? <props.fieldComponent id={id} {...props} /> : props.children}
+            {props.fieldComponent ? (
+              <props.fieldComponent id={id} hasError={error ? true : false} {...fieldProps} />
+            ) : (
+              props.children
+            )}
             {props.error ? <StyledError>{props.error}</StyledError> : null}
             {props.helpText ? <HelpText>{props.helpText}</HelpText> : null}
           </ContentLayout>

--- a/core/components/molecules/form/field/field.md
+++ b/core/components/molecules/form/field/field.md
@@ -4,11 +4,11 @@
 
 Form Fields are a group of field types supported in `Form`:
 
-* `Form.TextInput`
-* `Form.TextArea`
-* `Form.Select`
-* `Form.Switch`
-* `Form.Radio`
+- `Form.TextInput`
+- `Form.TextArea`
+- `Form.Select`
+- `Form.Switch`
+- `Form.Radio`
 
 If you need something we don't have, you can use a custom component with `Form.Field`
 
@@ -127,7 +127,7 @@ All the props are passed on to the custom component, so you can set the id, erro
 <Form>
   <Form.Field label="Height" helpText="How tall are you?" error="Show only in the first field">
     <Stack>
-      <TextInput placeholder="Value" error="Show only in the first field" />
+      <TextInput placeholder="Value" hasError />
       <Select options={[{ text: 'centimetres', value: 'cm' }, { text: 'inches', value: 'in' }]} />
       <Button appearance="link" icon="copy" label="Copy value" onClick={e => console.log(e)} />
     </Stack>


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/680

Components that use `_styled-input` (`TextInput`, `TextArea`, etc.) now accept a new prop: 
`hasError: Proptypes.bool`


They continue to support `error: Proptypes.string` as well but throw a validation warning 
_'error' prop has been deprecated. Use 'hasError' instead_

The intention is to do a smooth deprecation by supporting both for a while. I've also added a new `deprecate` helper in [custom-validations](https://github.com/auth0/cosmos/blob/master/core/components/_helpers/custom-validations.js)
