### PR TITLE
End support for uncontrolled state in Tabs

### DIFF
--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -38,7 +38,9 @@ class Tabs extends React.Component {
   constructor(props) {
     super(props)
     this.tabs = React.Children.toArray(props.children)
-    this.state = { selectedIndex: this.getSelectedTabFromChildProps(this.tabs) }
+    this.state = {
+      selectedIndex: this.getSelectedTabFromChildProps(this.tabs)
+    }
   }
 
   componentDidUpdate() {
@@ -53,7 +55,9 @@ class Tabs extends React.Component {
 
   componentWillReceiveProps(newProps) {
     this.tabs = React.Children.toArray(newProps.children)
-    this.setState({ selectedIndex: this.getSelectedTabFromChildProps(this.tabs) })
+    this.setState({
+      selectedIndex: this.getSelectedTabFromChildProps(this.tabs)
+    })
   }
 
   getSelectedTabFromChildProps(tabs) {
@@ -68,15 +72,15 @@ class Tabs extends React.Component {
   }
 
   changeTab(nextIndex) {
-    const currentIndex = this.props.selected; 
+    const currentIndex = this.props.selected
 
     if (currentIndex !== nextIndex) {
-        this.props.onSelect(nextIndex)
+      this.props.onSelect(nextIndex)
     }
   }
 
   render() {
-    const { selected: selectedIndex } = this.props;
+    const { selected: selectedIndex } = this.props
 
     return (
       <Wrapper>
@@ -112,4 +116,4 @@ Tabs.defaultProps = {
   children: []
 }
 
-export default Tabs 
+export default Tabs

--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -68,33 +68,15 @@ class Tabs extends React.Component {
   }
 
   changeTab(nextIndex) {
-    const currentIndex = this.getSelectedTabFromPropsOrState()
+    const currentIndex = this.props.selected; 
 
     if (currentIndex !== nextIndex) {
-      if (this.props.onSelect) {
         this.props.onSelect(nextIndex)
-      } else {
-        const { cosmosKey } = this.props
-        if (cosmosKey) {
-          tabStore[cosmosKey] = nextIndex
-        }
-
-        this.setState({ selectedIndex: nextIndex })
-      }
     }
   }
 
-  getSelectedTabFromPropsOrState() {
-    const stateSelectedIndex = this.state.selectedIndex
-    const propsSelectedIndex = this.props.selected
-    const selectedIndex =
-      typeof propsSelectedIndex !== 'undefined' ? propsSelectedIndex : stateSelectedIndex
-
-    return selectedIndex
-  }
-
   render() {
-    const selectedIndex = this.getSelectedTabFromPropsOrState()
+    const { selected: selectedIndex } = this.props;
 
     return (
       <Wrapper>
@@ -102,7 +84,7 @@ class Tabs extends React.Component {
           {this.tabs.map((tab, index) => (
             <TabLink
               onClick={() => this.changeTab(index)}
-              key={tab.props.label}
+              key={index}
               selected={selectedIndex === index}
             >
               {tab.props.label}
@@ -121,35 +103,13 @@ Tabs.propTypes = {
   /** Children should be an array of Tabs.Tab */
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
   /** Selected should be the index of the desired selected tab */
-  selected: PropTypes.number,
+  selected: PropTypes.number.isRequired,
   /** onSelect will be called with the new index when a new tab is selected by the user */
-  onSelect: PropTypes.func
+  onSelect: PropTypes.func.isRequired
 }
 
 Tabs.defaultProps = {
   children: []
 }
 
-const generateKey = WrappedComponent =>
-  class KeyWrapper extends React.Component {
-    shouldComponentUpdate(nextProps) {
-      const { selected } = this.props
-      if (typeof selected === 'undefined') return false
-
-      return selected !== nextProps.selected
-    }
-
-    render() {
-      const key = makeId('tab')
-      return this.props.selected ? (
-        <WrappedComponent {...this.props} />
-      ) : (
-        <WrappedComponent {...this.props} cosmosKey={key} />
-      )
-    }
-  }
-
-const TabWithKey = generateKey(Tabs)
-TabWithKey.Tab = TabContent
-
-export default TabWithKey
+export default Tabs 

--- a/core/components/molecules/tabs/tabs.md
+++ b/core/components/molecules/tabs/tabs.md
@@ -4,32 +4,17 @@
 ```
 
 ```jsx
-<Tabs>
+<Tabs selected={0} onSelect={() => {}}>
   <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
   <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
   <Tabs.Tab label="Tab 3">Third tab's the charm!</Tabs.Tab>
 </Tabs>
 ```
 
-## Examples
+## Example
 
-### Default selected tab
-
-By default, the first tab is selected but you can change this behavior attaching the `selected` prop to a `Tab`.
-
-```js
-<Tabs>
-  <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
-  <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
-  <Tabs.Tab label="Tab 3" selected>
-    Look, third tab is selected by default!
-  </Tabs.Tab>
-</Tabs>
-```
-
-### Controlled tab state
-
-Sometimes you need to have control on what tab is selected anytime. So you can pass the current selected tab index in the `selected` prop, as well as a callback function in the `onSelect` prop, and Cosmos will notify you when the user tries to change the tab so you can act accordingly.
+You must pass a `selected` prop with the index of the selected tab. Also, you must listen for changes
+on the selected tab with the `onSelect` function and update the `selected` prop accordingly.
 
 ```js
 class TabContainer extends React.Component {
@@ -68,3 +53,4 @@ class TabContainer extends React.Component {
   }
 }
 ```
+

--- a/core/components/molecules/tabs/tabs.md
+++ b/core/components/molecules/tabs/tabs.md
@@ -4,11 +4,26 @@
 ```
 
 ```jsx
-<Tabs selected={0} onSelect={() => {}}>
-  <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
-  <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
-  <Tabs.Tab label="Tab 3">Third tab's the charm!</Tabs.Tab>
-</Tabs>
+class TabContainer extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { selected: 0 }
+  }
+
+  handleSelected(selected) {
+    this.setState({ selected })
+  }
+
+  render() {
+    return (
+      <Tabs onSelect={nextIndex => this.handleSelected(nextIndex)} selected={this.state.selected}>
+        <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
+        <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
+        <Tabs.Tab label="Tab 3">Third tabs the charm!</Tabs.Tab>
+      </Tabs>
+    )
+  }
+}
 ```
 
 ## Example
@@ -53,4 +68,3 @@ class TabContainer extends React.Component {
   }
 }
 ```
-

--- a/core/components/molecules/tabs/tabs.story.js
+++ b/core/components/molecules/tabs/tabs.story.js
@@ -6,7 +6,7 @@ import { Button, Tabs } from '@auth0/cosmos'
 
 storiesOf('Tabs').add('default', () => (
   <Example title="default">
-    <Tabs>
+    <Tabs selected={0}>
       <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
       <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
       <Tabs.Tab label="Tab 3">Look, third tab is selected by default!</Tabs.Tab>
@@ -16,7 +16,7 @@ storiesOf('Tabs').add('default', () => (
 
 storiesOf('Tabs').add('default selected', () => (
   <Example title="default">
-    <Tabs>
+    <Tabs selected={2}>
       <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
       <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>
       <Tabs.Tab selected label="Tab 3">
@@ -28,7 +28,7 @@ storiesOf('Tabs').add('default selected', () => (
 
 storiesOf('Tabs').add('null tab in children', () => (
   <Example title="default">
-    <Tabs>
+    <Tabs selected={0}>
       <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
       {null}
       <Tabs.Tab label="Tab 2">You can render anything you want here</Tabs.Tab>


### PR DESCRIPTION
This will avoid having `shouldComponentUpdate` logic in the Cosmos internals. Handing over that responsibility to the Cosmos user.

Resolves #754 