### PR TITLE
Proposal: Use standard prettier config to improve IDE plugin compatibility.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+singleQuote: true
+semi: false
+printWidth: 100

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-singleQuote: true
-semi: false
-printWidth: 100

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "git add"
     ]
   },
+  "prettier": {
+    "singleQuote": true,
+    "semi": false,
+    "printWidth": 100
+  },
   "dependencies": {},
   "devDependencies": {
     "@storybook/addon-actions": "4.0.0-alpha.12",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "lint-staged": {
     "*.{js,json,md}": [
-      "prettier --write --single-quote --no-semi --print-width 100",
+      "prettier --write",
       "git add"
     ]
   },


### PR DESCRIPTION
This PR replaces the command line interface parameters to `prettier` in favor of a `.prettierrc` file that also allows IDE plugins like the one in Visual Studio Code to read our Prettier settings and format appropriately on save (if set).