### PR TITLE
added spinner size

### DIFF
--- a/core/components/atoms/spinner/spinner.js
+++ b/core/components/atoms/spinner/spinner.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
 import PropTypes from 'prop-types'
+import { misc } from '@auth0/cosmos-tokens'
 
 const rotate = keyframes`
   0% { transform: rotate(0deg) }
@@ -26,21 +27,24 @@ const StyledSpinner = styled.span`
   border-bottom: 2px solid ${props => getColor(props)};
   border-left: 2px solid ${props => getColor(props, true)};
   border-radius: 50%;
-  width: 1em;
-  height: 1em;
+  width: ${props => misc.spinner[props.size]};
+  height: ${props => misc.spinner[props.size]};
   vertical-align: text-bottom;
   animation: ${rotate} 0.8s infinite linear;
 `
 
-const Spinner = props => <StyledSpinner {...props} />
+const Spinner = props => <StyledSpinner size={props.size} {...props} />
 
 Spinner.propTypes = {
   /** Invert for dark background */
-  inverse: PropTypes.bool
+  inverse: PropTypes.bool,
+  /** Size of the Spinner */
+  size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large'])
 }
 
 Spinner.defaultProps = {
-  inverse: false
+  inverse: false,
+  size: 'xsmall'
 }
 
 export default Spinner

--- a/core/components/atoms/spinner/spinner.md
+++ b/core/components/atoms/spinner/spinner.md
@@ -3,7 +3,11 @@ category: Miscellaneous
 desciption: Spinner is useful to notify the user of background activity
 ```
 
----
+`import { Spinner } from '@auth0/cosmos'`
+
+```jsx
+<Spinner {props} />
+```
 
 ## Examples
 

--- a/core/tokens/misc.js
+++ b/core/tokens/misc.js
@@ -24,6 +24,12 @@ const misc = {
     default: { height: '44px' },
     compressed: { height: '36px' },
     small: { height: '32px' }
+  },
+  spinner: {
+    xsmall: '1em',
+    small: '1.5em',
+    medium: '3em',
+    large: '4em'
   }
 }
 


### PR DESCRIPTION
https://github.com/auth0/cosmos/issues/679

Added spinner size prop. Inspired by https://styleguide.auth0.com/#/components/spinner/stage
Maybe we should add auth0 avatar inside when the spinner is `medium` or `large` like in styleguide. WDYT?

