### PR TITLE
Do not require form's primary action handler

### DIFF
--- a/core/components/_helpers/action-shape.js
+++ b/core/components/_helpers/action-shape.js
@@ -9,10 +9,16 @@ const actionShape = PropTypes.shape({
   handler: PropTypes.func.isRequired
 })
 
+const actionShapeWithoutRequiredHandler = PropTypes.shape({
+  label: PropTypes.string.isRequired,
+  icon: PropTypes.oneOf(__ICONNAMES__),
+  handler: PropTypes.func
+})
+
 const actionShapeWithRequiredIcon = PropTypes.shape({
   label: PropTypes.string.isRequired,
   icon: PropTypes.oneOf(__ICONNAMES__).isRequired,
   handler: PropTypes.func.isRequired
 })
 
-export { actionShape, actionShapeWithRequiredIcon, shapeForDocs }
+export { actionShape, actionShapeWithRequiredIcon, actionShapeWithoutRequiredHandler, shapeForDocs }

--- a/core/components/molecules/form/actions/actions.js
+++ b/core/components/molecules/form/actions/actions.js
@@ -9,7 +9,7 @@ import FormContext from '../form-context'
 import Button from '../../../atoms/button'
 import ButtonGroup from '../../../molecules/button-group'
 import { Right, Clear } from '../../../_helpers/float'
-import { actionShape } from '@auth0/cosmos/_helpers/action-shape'
+import { actionShape, actionShapeWithoutRequiredHandler } from '@auth0/cosmos/_helpers/action-shape'
 
 const StyledActions = styled.div`
   width: ${props => getLayoutValues(props.layout).formWidth};
@@ -71,7 +71,7 @@ const Actions = props => {
 Actions.displayName = 'Form Actions'
 
 Actions.propTypes = {
-  primaryAction: actionShape,
+  primaryAction: actionShapeWithoutRequiredHandler,
   secondaryActions: PropTypes.arrayOf(actionShape),
   destructiveAction: actionShape
 }


### PR DESCRIPTION
Question: In case a handler is still provided, should we automatically `preventDefault` so the form would not submit?