### PR TITLE
Form actions pass props through

### DIFF
--- a/core/components/_helpers/action-shape.js
+++ b/core/components/_helpers/action-shape.js
@@ -6,15 +6,13 @@ const shapeForDocs = { label: 'string', icon: 'enum', handler: 'func' }
 const actionShape = PropTypes.shape({
   label: PropTypes.string.isRequired,
   icon: PropTypes.oneOf(__ICONNAMES__),
-  handler: PropTypes.func.isRequired,
-  props: PropTypes.object
+  handler: PropTypes.func.isRequired
 })
 
 const actionShapeWithRequiredIcon = PropTypes.shape({
   label: PropTypes.string.isRequired,
   icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-  handler: PropTypes.func.isRequired,
-  props: PropTypes.object
+  handler: PropTypes.func.isRequired
 })
 
 export { actionShape, actionShapeWithRequiredIcon, shapeForDocs }

--- a/core/components/_helpers/action-shape.js
+++ b/core/components/_helpers/action-shape.js
@@ -6,13 +6,15 @@ const shapeForDocs = { label: 'string', icon: 'enum', handler: 'func' }
 const actionShape = PropTypes.shape({
   label: PropTypes.string.isRequired,
   icon: PropTypes.oneOf(__ICONNAMES__),
-  handler: PropTypes.func.isRequired
+  handler: PropTypes.func.isRequired,
+  props: PropTypes.object
 })
 
 const actionShapeWithRequiredIcon = PropTypes.shape({
   label: PropTypes.string.isRequired,
   icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
-  handler: PropTypes.func.isRequired
+  handler: PropTypes.func.isRequired,
+  props: PropTypes.object
 })
 
 export { actionShape, actionShapeWithRequiredIcon, shapeForDocs }

--- a/core/components/molecules/form/actions/actions.js
+++ b/core/components/molecules/form/actions/actions.js
@@ -30,10 +30,10 @@ const Actions = props => {
           <ButtonGroup>
             {primaryAction && (
               <Button
+                {...primaryAction.props}
                 appearance="primary"
                 icon={primaryAction.icon}
                 onClick={primaryAction.handler}
-                {...primaryAction.props}
               >
                 {primaryAction.label}
               </Button>
@@ -42,6 +42,7 @@ const Actions = props => {
             {secondaryActions &&
               secondaryActions.map((action, index) => (
                 <Button
+                  {...action.props}
                   appearance="secondary"
                   icon={action.icon}
                   key={index}
@@ -54,6 +55,7 @@ const Actions = props => {
             {destructiveAction && (
               <Right>
                 <Button
+                  {...destructiveAction.props}
                   appearance="destructive"
                   icon={destructiveAction.icon}
                   onClick={destructiveAction.handler}

--- a/core/components/molecules/form/actions/actions.js
+++ b/core/components/molecules/form/actions/actions.js
@@ -30,7 +30,7 @@ const Actions = props => {
           <ButtonGroup>
             {primaryAction && (
               <Button
-                {...primaryAction.props}
+                {...primaryAction}
                 appearance="primary"
                 icon={primaryAction.icon}
                 onClick={primaryAction.handler}
@@ -42,7 +42,7 @@ const Actions = props => {
             {secondaryActions &&
               secondaryActions.map((action, index) => (
                 <Button
-                  {...action.props}
+                  {...action}
                   appearance="secondary"
                   icon={action.icon}
                   key={index}
@@ -55,7 +55,7 @@ const Actions = props => {
             {destructiveAction && (
               <Right>
                 <Button
-                  {...destructiveAction.props}
+                  {...destructiveAction}
                   appearance="destructive"
                   icon={destructiveAction.icon}
                   onClick={destructiveAction.handler}

--- a/core/components/molecules/form/actions/actions.js
+++ b/core/components/molecules/form/actions/actions.js
@@ -33,6 +33,7 @@ const Actions = props => {
                 appearance="primary"
                 icon={primaryAction.icon}
                 onClick={primaryAction.handler}
+                {...primaryAction.props}
               >
                 {primaryAction.label}
               </Button>

--- a/core/components/molecules/form/actions/actions.md
+++ b/core/components/molecules/form/actions/actions.md
@@ -55,3 +55,16 @@ In case you want to represent a dangerous or unrecoverable action, you can pass 
   />
 </Form>
 ```
+
+### Passing button props
+
+You can pass any prop that `Button` accepts in a `props` object:
+
+```js
+<Form>
+  <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+  <Form.Actions
+    primaryAction={{ label: 'Save Changes', props: { disabled: true }, handler: () => {} }}
+  />
+</Form>
+```

--- a/core/components/molecules/form/actions/actions.md
+++ b/core/components/molecules/form/actions/actions.md
@@ -65,6 +65,7 @@ You can pass any prop that `Button` accepts in a `props` object:
   <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
   <Form.Actions
     primaryAction={{ label: 'Save Changes', props: { disabled: true }, handler: () => {} }}
+    destructiveAction={{ label: 'Delete', props: { disabled: true }, handler: () => {} }}
   />
 </Form>
 ```

--- a/core/components/molecules/form/actions/actions.md
+++ b/core/components/molecules/form/actions/actions.md
@@ -58,14 +58,18 @@ In case you want to represent a dangerous or unrecoverable action, you can pass 
 
 ### Passing button props
 
-You can pass any prop that `Button` accepts in a `props` object:
+You can pass any prop that `Button` accepts and they will be forwarded
 
 ```js
 <Form>
   <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
   <Form.Actions
-    primaryAction={{ label: 'Save Changes', props: { disabled: true }, handler: () => {} }}
-    destructiveAction={{ label: 'Delete', props: { disabled: true }, handler: () => {} }}
+    primaryAction={{ label: 'Save Changes', loading: true, handler: () => {} }}
+    destructiveAction={{
+      label: 'Delete',
+      disabled: true,
+      handler: () => {}
+    }}
   />
 </Form>
 ```


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/665

Added additional `props` prop that is forwarded to the `Button` component

```jsx  
<Form.Actions
  primaryAction={{ label: 'Save Changes', props: { disabled: true }, handler: () => {} }}
/>
```

Does this API look a little wonky? Should we use a more explicit name like `extraProps` or `buttonProps`?

&nbsp;

Demo: [form-actions#passing-button-props](https://auth0-cosmos-form-actions-pass-props-through.now.sh/#/component/form-actions#passing-button-props)

#### misuse 

There is little scope for misuse here, the `appearance` property comes after the spread props which means it will override it even if someone tries to pass `appearance="primary"` in a destructive action

```jsx
<Button {...destructiveAction.props} appearance="destructive" icon={destructiveAction.icon}>
  {destructiveAction.label}
</Button>
```

There is however room for indirection. These 2 blocks have the same effect:

```jsx
primaryAction={{ label: 'Save Changes', icon: 'home', props: { disabled: true }, handler: () => {} }}

primaryAction={{ label: 'Save Changes', props: { icon: 'home', disabled: true }, handler: () => {} }}
```

We pass the `icon` prop transparently to `Button` right now, but could be troublesome in the future

#### alternate syntax

We can offer the full control which is open to misuse but it supports all props directly because it is more composable

```jsx  
<Form.Actions>
  <Button appearance="primary" disabled={true} >Save Changes</Button>
  <Button appearance="primary">Two save buttons</Button>
</Form.Actions>
```