### PR TITLE
Fix table row hover

### DIFF
--- a/core/components/molecules/table/table.js
+++ b/core/components/molecules/table/table.js
@@ -158,6 +158,9 @@ Table.Body = styled.tbody``
 
 Table.Row = styled.tr`
   cursor: ${props => (props.onClick ? 'pointer' : 'inherit')};
+  &:hover {
+    background: ${props => (props.onClick ? colors.base.grayLightest : 'inherit')};
+  }
 `
 
 Table.Cell = styled.td`

--- a/core/components/molecules/table/table.js
+++ b/core/components/molecules/table/table.js
@@ -80,12 +80,11 @@ class Table extends React.Component {
     return items
   }
 
-  handleRowClicked = item => evt => {
-    this.props.onRowClick(evt, item)
-  }
-
-  handleRowClicked = item => evt => {
-    this.props.onRowClick(evt, item)
+  handleRowClicked = item => {
+    if (!this.props.onRowClick) return null
+    return evt => {
+      this.props.onRowClick(evt, item)
+    }
   }
 
   render() {
@@ -184,7 +183,7 @@ Table.propTypes = {
 }
 
 Table.defaultProps = {
-  onRowClick: () => null,
+  onRowClick: null,
   onSort: null,
   sortDirection: 'asc'
 }


### PR DESCRIPTION
As addressed in #800, this patch fixes the issue with `cursor: pointer` being set on table rows even if there is no `onRowClick` callback present. It also adds highlighting to the row on hover if `onRowClick` is set.