### PR TITLE
Add support for table column alignment

### DIFF
--- a/core/components/molecules/table/table-column.js
+++ b/core/components/molecules/table/table-column.js
@@ -7,8 +7,13 @@ TableColumn.propTypes = {
   field: PropTypes.string.isRequired,
   title: PropTypes.string,
   width: PropTypes.string,
+  align: PropTypes.oneOf(['left', 'center', 'right']),
   sortable: PropTypes.bool,
   comparator: PropTypes.func
+}
+
+TableColumn.defaultProps = {
+  align: 'left'
 }
 
 export default TableColumn

--- a/core/components/molecules/table/table-header.js
+++ b/core/components/molecules/table/table-header.js
@@ -57,7 +57,7 @@ TableHeader.Row = styled.tr``
 TableHeader.Cell = styled.th`
   padding: ${spacing.xsmall};
   border-bottom: 2px solid ${colors.base.grayLight};
-  text-align: left;
+  text-align: ${props => props.column.align};
   vertical-align: bottom;
   line-height: 2;
   cursor: ${props => (props.sortable ? 'pointer' : 'auto')};

--- a/core/components/molecules/table/table.js
+++ b/core/components/molecules/table/table.js
@@ -164,7 +164,7 @@ Table.Row = styled.tr`
 Table.Cell = styled.td`
   padding: ${spacing.xsmall};
   border-top: 1px solid ${colors.base.grayLight};
-  text-align: left;
+  text-align: ${props => props.column.align};
   vertical-align: middle;
   line-height: 2;
   width: ${props => props.column.width || 'auto'};

--- a/core/components/molecules/table/table.md
+++ b/core/components/molecules/table/table.md
@@ -93,8 +93,8 @@ You can add `sortable` prop to `Table.Column` that you want the `Table` to be so
   </Table.Column>
   <Table.Column field="name" title="Name" width="30%" />
   <Table.Column field="country" title="Country" />
-  <Table.Column field="goals" title="Goals" sortable />
-  <Table.Column field="assists" title="Assists" sortable />
+  <Table.Column field="goals" title="Goals" align="right" sortable />
+  <Table.Column field="assists" title="Assists" align="right" sortable />
 </Table>
 ```
 

--- a/core/components/molecules/table/table.story.js
+++ b/core/components/molecules/table/table.story.js
@@ -54,6 +54,16 @@ storiesOf('Table').add('explicit widths', () => (
   </Example>
 ))
 
+storiesOf('Table').add('alignment', () => (
+  <Example title="alignment">
+    <Table items={items}>
+      <Table.Column field="name" title="Name" width="70%" align="center" />
+      <Table.Column field="born" title="Born" align="right" />
+      <Table.Column field="died" title="Died" align="right" />
+    </Table>
+  </Example>
+))
+
 storiesOf('Table').add('cell renderer', () => (
   <Example title="default">
     <Table items={items}>
@@ -82,15 +92,26 @@ storiesOf('Table').add('sorting', () => (
 
 storiesOf('Table').add('stressed', () => (
   <Example title="stressed - 7 columns with 119 characters per row">
-    <Table items={[{
-      data: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
-    }, {
-      data: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
-    }, {
-      data: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
-    }, {
-      data: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
-    }]}>
+    <Table
+      items={[
+        {
+          data:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
+        },
+        {
+          data:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
+        },
+        {
+          data:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
+        },
+        {
+          data:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vehicula massa augue, in consectetur tellus tristique ut.'
+        }
+      ]}
+    >
       <Table.Column field="data" title="Field 1" />
       <Table.Column field="data" title="Field 2" />
       <Table.Column field="data" title="Field 3" />
@@ -101,4 +122,3 @@ storiesOf('Table').add('stressed', () => (
     </Table>
   </Example>
 ))
-


### PR DESCRIPTION
As requested in #800. Closes #825.

This patch adds an `align` property to `Table.Column` which allows the user to align the content of the columns left, center, or right. The original design was to keep the table headers aligned left, but after seeing the results, I made the `align` property affect the header as well.