### PR TITLE
Add support for size prop to TextInput

### DIFF
--- a/core/components/_helpers/story-stack.js
+++ b/core/components/_helpers/story-stack.js
@@ -1,25 +1,31 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { spacing } from '@auth0/cosmos/tokens'
+import { spacing } from '@auth0/cosmos-tokens'
+import { sumOfElements, numberOfValues } from './custom-validations'
+
+const alignItems = {
+  top: 'flex-start',
+  center: 'center',
+  bottom: 'flex-end'
+}
 
 const justifyContent = {
   fill: 'space-between',
+  'space-between': 'space-between',
   left: 'flex-start',
   right: 'flex-end'
 }
 
 const StyledStack = styled.div`
   display: flex;
-  width: 100%;
   flex-direction: row;
   flex-wrap: nowrap;
-  align-items: bottom;
+  align-items: ${props => alignItems[props.alignVertical]};
   justify-content: ${props => justifyContent[props.align]};
-
   > * {
     flex: ${props => (props.align === 'fill' ? 1 : 'none')};
-    align-self: center;
     margin-right: ${props => (props.align === 'fill' ? spacing.xsmall : 0)};
   }
   > *:last-child {
@@ -29,8 +35,6 @@ const StyledStack = styled.div`
 
 const StackedItem = styled.div`
   flex-basis: ${props => props.width}%;
-  display: flex;
-  justify-content: center;
 `
 
 /*
@@ -41,16 +45,12 @@ const StackedItem = styled.div`
 
 const Stack = props => {
   let children
-  if (props.align === 'fill') {
+  if (props.align === 'fill' || props.align === 'space-between') {
     children = React.Children.map(props.children, (child, index) => {
       let width = 0
       if (props.widths) width = `${props.widths[index]}` || 0
 
-      return (
-        <StackedItem key={index} width={width}>
-          {child}
-        </StackedItem>
-      )
+      return <StackedItem width={width}>{child}</StackedItem>
     })
   } else {
     children = props.children
@@ -63,8 +63,24 @@ const Stack = props => {
   )
 }
 
+Stack.propTypes = {
+  /** Use align for stacking elements without margin between them */
+  align: PropTypes.oneOf(['fill', 'left', 'right', 'space-between']),
+  /** Vertically align */
+  alignVertical: PropTypes.oneOf(['top', 'center', 'bottom']),
+  /** Element widths in % */
+  widths: PropTypes.arrayOf(PropTypes.number),
+
+  /* internal props only used for validation */
+  /* sum of width values should be 100% */
+  _sum: props => sumOfElements(props.widths, 100),
+  /* the number of widths should match number of children */
+  _numberOfValues: props => numberOfValues(props.widths, React.Children.count(props.children))
+}
+
 Stack.defaultProps = {
-  align: 'fill'
+  align: 'fill',
+  alignVertical: 'center'
 }
 
 export default Stack

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -15,7 +15,7 @@ const TextInput = ({ defaultValue, type, ...props }) => {
 }
 
 TextInput.Element = StyledInput.extend`
-  height: ${misc.input.default.height};
+  height: ${props => misc.input[props.size].height};
 `
 
 TextInput.propTypes = {
@@ -37,6 +37,8 @@ TextInput.propTypes = {
   defaultValue: PropTypes.string,
   /** The (HTML) type for the input. */
   type: PropTypes.string,
+  /** The size of the input. */
+  size: PropTypes.oneOf(['default', 'large', 'small', 'compressed']),
 
   /** deprecate error string prop */
   _error: props => deprecate(props, { name: 'error', replacement: 'hasError' })
@@ -47,7 +49,8 @@ TextInput.defaultProps = {
   code: false,
   error: null,
   onChange: null,
-  type: 'text'
+  type: 'text',
+  size: 'default'
 }
 
 export default TextInput

--- a/core/components/atoms/text-input/text-input.story.js
+++ b/core/components/atoms/text-input/text-input.story.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { TextInput } from '@auth0/cosmos'
+import { Button, TextInput } from '@auth0/cosmos'
 
 storiesOf('TextInput').add('simple', () => (
   <Example title="simple">
@@ -40,5 +40,32 @@ storiesOf('TextInput').add('readonly', () => (
 storiesOf('TextInput').add('masked', () => (
   <Example title="masked">
     <TextInput defaultValue="secret-client-hash" masked />
+  </Example>
+))
+
+storiesOf('TextInput').add('sizes', () => (
+  <Example title="sizes">
+    <Stack style={{ marginBottom: '1em' }}>
+      <TextInput size="large" defaultValue="Size large" />
+      <Button size="large" appearance="primary">
+        Button
+      </Button>
+    </Stack>
+    <Stack style={{ marginBottom: '1em' }}>
+      <TextInput label="This field has text" defaultValue="Size normal" />
+      <Button appearance="primary">Button</Button>
+    </Stack>
+    <Stack style={{ marginBottom: '1em' }}>
+      <TextInput size="compressed" defaultValue="Size compressed" />
+      <Button size="compressed" appearance="primary">
+        Button
+      </Button>
+    </Stack>
+    <Stack style={{ marginBottom: '1em' }}>
+      <TextInput size="small" defaultValue="Size small" />
+      <Button size="small" appearance="primary">
+        Button
+      </Button>
+    </Stack>
   </Example>
 ))

--- a/internal/docs/overview/examples/buttons-inputs.js
+++ b/internal/docs/overview/examples/buttons-inputs.js
@@ -8,7 +8,7 @@ const ButtonInputs = () => (
   <Section>
     <Example title="Inputs + Buttons">
       <Stack style={{ marginBottom: '1em' }}>
-        <TextInput size="large" defaultValue="Size large (not implemented)" />
+        <TextInput size="large" defaultValue="Size large" />
         <Button size="large" appearance="primary">
           Button
         </Button>
@@ -18,13 +18,13 @@ const ButtonInputs = () => (
         <Button appearance="primary">Button</Button>
       </Stack>
       <Stack style={{ marginBottom: '1em' }}>
-        <TextInput size="compressed" defaultValue="Size compressed (not implemented)" />
+        <TextInput size="compressed" defaultValue="Size compressed" />
         <Button size="compressed" appearance="primary">
           Button
         </Button>
       </Stack>
       <Stack style={{ marginBottom: '1em' }}>
-        <TextInput size="small" defaultValue="Size small (not implemented)" />
+        <TextInput size="small" defaultValue="Size small" />
         <Button size="small" appearance="primary">
           Button
         </Button>


### PR DESCRIPTION
Closes #707.

This patch adds a `size` prop to `TextInput` which supports `default`, `large`, `small`, and `compressed` sizes that match those used in `Button`.

I also updated the `Stack` used in Chromatic tests in this patch, so it's possible there may be a few unexpected changes.