### PR TITLE
Implement gray spinner for variable backgrounds. Apply in buttons.

### DIFF
--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -105,8 +105,7 @@ Alert.propTypes = {
   /** Title text (in bold) */
   title: PropTypes.string,
 
-  /** Details */
-  // @deprecated
+  /** @deprecated Details */
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /** Link to documentation */

--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -20,7 +20,7 @@ const appearances = {
     focusBorder: colors.button.default.borderFocus,
     activeBackground: colors.button.default.backgroundActive,
     activeBorder: colors.button.default.borderActive,
-    loadingInverse: false
+    spinnerStyle: 'normal'
   },
   primary: {
     text: colors.button.primary.text,
@@ -33,7 +33,7 @@ const appearances = {
     focusBorder: colors.button.primary.borderFocus,
     activeBackground: colors.button.primary.backgroundActive,
     activeBorder: colors.button.primary.borderActive,
-    loadingInverse: true
+    spinnerStyle: 'inverse'
   },
   secondary: {
     text: colors.button.secondary.text,
@@ -46,7 +46,7 @@ const appearances = {
     focusBorder: colors.button.secondary.borderFocus,
     activeBackground: colors.button.secondary.backgroundActive,
     activeBorder: colors.button.secondary.borderActive,
-    loadingInverse: false
+    spinnerStyle: 'gray'
   },
   cta: {
     text: colors.button.cta.text,
@@ -59,7 +59,7 @@ const appearances = {
     focusBorder: colors.button.cta.borderFocus,
     activeBackground: colors.button.cta.backgroundActive,
     activeBorder: colors.button.cta.borderActive,
-    loadingInverse: true
+    spinnerStyle: 'inverse'
   },
   destructive: {
     text: colors.button.destructive.text,
@@ -72,7 +72,7 @@ const appearances = {
     focusBorder: colors.button.destructive.borderFocus,
     activeBackground: colors.button.destructive.backgroundActive,
     activeBorder: colors.button.destructive.borderActive,
-    loadingInverse: true
+    spinnerStyle: 'inverse'
   },
   link: {
     text: colors.button.link.text,
@@ -85,7 +85,7 @@ const appearances = {
     focusText: colors.button.link.focus,
     focusBackground: 'transparent',
     focusBorder: 'transparent',
-    loadingInverse: false
+    spinnerStyle: 'gray'
   }
 }
 
@@ -170,7 +170,7 @@ const ButtonContent = props => {
   let icon = props.success ? 'check' : props.icon
 
   if (props.loading) {
-    content.push(<Spinner key="spinner" inverse={getAttributes(props).loadingInverse} />)
+    content.push(<Spinner key="spinner" type={getAttributes(props).spinnerStyle} />)
   } else if (icon) {
     content.push(<Icon key="icon" size={16} name={icon} color={getAttributes(props).icon} />)
   }

--- a/core/components/atoms/spinner/spinner.js
+++ b/core/components/atoms/spinner/spinner.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
 import PropTypes from 'prop-types'
+import { deprecate } from '../../_helpers/custom-validations'
 
 const rotate = keyframes`
   0% { transform: rotate(0deg) }
@@ -10,10 +11,18 @@ const rotate = keyframes`
 const getColor = (props, highlight) => {
   let color = '0, 0, 0'
   let opacity = highlight ? 0.4 : 0.08
+  let type = props.type
 
-  if (props.inverse) {
+  if (props.inverse) type = 'inverse'
+
+  if (type === 'inverse') {
     color = '255, 255, 255'
     opacity = highlight ? 0.85 : 0.2
+  }
+
+  if (type === 'gray') {
+    color = '150, 150, 150'
+    opacity = highlight ? 0.65 : 0.1
   }
 
   return `rgba(${color}, ${opacity})`
@@ -36,10 +45,15 @@ const Spinner = props => <StyledSpinner {...props} />
 
 Spinner.propTypes = {
   /** Invert for dark background */
-  inverse: PropTypes.bool
+  type: PropTypes.oneOf(['normal', 'inverse', 'gray']),
+  inverse: PropTypes.bool,
+
+  /** deprecate boolean inverse prop */
+  _error: props => deprecate(props, { name: 'inverse', replacement: 'type' })
 }
 
 Spinner.defaultProps = {
+  type: 'normal',
   inverse: false
 }
 

--- a/core/components/atoms/spinner/spinner.js
+++ b/core/components/atoms/spinner/spinner.js
@@ -46,6 +46,7 @@ const Spinner = props => <StyledSpinner {...props} />
 Spinner.propTypes = {
   /** Invert for dark background */
   type: PropTypes.oneOf(['normal', 'inverse', 'gray']),
+  /** @deprecated Shows a white spinner instead of the default. */
   inverse: PropTypes.bool,
 
   /** deprecate boolean inverse prop */

--- a/core/components/atoms/spinner/spinner.md
+++ b/core/components/atoms/spinner/spinner.md
@@ -3,7 +3,9 @@ category: Miscellaneous
 desciption: Spinner is useful to notify the user of background activity
 ```
 
----
+```jsx
+<Spinner {props} />
+```
 
 ## Examples
 

--- a/core/components/atoms/spinner/spinner.md
+++ b/core/components/atoms/spinner/spinner.md
@@ -19,6 +19,21 @@ desciption: Spinner is useful to notify the user of background activity
 
 ```js
 <div style={{ background: '#333', padding: '20px' }}>
-  <Spinner inverse />
+  <Spinner type="inverse" />
 </div>
+```
+
+### Gray for variable backgrounds
+
+Sometimes you may have a component that can have light or dark backgrounds in an uncontrolled mode. A gray spinner will look fine on both.
+
+```js
+<Stack>
+  <div style={{ background: '#333', padding: '20px' }}>
+    <Spinner type="gray" />
+  </div>
+  <div style={{ padding: '20px' }}>
+    <Spinner type="gray" />
+  </div>
+</Stack>
 ```

--- a/core/components/atoms/spinner/spinner.story.js
+++ b/core/components/atoms/spinner/spinner.story.js
@@ -12,6 +12,18 @@ storiesOf('Spinner').add('default', () => (
 
 storiesOf('Spinner').add('dark background', () => (
   <Example title="Spinner" background="dark">
-    <Spinner inverse />
+    <Spinner type="inverse" />
+  </Example>
+))
+
+storiesOf('Spinner').add('neutral gray', () => (
+  <Example title="Spinner">
+    <Spinner type="gray" />
+  </Example>
+))
+
+storiesOf('Spinner').add('neutral gray with dark background', () => (
+  <Example title="Spinner" background="dark">
+    <Spinner type="gray" />
   </Example>
 ))

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -27,7 +27,7 @@ TextInput.propTypes = {
   code: PropTypes.bool,
   /** Pass hasError to show error state */
   hasError: PropTypes.bool,
-  /** Pass error string directly to show error state */
+  /** @deprecated Pass error string directly to show error state */
   error: PropTypes.string,
   /** onChange transparently passed to the input */
   onChange: PropTypes.func,

--- a/internal/docs/docs-components/tag.js
+++ b/internal/docs/docs-components/tag.js
@@ -4,11 +4,17 @@ import PropTypes from 'prop-types'
 
 import { colors, fonts } from '@auth0/cosmos-tokens'
 
+const getColor = props => {
+  if (props.warning) return colors.base.orangeLighter
+  else if (props.error) return colors.base.red
+  else return colors.base.gray
+}
+
 const StyledTag = styled.span`
   display: inline-block;
-  color: ${props => (props.warning ? colors.base.orangeLighter : colors.base.gray)};
+  color: ${props => getColor(props)};
   border: 1px solid;
-  border-color: ${props => (props.warning ? colors.base.orangeLighter : colors.base.gray)};
+  border-color: ${props => getColor(props)};
   border-radius: 5px;
   min-width: 10px;
   padding: 4px 8px;

--- a/internal/docs/spec/props.js
+++ b/internal/docs/spec/props.js
@@ -43,6 +43,11 @@ const Type = styled.div`
   left: -${spacing.xsmall};
 `
 
+const Deprecated = Type.withComponent('span').extend`
+  color: ${colors.text.error};
+  &:after { content: '(deprecated)' }
+`
+
 const Required = styled.span`
   color: ${colors.base.orange};
   &:after {
@@ -60,6 +65,14 @@ class Props extends React.Component {
     const defaultsFromDocs = props.defaultsFromDocs
     Object.keys(defaultsFromDocs).forEach(key => {
       if (propData[key]) propData[key].value = defaultsFromDocs[key]
+    })
+
+    /* mark deprecations */
+    Object.keys(propData).forEach(key => {
+      if (propData[key].description && propData[key].description.includes('@deprecated')) {
+        propData[key].deprecated = true
+        propData[key].description = propData[key].description.replace('@deprecated', '')
+      }
     })
 
     this.state = { propData: propData }
@@ -102,7 +115,10 @@ class Props extends React.Component {
           {keys.map(key => (
             <tr key={key}>
               <td>
-                <Code>{key}</Code>
+                <Code style={{ color: propData[key].deprecated ? colors.text.error : 'inherit' }}>
+                  {key}
+                </Code>
+                {propData[key].deprecated && <Deprecated />}
                 {propData[key].required && <Required />}
               </td>
               <td>


### PR DESCRIPTION
Resolves #842 

### ⚠️ Deprecation warning
This PR deprecates `inverse` prop in Spinner in favor of `type` which supports more than two types.