### PR TITLE
Reproduce chromatic bug

### DIFF
--- a/core/tokens/colors.js
+++ b/core/tokens/colors.js
@@ -34,7 +34,7 @@ const colors = {
   input: {
     background: '#FFF',
     backgroundReadOnly: '#F3F4F4',
-    border: '#000000',
+    border: '#CCCCCC',
     borderHover: '#B7B7B7',
     borderFocus: '#0a84ae',
     borderError: '#FF0000',

--- a/core/tokens/colors.js
+++ b/core/tokens/colors.js
@@ -34,7 +34,7 @@ const colors = {
   input: {
     background: '#FFF',
     backgroundReadOnly: '#F3F4F4',
-    border: '#D9D9D9',
+    border: '#000000',
     borderHover: '#B7B7B7',
     borderFocus: '#0a84ae',
     borderError: '#FF0000',


### PR DESCRIPTION
Test subject: `TextInput` component

master uses D9D9D9

Commit 1 uses 000000 
Making it super dark to test if the component is caught by chromatic.
✅[Yep it is](https://www.chromaticqa.com/snapshot?appId=5aba7f6a07f95800202658ff&id=5b73db831615c0002480e2a9)

Commit 2 uses CCCCCC
Make it the color we want, see if that's caught by chromatic
⚠️[It didn't!](https://www.chromaticqa.com/component?appId=5aba7f6a07f95800202658ff&name=TextInput&branch=reproduce-chromatic-bug&buildNumber=691): inspecting the `Live View` shows that the color has changed, but it was caught by the test.