### PR TITLE
Form inside Dialog

### DIFF
--- a/core/components/molecules/dialog/dialog-action.js
+++ b/core/components/molecules/dialog/dialog-action.js
@@ -1,9 +1,0 @@
-class DialogAction {
-  constructor(label, handler, appearance = 'default') {
-    this.label = label
-    this.handler = handler
-    this.appearance = appearance
-  }
-}
-
-export default DialogAction

--- a/core/components/molecules/dialog/dialog.js
+++ b/core/components/molecules/dialog/dialog.js
@@ -1,36 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import Button from '../../atoms/button'
-import ButtonGroup from '../../molecules/button-group'
+
 import Overlay from '../../atoms/_overlay'
 import Icon from '../../atoms/icon'
 import Link from '../../atoms/link'
-import DialogAction from './dialog-action'
+import DialogFooter from './footer'
 import { colors, fonts, spacing } from '@auth0/cosmos-tokens'
-
-const createButtonForAction = (action, index) => {
-  // As we also support passing raw <Button> components
-  // as actions, we only need to create buttons for actions
-  // when the action is instance of DialogAction.
-  if (!(action instanceof DialogAction)) {
-    if (action.displayName !== Button.displayName) {
-      throw new Error('Invalid action component passed to Dialog.')
-    }
-
-    return action
-  }
-
-  const buttonProps = {
-    onClick: action.handler,
-    appearance: action.appearance
-  }
-  return (
-    <Button key={index} {...buttonProps}>
-      {action.label}
-    </Button>
-  )
-}
 
 const Dialog = props => (
   <Overlay {...props}>
@@ -41,10 +17,7 @@ const Dialog = props => (
           <Icon name="close" size={16} />
         </Link>
       </DialogTitleBar>
-      <DialogBody>{props.children}</DialogBody>
-      <DialogFooter>
-        <ButtonGroup>{props.actions.map(createButtonForAction)}</ButtonGroup>
-      </DialogFooter>
+      {props.children}
     </DialogElement>
   </Overlay>
 )
@@ -80,20 +53,11 @@ const DialogBody = styled.div`
   padding: ${spacing.medium} ${spacing.large};
 `
 
-const DialogFooter = styled.div`
-  display: flex;
-  justify-content: center;
-  padding: ${spacing.small};
-  border-top: 1px solid ${colors.base.grayLight};
-`
-
-Dialog.Action = DialogAction
+Dialog.Body = DialogBody
 Dialog.Element = DialogElement
+Dialog.Footer = DialogFooter
 
 Dialog.propTypes = {
-  actions: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.instanceOf(DialogAction), PropTypes.element])
-  ).isRequired,
   title: PropTypes.string.isRequired,
   width: PropTypes.number,
   onClose: PropTypes.func

--- a/core/components/molecules/dialog/dialog.js
+++ b/core/components/molecules/dialog/dialog.js
@@ -10,7 +10,7 @@ import { colors, fonts, spacing } from '@auth0/cosmos-tokens'
 
 const Dialog = props => (
   <Overlay {...props}>
-    <DialogElement width={props.width}>
+    <DialogElement width={props.size === 'large' ? 750 : 500}>
       <DialogTitleBar>
         <span>{props.title}</span>
         <Link onClick={props.onClose}>
@@ -59,12 +59,12 @@ Dialog.Footer = DialogFooter
 
 Dialog.propTypes = {
   title: PropTypes.string.isRequired,
-  width: PropTypes.number,
+  size: PropTypes.oneOf(['default', 'large']),
   onClose: PropTypes.func
 }
 
 Dialog.defaultProps = {
-  width: 500
+  size: 'default'
 }
 
 export default Dialog

--- a/core/components/molecules/dialog/dialog.md
+++ b/core/components/molecules/dialog/dialog.md
@@ -26,20 +26,19 @@ class DialogContainer extends React.Component {
           open={this.state.open}
           title="Example Dialog"
           onClose={() => this.setDialogState(false)}
-          actions={[
-            new Dialog.Action(
-              'OK',
-              () => {
-                alert("You've performed the 'OK' action.")
-              },
-              'primary'
-            ),
-            new Dialog.Action('Cancel', () => {
-              alert("You've performed the 'Cancel' action.")
-            })
-          ]}
         >
-          Are you sure?
+          <Dialog.Body>Are you sure?</Dialog.Body>
+          <Dialog.Footer>
+            <Button appearance="primary" onClick={() => alert("You've performed the 'OK' action.")}>
+              OK
+            </Button>
+            <Button
+              appearance="secondary"
+              onClick={() => alert("You've performed the 'Cancel' action.")}
+            >
+              Cancel
+            </Button>
+          </Dialog.Footer>
         </Dialog>
       </div>
     )
@@ -47,9 +46,9 @@ class DialogContainer extends React.Component {
 }
 ```
 
-## Passing buttons as actions
+## Form inside Dialog
 
-You can use pass a `<Button />` array as actions to a Dialog.
+You can choose not to render `Dialog.Footer` if the body has a component with actions. Use the `width` prop to modify the size of the dialog
 
 ```js
 class DialogContainer extends React.Component {
@@ -69,13 +68,32 @@ class DialogContainer extends React.Component {
         <Dialog
           open={this.state.open}
           title="Example Dialog"
+          width={750}
           onClose={() => this.setDialogState(false)}
-          actions={[
-            <Button appearance="primary">OK</Button>,
-            <Button appearance="secondary">Cancel</Button>
-          ]}
         >
-          Are you sure?
+          <Dialog.Body>
+            <Form>
+              <Form.TextInput
+                label="Application Name"
+                type="text"
+                placeholder="What's your application called?"
+              />
+              <Form.Select
+                label="Application Type"
+                options={[
+                  { text: 'Native', value: 'native', defaultSelected: true },
+                  { text: 'Non Interactive Application', value: 'non-interactive' },
+                  { text: 'Regular Web Application', value: 'regular' },
+                  { text: 'Single Page Application', value: 'spa' }
+                ]}
+                helpText="The type of application will determine which settings you can configure from the dashboard."
+              />
+              <Form.Actions
+                primaryAction={{ label: 'Save Changes', handler: () => {} }}
+                secondaryActions={[{ label: 'Cancel', handler: () => {} }]}
+              />
+            </Form>
+          </Dialog.Body>
         </Dialog>
       </div>
     )

--- a/core/components/molecules/dialog/dialog.md
+++ b/core/components/molecules/dialog/dialog.md
@@ -48,7 +48,7 @@ class DialogContainer extends React.Component {
 
 ## Form inside Dialog
 
-You can choose not to render `Dialog.Footer` if the body has a component with actions. Use the `width` prop to modify the size of the dialog
+You can use add actions inside `Dialog.Footer` for the form. Use the `size` prop to get a wider dialog.
 
 ```js
 class DialogContainer extends React.Component {
@@ -61,6 +61,8 @@ class DialogContainer extends React.Component {
     this.setState({ open })
   }
 
+  save() {}
+
   render() {
     return (
       <div>
@@ -68,7 +70,7 @@ class DialogContainer extends React.Component {
         <Dialog
           open={this.state.open}
           title="Example Dialog"
-          width={750}
+          size="large"
           onClose={() => this.setDialogState(false)}
         >
           <Dialog.Body>
@@ -88,12 +90,14 @@ class DialogContainer extends React.Component {
                 ]}
                 helpText="The type of application will determine which settings you can configure from the dashboard."
               />
-              <Form.Actions
-                primaryAction={{ label: 'Save Changes', handler: () => {} }}
-                secondaryActions={[{ label: 'Cancel', handler: () => {} }]}
-              />
             </Form>
           </Dialog.Body>
+          <Dialog.Footer>
+            <Button appearance="primary" onClick={() => this.save}>
+              Save Changes
+            </Button>
+            <Button onClick={() => this.setDialogState(false)}>Cancel</Button>
+          </Dialog.Footer>
         </Dialog>
       </div>
     )

--- a/core/components/molecules/dialog/dialog.md
+++ b/core/components/molecules/dialog/dialog.md
@@ -92,10 +92,10 @@ class DialogContainer extends React.Component {
               />
             </Dialog.Body>
             <Dialog.Footer>
-              <Button appearance="primary" onClick={() => this.save}>
-                Save Changes
-              </Button>
-              <Button onClick={() => this.setDialogState(false)}>Cancel</Button>
+              <Form.Actions
+                primaryAction={{ label: 'Save Changes', handler: () => {} }}
+                secondaryActions={[{ label: 'Cancel', handler: () => {} }]}
+              />
             </Dialog.Footer>
           </Form>
         </Dialog>

--- a/core/components/molecules/dialog/dialog.md
+++ b/core/components/molecules/dialog/dialog.md
@@ -73,8 +73,8 @@ class DialogContainer extends React.Component {
           size="large"
           onClose={() => this.setDialogState(false)}
         >
-          <Dialog.Body>
-            <Form>
+          <Form>
+            <Dialog.Body>
               <Form.TextInput
                 label="Application Name"
                 type="text"
@@ -90,14 +90,14 @@ class DialogContainer extends React.Component {
                 ]}
                 helpText="The type of application will determine which settings you can configure from the dashboard."
               />
-            </Form>
-          </Dialog.Body>
-          <Dialog.Footer>
-            <Button appearance="primary" onClick={() => this.save}>
-              Save Changes
-            </Button>
-            <Button onClick={() => this.setDialogState(false)}>Cancel</Button>
-          </Dialog.Footer>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button appearance="primary" onClick={() => this.save}>
+                Save Changes
+              </Button>
+              <Button onClick={() => this.setDialogState(false)}>Cancel</Button>
+            </Dialog.Footer>
+          </Form>
         </Dialog>
       </div>
     )

--- a/core/components/molecules/dialog/dialog.sketch.js
+++ b/core/components/molecules/dialog/dialog.sketch.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Dialog } from '@auth0/cosmos'
+import { Dialog, Button } from '@auth0/cosmos'
 
 /* how do we pass open to the underlying overlay here? */
 storiesOf('Dialog', module).add('default', () => (

--- a/core/components/molecules/dialog/dialog.sketch.js
+++ b/core/components/molecules/dialog/dialog.sketch.js
@@ -5,11 +5,11 @@ import { Dialog } from '@auth0/cosmos'
 
 /* how do we pass open to the underlying overlay here? */
 storiesOf('Dialog', module).add('default', () => (
-  <Dialog
-    title="Example Dialog"
-    onClose={() => {}}
-    actions={[new Dialog.Action('OK', () => {}, 'primary'), new Dialog.Action('Cancel', () => {})]}
-  >
-    Are you sure?
+  <Dialog title="Example Dialog" onClose={() => {}}>
+    <Dialog.Body>Are you sure?</Dialog.Body>
+    <Dialog.Footer>
+      <Button appearance="primary">OK</Button>
+      <Button appearance="secondary">Cancel</Button>
+    </Dialog.Footer>
   </Dialog>
 ))

--- a/core/components/molecules/dialog/dialog.story.js
+++ b/core/components/molecules/dialog/dialog.story.js
@@ -10,89 +10,75 @@ const StyledExample = styled(Example)`
 
 storiesOf('Dialog').add('default', () => (
   <StyledExample title="default">
-    <Dialog
-      open
-      title="Example Dialog"
-      onClose={() => {}}
-      actions={[
-        new Dialog.Action('OK', () => {}, 'primary'),
-        new Dialog.Action('Cancel', () => {})
-      ]}
-    >
-      Are you sure?
+    <Dialog open title="Example Dialog" onClose={() => {}}>
+      <Dialog.Body>Are you sure?</Dialog.Body>
+      <Dialog.Footer>
+        <Button appearance="primary">OK</Button>
+        <Button>Cancel</Button>
+      </Dialog.Footer>
     </Dialog>
   </StyledExample>
 ))
 
 storiesOf('Dialog').add('with primary button only', () => (
   <StyledExample title="with primary button only">
-    <Dialog
-      open
-      title="Example Dialog"
-      onClose={() => {}}
-      actions={[new Dialog.Action('OK', () => {}, 'primary')]}
-    >
-      Are you sure?
+    <Dialog open title="Example Dialog" onClose={() => {}}>
+      <Dialog.Body>Are you sure?</Dialog.Body>
+      <Dialog.Footer>
+        <Button appearance="primary">OK</Button>
+      </Dialog.Footer>
     </Dialog>
   </StyledExample>
 ))
 
 storiesOf('Dialog').add('with secondary button only', () => (
   <StyledExample title="with secondary button only">
-    <Dialog
-      open
-      title="Example Dialog"
-      onClose={() => {}}
-      actions={[new Dialog.Action('Dismiss', () => {})]}
-    >
-      Are you sure?
+    <Dialog open title="Example Dialog" onClose={() => {}}>
+      <Dialog.Body>Are you sure?</Dialog.Body>
+      <Dialog.Footer>
+        <Button>Dismiss</Button>
+      </Dialog.Footer>
     </Dialog>
   </StyledExample>
 ))
 
 storiesOf('Dialog').add('with form', () => (
   <StyledExample title="with form">
-    <Dialog
-      open
-      title="Example Dialog"
-      onClose={() => {}}
-      actions={[
-        new Dialog.Action('OK', () => {}, 'primary'),
-        new Dialog.Action('Cancel', () => {})
-      ]}
-      width={600}
-    >
-      <Form layout="label-on-top">
-        <Form.TextInput label="First Name" type="text" placeholder="John" />
-        <Form.TextInput label="Last Name" type="text" placeholder="Doe" />
-        <Form.TextInput label="Email Address" type="text" placeholder="john.doe@auth0.com" />
-      </Form>
+    <Dialog open title="Example Dialog" onClose={() => {}} width={600}>
+      <Dialog.Body>
+        <Form layout="label-on-top">
+          <Form.TextInput label="First Name" type="text" placeholder="John" />
+          <Form.TextInput label="Last Name" type="text" placeholder="Doe" />
+          <Form.TextInput label="Email Address" type="text" placeholder="john.doe@auth0.com" />
+        </Form>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Button appearance="primary">OK</Button>
+        <Button>Cancel</Button>
+      </Dialog.Footer>
     </Dialog>
   </StyledExample>
 ))
 
 storiesOf('Dialog').add('with introduction + form', () => (
   <StyledExample title="with introduction + form">
-    <Dialog
-      open
-      title="Example Dialog"
-      onClose={() => {}}
-      actions={[
-        new Dialog.Action('OK', () => {}, 'primary'),
-        new Dialog.Action('Cancel', () => {})
-      ]}
-      width={600}
-    >
-      <p>
-        This is a brief introduction to the form. This is a short text that goes before the form
-        starts and may include <a href="#">links to other sites</a> and/or <strong>bold</strong>{' '}
-        text.
-      </p>
+    <Dialog open title="Example Dialog" onClose={() => {}} width={600}>
+      <Dialog.Body>
+        <p>
+          This is a brief introduction to the form. This is a short text that goes before the form
+          starts and may include <a href="#">links to other sites</a> and/or <strong>bold</strong>{' '}
+          text.
+        </p>
+      </Dialog.Body>
       <Form layout="label-on-top">
         <Form.TextInput label="First Name" type="text" placeholder="John" />
         <Form.TextInput label="Last Name" type="text" placeholder="Doe" />
         <Form.TextInput label="Email Address" type="text" placeholder="john.doe@auth0.com" />
       </Form>
+      <Dialog.Footer>
+        <Button appearance="primary">OK</Button>
+        <Button>Cancel</Button>
+      </Dialog.Footer>
     </Dialog>
   </StyledExample>
 ))

--- a/core/components/molecules/dialog/dialog.story.js
+++ b/core/components/molecules/dialog/dialog.story.js
@@ -44,7 +44,7 @@ storiesOf('Dialog').add('with secondary button only', () => (
 
 storiesOf('Dialog').add('with form', () => (
   <StyledExample title="with form">
-    <Dialog open title="Example Dialog" onClose={() => {}} width={600}>
+    <Dialog open title="Example Dialog" onClose={() => {}} size="large">
       <Dialog.Body>
         <Form layout="label-on-top">
           <Form.TextInput label="First Name" type="text" placeholder="John" />
@@ -62,7 +62,7 @@ storiesOf('Dialog').add('with form', () => (
 
 storiesOf('Dialog').add('with introduction + form', () => (
   <StyledExample title="with introduction + form">
-    <Dialog open title="Example Dialog" onClose={() => {}} width={600}>
+    <Dialog open title="Example Dialog" onClose={() => {}} size="large">
       <Dialog.Body>
         <p>
           This is a brief introduction to the form. This is a short text that goes before the form

--- a/core/components/molecules/dialog/dialog.story.js
+++ b/core/components/molecules/dialog/dialog.story.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
-import { Dialog, Form } from '@auth0/cosmos'
+import { Dialog, Button, Form } from '@auth0/cosmos'
 
 const StyledExample = styled(Example)`
   min-height: 800px;
@@ -69,12 +69,12 @@ storiesOf('Dialog').add('with introduction + form', () => (
           starts and may include <a href="#">links to other sites</a> and/or <strong>bold</strong>{' '}
           text.
         </p>
+        <Form layout="label-on-top">
+          <Form.TextInput label="First Name" type="text" placeholder="John" />
+          <Form.TextInput label="Last Name" type="text" placeholder="Doe" />
+          <Form.TextInput label="Email Address" type="text" placeholder="john.doe@auth0.com" />
+        </Form>
       </Dialog.Body>
-      <Form layout="label-on-top">
-        <Form.TextInput label="First Name" type="text" placeholder="John" />
-        <Form.TextInput label="Last Name" type="text" placeholder="Doe" />
-        <Form.TextInput label="Email Address" type="text" placeholder="john.doe@auth0.com" />
-      </Form>
       <Dialog.Footer>
         <Button appearance="primary">OK</Button>
         <Button>Cancel</Button>

--- a/core/components/molecules/dialog/footer.js
+++ b/core/components/molecules/dialog/footer.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { colors, spacing } from '@auth0/cosmos-tokens'
+import { ButtonGroup } from '@auth0/cosmos'
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: ${spacing.small};
+  border-top: 1px solid ${colors.base.grayLight};
+`
+
+const DialogFooter = props => {
+  return (
+    <Container>
+      <ButtonGroup>{props.children}</ButtonGroup>
+    </Container>
+  )
+}
+
+export default DialogFooter

--- a/core/components/molecules/dialog/footer.js
+++ b/core/components/molecules/dialog/footer.js
@@ -7,7 +7,7 @@ import { ButtonGroup } from '@auth0/cosmos'
 const Container = styled.div`
   display: flex;
   justify-content: center;
-  padding: ${spacing.small};
+  padding: ${spacing.small} 0;
   border-top: 1px solid ${colors.base.grayLight};
 `
 


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/682

Not sure if I'm going in the right direction, could use some advice @nkohari @francocorreasosa 

Here's what a `Form` inside a `Dialog` looks like:

<img width="849" alt="screen shot 2018-07-19 at 4 33 19 pm" src="https://user-images.githubusercontent.com/1863771/42938901-7dda98be-8b71-11e8-9e26-b3510297b46b.png">

Changes made: I've pulled out `Body` and `Footer` to make the `Dialog` more composable:

```jsx
<Dialog open={this.state.open} title="Example Dialog" onClose={() => this.setDialogState(false)}>

  <Dialog.Body>Are you sure?</Dialog.Body>

  <Dialog.Footer>
    <Button appearance="primary" onClick={ () => {} }>OK</Button>
    <Button appearance="secondary" onClick={ () => {} }>Cancel</Button>
  </Dialog.Footer>

</Dialog>
```

- No changes in chromatic previews 👌

- This also makes passing `Button`s the default way of composing actions, deprecating the `actions` prop.

- To make the form fit nicely inside, I passed the `width` prop with value `750`. We should probably have a way of converting this into a prop?

@landitus Should we have 2 sizes for the dialog? `default` and `wide`? `<Dialog size="wide">`?

_I thought about building `FormDialog` which has locks in `width={750}` and `actions=[]` inside it, but the wide form will be useful for other content as well like tables, videos, etc._

TODO:
- [ ] Update manage PoC
- [ ] Properly deprecate `actions` and `width` props

Bigger question here:

It feels we are converting every strictly built component with a `shape` type prop to a component that's more composable by exposing it's children.

Every time we do that, we are letting go of some _design decisions baked in_. This will mean people can use it in ways we don't want them to.

Should we be worried about this?