### PR TITLE
Add option to disable globals

### DIFF
--- a/core/components/_helpers/globals.js
+++ b/core/components/_helpers/globals.js
@@ -1,7 +1,14 @@
 import { injectGlobal } from 'styled-components'
 import { fonts, misc } from '@auth0/cosmos-tokens'
 
-injectGlobal`
+let includeGlobals = true
+
+if (process && process.env && process.env.COSMOS_DISABLE_RESETS) {
+  includeGlobals = false
+}
+
+if (includeGlobals) {
+  injectGlobal`
   html, body, div, span, applet, object, iframe,
   h1, h2, h3, h4, h5, h6, p, blockquote, pre,
   a, abbr, acronym, address, big, cite, code,
@@ -125,3 +132,4 @@ injectGlobal`
   }
 
 `
+}

--- a/internal/docs/usage.js
+++ b/internal/docs/usage.js
@@ -86,6 +86,24 @@ class Usage extends React.Component {
           </Link>{' '}
           where you can learn how to use it.
         </Text>
+
+        <Heading2>Disable global resets</Heading2>
+        <Text>
+          Cosmos adds a set of resets the same resets to your application, if you already have some
+          resets in place, you can disable the resets from Cosmos by setting an environment variable
+          with webpack
+          <CodeBlock language="javascript">
+            {`
+{
+   plugins: [
+      new webpack.EnvironmentPlugin({
+         COSMOS_DISABLE_RESETS: true
+      })
+   ]
+}
+`}
+          </CodeBlock>
+        </Text>
       </div>
     )
   }


### PR DESCRIPTION
By default `cosmos` will add the resets. This let's us have a out of the box setup.

You can disable the resets by passing information via webpack

```js
{
   plugins: [
      new webpack.EnvironmentPlugin({
         COSMOS_DISABLE_RESETS: true
      })
   ]
}
```

Added this to docs as well