### PR TITLE
Better class names for debugging

### DIFF
--- a/core/babel-preset/index.js
+++ b/core/babel-preset/index.js
@@ -5,5 +5,5 @@
 
 module.exports = {
   presets: ['env', 'react', 'es2015'],
-  plugins: ['transform-object-rest-spread', 'transform-class-properties']
+  plugins: ['styled-components', 'transform-object-rest-spread', 'transform-class-properties']
 }

--- a/core/babel-preset/package.json
+++ b/core/babel-preset/package.json
@@ -7,6 +7,7 @@
   "author": "siddharthkp",
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-styled-components": "1.5.1",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-preset-es2015": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,12 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.42"
 
+"@babel/helper-annotate-as-pure@^7.0.0-beta.37":
+  version "7.0.0-beta.54"
+  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.54.tgz#1626126a3f9fc4ed280ac942372c7d39653d7121"
+  dependencies:
+    "@babel/types" "7.0.0-beta.54"
+
 "@babel/helper-module-imports@7.0.0-beta.40":
   version "7.0.0-beta.40"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.40.tgz#251cbb6404599282e8f7356a5b32c9381bef5d2d"
@@ -29,6 +35,14 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.54.tgz#025ad68492fed542c13f14c579a44c848e531063"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
 "@emotion/babel-utils@^0.6.4":
@@ -1196,6 +1210,14 @@ babel-plugin-react-docgen@^2.0.0-rc.1:
     babel-types "^6.26.0"
     lodash "^4.17.10"
     react-docgen "^3.0.0-beta12"
+
+babel-plugin-styled-components@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.5.1.tgz#31dbeb696d1354d1585e60d66c7905f5e474afcd"
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0-beta.37"
+    babel-types "^6.26.0"
+    stylis "^3.0.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -8404,6 +8426,10 @@ stylis-rule-sheet@^0.0.10:
 stylis-rule-sheet@^0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.7.tgz#5c51dc879141a61821c2094ba91d2cbcf2469c6c"
+
+stylis@^3.0.0:
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
 
 stylis@^3.4.0, stylis@^3.5.0:
   version "3.5.1"


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/166

_This changes ALL the class names and hence all the chromatic snapshots need approval_

Converts

```html
<button class="sc-dnqmqq jTtzor" icon="apis">
  <i class="sc-bwzfXH fRCcvq">
    <svg class="sc-htpNat WAuWX"></svg>
  </i>
  <span class="sc-gZMcBi gZDevs">Button</span>
</button>
```

to

```html
<button class="button__Element-kXFKBl eJZKsk" icon="apis">
  <i class="icon__Element-hNoGcs fCXlyr">
    <svg class="icon__Image-HcNJc ecgQOf"></svg>
  </i>
  <span class="button__Text-csEsbi eoVnij">Button</span>
</button>
```