### PR TITLE
Adding support for attributes for automation

### DIFF
--- a/core/components/_helpers/automation-attribute.js
+++ b/core/components/_helpers/automation-attribute.js
@@ -1,0 +1,3 @@
+export default (defaultKey) => ({
+  'data-cosmos-key': defaultKey
+});

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -6,6 +6,7 @@ import Link, { StyledLink } from '../link'
 import Paragraph, { StyledParagraph } from '../paragraph'
 import { Text } from '../../_helpers/free-text'
 import { deprecate } from '../../_helpers/custom-validations'
+import Automation from '../../_helpers/automation-attribute'
 
 const ReadMoreLink = styled(Link)`
   color: ${props => colors.alert[props.type].text};
@@ -48,7 +49,7 @@ class Alert extends React.Component {
   render() {
     if (this.state.visible) {
       return (
-        <Alert.Element type={this.props.type}>
+        <Alert.Element type={this.props.type} {...Automation('alert')}>
           <Paragraph>
             <em>{this.props.title}</em> <Text {...this.props} />
             {this.props.link && (
@@ -57,7 +58,9 @@ class Alert extends React.Component {
               </ReadMoreLink>
             )}
           </Paragraph>
-          {this.props.dismissible && <Cross onClick={this.dismiss} />}
+          {this.props.dismissible && (
+            <Cross onClick={this.dismiss} {...Automation('alert.dismiss')} />
+          )}
         </Alert.Element>
       )
     } else return null

--- a/core/components/atoms/breadcrumb/breadcrumb.js
+++ b/core/components/atoms/breadcrumb/breadcrumb.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import Automation from '../../_helpers/automation-attribute'
 
 import { fonts, spacing, colors } from '@auth0/cosmos-tokens'
 
@@ -67,10 +68,10 @@ const Wrapper = styled.div`
   }
 `
 
-const Breadcrumb = props => <Wrapper {...props} />
+const Breadcrumb = props => <Wrapper {...props} {...Automation('breadcrumb')} />
 
 Breadcrumb.Link = props => (
-  <Link {...props}>
+  <Link {...props} {...Automation('breadcrumb.link')}>
     {props.icon && <LinkIcon name={props.icon} size={12} color="grayDarkest" />}
     {props.children}
     <Separator name="chevron-right-fill" size={12} color="grayMedium" />

--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -7,6 +7,7 @@ import { colors, spacing, fonts, misc } from '@auth0/cosmos-tokens'
 import Icon, { __ICONNAMES__ } from '../icon'
 import Spinner, { StyledSpinner } from '../spinner'
 import Tooltip from '../tooltip'
+import Automation from '../../_helpers/automation-attribute'
 
 const appearances = {
   default: {
@@ -185,7 +186,7 @@ const ButtonContent = props => {
 }
 
 const Button = ({ children, ...props }) => {
-  let button = <ButtonContent {...props} text={children} />
+  let button = <ButtonContent {...props} text={children} {...Automation('button')} />
 
   // If a label was specified, wrap the Button in a Tooltip.
   if (props.label) {

--- a/core/components/atoms/checkbox/checkbox.js
+++ b/core/components/atoms/checkbox/checkbox.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
+import Automation from '../../_helpers/automation-attribute'
 
 const CheckMark = styled.span``
 const Label = styled.span``
@@ -35,7 +36,7 @@ const StyledCheckboxOption = styled.label`
     height: 16px;
     width: 16px;
     background-color: ${props =>
-      props.readOnly ? colors.radio.backgroundDisabled : colors.radio.background};
+    props.readOnly ? colors.radio.backgroundDisabled : colors.radio.background};
     border: 1px solid
       ${props => (props.readOnly ? colors.radio.borderDisabled : colors.radio.border)};
     box-shadow: inset 0 1px 2px 0
@@ -90,7 +91,7 @@ const StyledCheckbox = styled.div`
 `
 
 const Checkbox = props => (
-  <StyledCheckboxOption readOnly={props.readOnly}>
+  <StyledCheckboxOption readOnly={props.readOnly} {...Automation('checkbox')}>
     <input
       type="checkbox"
       name={props.name}
@@ -106,7 +107,7 @@ const Checkbox = props => (
 )
 
 const CheckboxGroup = props => (
-  <StyledCheckbox {...props}>
+  <StyledCheckbox {...props} {...Automation('checkbox.group')}>
     {React.Children.map(props.children, child => {
       return React.cloneElement(child, {
         name: props.name,

--- a/core/components/atoms/link/link.js
+++ b/core/components/atoms/link/link.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import propTypes from 'prop-types'
 import styled from 'styled-components'
+import Automation from '../../_helpers/automation-attribute'
 
 import { colors } from '@auth0/cosmos-tokens'
 
@@ -12,7 +13,7 @@ const StyledLink = styled.a`
   }
 `
 
-const Link = props => <StyledLink {...props}>{props.children}</StyledLink>
+const Link = props => <StyledLink {...props} {...Automation('link')}>{props.children}</StyledLink>
 
 Link.propTypes = {
   /** URL to follow */

--- a/core/components/atoms/radio/radio.js
+++ b/core/components/atoms/radio/radio.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
+import Automation from '../../_helpers/automation-attribute'
 
 const CheckMark = styled.span``
 const Label = styled.span``
@@ -93,6 +94,8 @@ const StyledRadio = styled.div`
 const RadioOption = props => (
   <StyledRadioOption readOnly={props.readOnly}>
     <input
+      {...Automation('radio.option')}
+      pepe="test"
       type="radio"
       name={props.name}
       value={props.value}
@@ -106,7 +109,7 @@ const RadioOption = props => (
 )
 
 const Radio = props => (
-  <StyledRadio {...props}>
+  <StyledRadio {...props} {...Automation('radio')}>
     {React.Children.map(props.children, child => {
       return React.cloneElement(child, {
         name: props.name,

--- a/core/components/atoms/select/select.js
+++ b/core/components/atoms/select/select.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Automation from '../../_helpers/automation-attribute'
 
 import { misc } from '@auth0/cosmos-tokens'
 import { StyledInput } from '../_styled-input'
@@ -17,9 +18,9 @@ const Select = ({ options, ...props }) => {
   if (props.readOnly) props.disabled = true
 
   return (
-    <StyledSelect {...props}>
+    <StyledSelect {...props} {...Automation('select')}>
       {options.map((option, index) => (
-        <option key={index} value={option.value}>
+        <option key={index} value={option.value} {...Automation('select.option')}>
           {option.text}
         </option>
       ))}

--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
+import Automation from '../../_helpers/automation-attribute'
 
 import { colors, fonts, spacing, misc } from '@auth0/cosmos-tokens'
 
@@ -90,7 +91,7 @@ class Switch extends React.Component {
       and is itself a readOnly component
     */
     return (
-      <StyledSwitch onClick={this.onToggle.bind(this)}>
+      <StyledSwitch onClick={this.onToggle.bind(this)} {...Automation('switch')}>
         <Checkbox type="checkbox" checked={this.state.on} readOnly id={this.props.id} />
         <Toggle on={this.state.on} readOnly={this.props.readOnly} />
         <Label>{this.state.on ? onLabel : offLabel}</Label>

--- a/core/components/atoms/tag/tag.js
+++ b/core/components/atoms/tag/tag.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Icon from '../icon'
 import { spacing, fonts, colors, misc } from '@auth0/cosmos-tokens'
+import Automation from '../../_helpers/automation-attribute'
 
 const StyledTag = styled.span`
   display: inline-block;
@@ -40,21 +41,21 @@ const Tag = props => {
       props.onRemove(evt)
     }
     icon = (
-      <a onClick={handleRemove}>
+      <a onClick={handleRemove} {...Automation('tag.remove')}>
         <Icon name="close" size={9} />
       </a>
     )
   }
 
   return (
-    <StyledTag onClick={props.onClick}>
+    <StyledTag onClick={props.onClick} {...Automation('tag')}>
       {props.children}
       {icon}
     </StyledTag>
   )
 }
 
-Tag.Group = TagGroup
+Tag.Group = ({ children }) => <TagGroup {...Automation('tag.group')}>{children}</TagGroup>
 
 Tag.propTypes = {
   /** The function to call when a user clicks the tag */

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -4,14 +4,15 @@ import PropTypes from 'prop-types'
 import { misc } from '@auth0/cosmos-tokens'
 import { StyledInput } from '../_styled-input'
 import { deprecate } from '../../_helpers/custom-validations'
+import Automation from '../../_helpers/automation-attribute'
 
 const TextInput = ({ defaultValue, type, ...props }) => {
   if (props.masked) {
     const length = defaultValue ? defaultValue.length : 8
     const maskedValue = new Array(length).join('•')
-    return <TextInput.Element type={type} {...props} placeholder={maskedValue} readOnly />
+    return <TextInput.Element type={type} {...props} placeholder={maskedValue} readOnly {...Automation('text-input')} />
   }
-  return <TextInput.Element type={type} defaultValue={defaultValue} {...props} />
+  return <TextInput.Element {...Automation('text-input')} type={type} defaultValue={defaultValue} {...props} />
 }
 
 TextInput.Element = StyledInput.extend`

--- a/core/components/atoms/textarea/textarea.js
+++ b/core/components/atoms/textarea/textarea.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types'
 
 import { StyledInput } from '../_styled-input'
 import { deprecate } from '../../_helpers/custom-validations'
+import Automation from '../../_helpers/automation-attribute'
 
 const StyledTextArea = StyledInput.withComponent('textarea').extend`
   resize: ${props => (props.resizable ? 'vertical' : 'none')};
   font-size: ${props => (props.code ? '13px' : 'inherit')};
 `
 
-const TextArea = props => <StyledTextArea rows={props.length} {...props} />
+const TextArea = props => <StyledTextArea rows={props.length} {...props} {...Automation('text-area')} />
 
 TextArea.propTypes = {
   /** Length of the textarea in rows */

--- a/core/components/molecules/button-group/button-group.js
+++ b/core/components/molecules/button-group/button-group.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
+import Automation from '../../_helpers/automation-attribute'
 
 import Button from '../../atoms/button'
 import { spacing } from '@auth0/cosmos-tokens'
@@ -35,13 +36,13 @@ const StyledButtonGroup = styled.div`
 
   ${Button.Element} {
     ${props => (props.align === 'left' ? 'margin-right' : 'margin-left')}: ${props =>
-      props.compressed ? 0 : spacing.xsmall};
+    props.compressed ? 0 : spacing.xsmall};
   }
 
   ${props => (props.compressed ? groupRadiusStyles : null)};
 `
 
-const ButtonGroup = props => <StyledButtonGroup {...props}>{props.children}</StyledButtonGroup>
+const ButtonGroup = props => <StyledButtonGroup {...props} {...Automation('button-group')}>{props.children}</StyledButtonGroup>
 
 ButtonGroup.propTypes = {
   /** Make Buttons are ordered with the correct space between them  */

--- a/core/components/molecules/dialog/dialog.js
+++ b/core/components/molecules/dialog/dialog.js
@@ -8,6 +8,7 @@ import Icon from '../../atoms/icon'
 import Link from '../../atoms/link'
 import DialogAction from './dialog-action'
 import { colors, fonts, spacing } from '@auth0/cosmos-tokens'
+import Automation from '../../_helpers/automation-attribute'
 
 const createButtonForAction = (action, index) => {
   // As we also support passing raw <Button> components
@@ -34,15 +35,15 @@ const createButtonForAction = (action, index) => {
 
 const Dialog = props => (
   <Overlay {...props}>
-    <DialogElement width={props.width}>
-      <DialogTitleBar>
+    <DialogElement width={props.width} {...Automation('dialog')}>
+      <DialogTitleBar {...Automation('dialog.title')}>
         <span>{props.title}</span>
         <Link onClick={props.onClose}>
           <Icon name="close" size={16} />
         </Link>
       </DialogTitleBar>
-      <DialogBody>{props.children}</DialogBody>
-      <DialogFooter>
+      <DialogBody {...Automation('dialog.body')}>{props.children}</DialogBody>
+      <DialogFooter {...Automation('dialog.footer')}>
         <ButtonGroup>{props.actions.map(createButtonForAction)}</ButtonGroup>
       </DialogFooter>
     </DialogElement>

--- a/core/components/molecules/empty-state/empty-state.js
+++ b/core/components/molecules/empty-state/empty-state.js
@@ -9,6 +9,7 @@ import Heading from '../../atoms/heading'
 import { actionShapeWithRequiredIcon } from '../../_helpers/action-shape'
 import { Text } from '../../_helpers/free-text'
 import { deprecate } from '../../_helpers/custom-validations'
+import Automation from '../../_helpers/automation-attribute'
 
 const EmptyState = props => {
   let helpLink
@@ -22,7 +23,7 @@ const EmptyState = props => {
     )
   }
   return (
-    <Wrapper>
+    <Wrapper {...Automation('empty-state')}>
       <Title size={1}>{props.title}</Title>
       <Body>
         <Icon name={props.icon} size={110} color="blue" />

--- a/core/components/molecules/form-group/form-group.js
+++ b/core/components/molecules/form-group/form-group.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import Automation from '../../_helpers/automation-attribute'
 
 import Well from '../../atoms/_well'
 import { spacing } from '@auth0/cosmos-tokens'
@@ -17,7 +18,7 @@ const FormGroup = props => {
     return <StyledFormWrapper>{child}</StyledFormWrapper>
   })
 
-  return <StyledFormGroup>{children}</StyledFormGroup>
+  return <StyledFormGroup {...Automation('form-group')}>{children}</StyledFormGroup>
 }
 
 FormGroup.propTypes = {

--- a/core/components/molecules/form/field/field.js
+++ b/core/components/molecules/form/field/field.js
@@ -6,6 +6,7 @@ import { spacing, misc } from '@auth0/cosmos-tokens'
 import getLayoutValues from '../layout'
 import uniqueId from '../../../_helpers/uniqueId'
 import FormContext from '../form-context'
+import Automation from '../../../_helpers/automation-attribute'
 
 import StyledLabel from '../label'
 import StyledError from '../error'
@@ -55,7 +56,7 @@ const Field = props => {
   return (
     <FormContext.Consumer>
       {context => (
-        <StyledField layout={context.layout}>
+        <StyledField layout={context.layout} {...Automation('form.field')}>
           <LabelLayout layout={context.layout}>
             <StyledLabel htmlFor={id}>{props.label}</StyledLabel>
           </LabelLayout>
@@ -63,8 +64,8 @@ const Field = props => {
             {props.fieldComponent ? (
               <props.fieldComponent id={id} hasError={error ? true : false} {...fieldProps} />
             ) : (
-              props.children
-            )}
+                props.children
+              )}
             {props.error ? <StyledError>{props.error}</StyledError> : null}
             {props.helpText ? <HelpText>{props.helpText}</HelpText> : null}
           </ContentLayout>

--- a/core/components/molecules/form/fieldset/fieldset.js
+++ b/core/components/molecules/form/fieldset/fieldset.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 
 import { spacing } from '@auth0/cosmos-tokens'
 import StyledDivider from './divider'
+import Automation from '../../../_helpers/automation-attribute'
 
 const StyledFieldSet = styled.fieldset`
   border: none;
@@ -15,7 +16,7 @@ const StyledFieldSet = styled.fieldset`
 `
 
 const FieldSet = props => (
-  <StyledFieldSet>
+  <StyledFieldSet {...Automation('form.fieldset')}>
     <StyledDivider>{props.label}</StyledDivider>
     {props.children}
   </StyledFieldSet>

--- a/core/components/molecules/form/form.js
+++ b/core/components/molecules/form/form.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Automation from '../../_helpers/automation-attribute'
 
 import ActionInput from '../../molecules/_action-input'
 import TextArea from '../../atoms/textarea'
@@ -15,7 +16,7 @@ import FormContext from './form-context'
 
 const Form = props => (
   <FormContext.Provider value={{ layout: props.layout }}>
-    <form {...props} />
+    <form {...props} {...Automation('form')} />
   </FormContext.Provider>
 )
 

--- a/core/components/molecules/list/list.js
+++ b/core/components/molecules/list/list.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import Automation from '../../_helpers/automation-attribute'
 
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import Heading, { StyledHeading } from '../../atoms/heading'
@@ -27,13 +28,13 @@ const StyledList = styled.div`
 
 const List = props => {
   return (
-    <StyledList>
+    <StyledList {...Automation('list')}>
       {props.label ? (
         <StyledLabel>
           <Heading size={4}>{props.label}</Heading>
         </StyledLabel>
       ) : null}
-      {React.Children.map(props.children, child => <StyledRow>{child}</StyledRow>)}
+      {React.Children.map(props.children, child => <StyledRow {...Automation('list.item')}>{child}</StyledRow>)}
     </StyledList>
   )
 }

--- a/core/components/molecules/page-header/page-header.js
+++ b/core/components/molecules/page-header/page-header.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import Automation from '../../_helpers/automation-attribute'
 
 import { spacing } from '@auth0/cosmos-tokens'
 
@@ -39,7 +40,7 @@ const SoftDescription = ({ description, learnMore }) => {
 
 const PageHeader = props => {
   return (
-    <StyledPageHeader>
+    <StyledPageHeader {...Automation('page-header')}>
       <ButtonGroup align="right">
         {props.secondaryAction && (
           <Button

--- a/core/components/molecules/pager/pager.js
+++ b/core/components/molecules/pager/pager.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import Automation from '../../_helpers/automation-attribute'
 
 import Button from '../../atoms/button'
 import Icon from '../../atoms/icon'
@@ -30,7 +31,7 @@ const StyledButton = styled(Button)`
 `
 
 const Pager = ({ onPageChanged, page, perPage, items }) => (
-  <StyledPager>
+  <StyledPager {...Automation('pager')}>
     <StyledButton
       position="left"
       size="compressed"

--- a/core/components/molecules/pagination-toolbar/pagination-toolbar.js
+++ b/core/components/molecules/pagination-toolbar/pagination-toolbar.js
@@ -6,6 +6,7 @@ import TextInput from '../../atoms/text-input'
 import Button from '../../atoms/button'
 import ButtonGroup from '../../molecules/button-group'
 import Icon from '../../atoms/icon'
+import Automation from '../../_helpers/automation-attribute'
 
 import { changePageIfAppropiate, pageInputWidth, pagesFromItems } from '../../_helpers/pagination'
 
@@ -55,7 +56,7 @@ const PaginationToolbar = ({ onPageChanged, page, perPage, items }) => {
   if (pages === 1) return null
 
   return (
-    <PaginationToolbar.Element>
+    <PaginationToolbar.Element {...Automation('pagination-toolbar')}>
       <StyledPageSelector page={page}>
         <div>Page</div>
         <TextInput

--- a/core/components/molecules/pagination/pagination.js
+++ b/core/components/molecules/pagination/pagination.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { spacing, colors, misc } from '@auth0/cosmos-tokens'
 import Button from '../../atoms/button'
 import Icon from '../../atoms/icon'
+import Automation from '../../_helpers/automation-attribute'
 
 import {
   getPaginationSlice,
@@ -45,15 +46,15 @@ const StyledPaginationItem = styled(Button)`
     }
 
     ${props =>
-      props.left &&
-      `
+    props.left &&
+    `
       left: ${spacing.xxsmall};
       padding-right: ${spacing.xxsmall};
       border-right: 1px solid ${colors.base.grayLight}
     `};
     ${props =>
-      props.right &&
-      `
+    props.right &&
+    `
       right: calc(${spacing.xxsmall});
       padding-left: ${spacing.xxsmall};
       border-left: 1px solid ${colors.base.grayLight}
@@ -83,17 +84,17 @@ const renderPaginationItem = ({
   right = false,
   iconOnly = false
 }) => (
-  <StyledPaginationItem
-    left={left}
-    right={right}
-    iconOnly={iconOnly}
-    appearance={appearance}
-    size="compressed"
-    onClick={() => changePageIfAppropiate(toPage, items, perPage, onPageChanged)}
-  >
-    {content}
-  </StyledPaginationItem>
-)
+    <StyledPaginationItem
+      left={left}
+      right={right}
+      iconOnly={iconOnly}
+      appearance={appearance}
+      size="compressed"
+      onClick={() => changePageIfAppropiate(toPage, items, perPage, onPageChanged)}
+    >
+      {content}
+    </StyledPaginationItem>
+  )
 
 const handlePaginationButtonClick = (page, items, perPage, onPageChanged) => {
   if (page.clickable === false) return
@@ -113,7 +114,7 @@ const lastPageButton = (
 )
 
 const Pagination = ({ page, perPage, items, appearance, onPageChanged }) => (
-  <StyledPagination>
+  <StyledPagination {...Automation('pagination')}>
     {renderPaginationItem({
       toPage: 1,
       content: firstPageButton,

--- a/core/components/molecules/resource-list/item/item.js
+++ b/core/components/molecules/resource-list/item/item.js
@@ -7,6 +7,7 @@ import { StyledTextAllCaps } from '@auth0/cosmos/atoms/text'
 import { actionShapeWithRequiredIcon } from '@auth0/cosmos/_helpers/action-shape'
 import { __ICONNAMES__ } from '@auth0/cosmos/atoms/icon'
 import { colors, spacing } from '@auth0/cosmos-tokens'
+import Automation from '../../../_helpers/automation-attribute'
 
 const StyledListItem = styled.li`
   display: flex;
@@ -96,7 +97,7 @@ const ResourceListItem = props => {
   }
 
   return (
-    <StyledListItem onClick={props.onClick ? callHandler(props.onClick) : null}>
+    <StyledListItem onClick={props.onClick ? callHandler(props.onClick) : null} {...Automation('resource-list.item')}>
       <ListItemHeader>
         {image}
         <div>

--- a/core/components/molecules/resource-list/resource-list.js
+++ b/core/components/molecules/resource-list/resource-list.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import ResourceListItem from './item'
 import { spacing } from '@auth0/cosmos-tokens'
 import { actionShapeWithRequiredIcon } from '@auth0/cosmos/_helpers/action-shape'
+import Automation from '../../_helpers/automation-attribute'
 
 const StyledList = styled.ul`
   margin: ${spacing.large} 0;
@@ -13,7 +14,7 @@ const StyledList = styled.ul`
 const defaultItemRenderer = (item, index) => <ResourceListItem {...item} />
 
 const ResourceList = props => (
-  <StyledList>
+  <StyledList {...Automation('resource-list')}>
     {props.items.map((item, index) => {
       const itemRenderer = props.renderItem || defaultItemRenderer
       return React.cloneElement(itemRenderer(item, index), {

--- a/core/components/molecules/sidebar/sidebar-link-group.js
+++ b/core/components/molecules/sidebar/sidebar-link-group.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import SidebarLink from './sidebar-link'
 import { __ICONNAMES__ } from '@auth0/cosmos/atoms/icon'
+import Automation from '../../_helpers/automation-attribute'
 
 class SidebarLinkGroup extends React.Component {
   constructor(props) {
@@ -25,7 +26,7 @@ class SidebarLinkGroup extends React.Component {
     const { icon, label, children } = this.props
     const { open } = this.state
     return (
-      <SidebarLinkGroup.Element>
+      <SidebarLinkGroup.Element {...Automation('sidebar.group')}>
         <SidebarLink icon={icon} label={label} onClick={this.handleClick} />
         <SidebarLinkGroup.Content open={open}>{children}</SidebarLinkGroup.Content>
       </SidebarLinkGroup.Element>

--- a/core/components/molecules/sidebar/sidebar-link.js
+++ b/core/components/molecules/sidebar/sidebar-link.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import Automation from '../../_helpers/automation-attribute'
 
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import Icon, { __ICONNAMES__ } from '../../atoms/icon'
 
 const SidebarLink = props => {
   return (
-    <SidebarLink.Element href={props.url} onClick={props.onClick} selected={props.selected}>
+    <SidebarLink.Element href={props.url} onClick={props.onClick} selected={props.selected} {...Automation('sidebar.link')}>
       <Icon
         name={props.icon ? props.icon : 'arrow-right'}
         size={18}

--- a/core/components/molecules/sidebar/sidebar.js
+++ b/core/components/molecules/sidebar/sidebar.js
@@ -2,12 +2,13 @@ import React from 'react'
 import styled from 'styled-components'
 import SidebarLink from './sidebar-link'
 import SidebarLinkGroup from './sidebar-link-group'
+import Automation from '../../_helpers/automation-attribute'
 
 import { spacing } from '@auth0/cosmos-tokens'
 import Icon from '../../atoms/icon'
 
 const Sidebar = props => {
-  return <Sidebar.Element {...props} />
+  return <Sidebar.Element {...props} {...Automation('sidebar')} />
 }
 
 Sidebar.Element = styled.div`

--- a/core/components/molecules/stack/stack.js
+++ b/core/components/molecules/stack/stack.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import Automation from '../../_helpers/automation-attribute'
 
 import { spacing } from '@auth0/cosmos-tokens'
 import { sumOfElements, numberOfValues } from '../../_helpers/custom-validations'
@@ -50,14 +51,14 @@ const Stack = props => {
       let width = 0
       if (props.widths) width = `${props.widths[index]}` || 0
 
-      return <StackedItem width={width}>{child}</StackedItem>
+      return <StackedItem width={width} {...Automation('stack.item')}>{child}</StackedItem>
     })
   } else {
     children = props.children
   }
 
   return (
-    <StyledStack {...props} align={props.align}>
+    <StyledStack {...props} align={props.align} {...Automation('stack')}>
       {children}
     </StyledStack>
   )

--- a/core/components/molecules/table/table-header.js
+++ b/core/components/molecules/table/table-header.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import TableColumn from './table-column'
+import Automation from '../../_helpers/automation-attribute'
 
 const TableHeader = props => {
   const cells = props.columns.map((column, index) => {
@@ -44,7 +45,7 @@ const TableHeader = props => {
   })
 
   return (
-    <TableHeader.Element>
+    <TableHeader.Element {...Automation('table.header')}>
       <TableHeader.Row>{cells}</TableHeader.Row>
     </TableHeader.Element>
   )

--- a/core/components/molecules/table/table.js
+++ b/core/components/molecules/table/table.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import TableColumn from './table-column'
 import TableHeader from './table-header'
+import Automation from '../../_helpers/automation-attribute'
 
 class Table extends React.Component {
   constructor(props) {
@@ -112,7 +113,7 @@ class Table extends React.Component {
     }
 
     const rows = sortedItems.map((item, index) => (
-      <Table.Row key={`row-${index}`} onClick={this.handleRowClicked(item)}>
+      <Table.Row key={`row-${index}`} onClick={this.handleRowClicked(item)} {...Automation('table.row')}>
         {columns.map(column => {
           const cellRenderer = column.children || this.defaultCellRenderer
 
@@ -126,14 +127,14 @@ class Table extends React.Component {
     ))
 
     return (
-      <Table.Element>
+      <Table.Element {...Automation('table')}>
         <Table.Header
           columns={columns}
           sortingColumn={sortingColumn}
           sortDirection={sortDirection}
           onSort={onSort}
         />
-        <Table.Body>{rows}</Table.Body>
+        <Table.Body {...Automation('table.body')}>{rows}</Table.Body>
       </Table.Element>
     )
   }

--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import makeId from '../../_helpers/uniqueId'
+import Automation from '../../_helpers/automation-attribute'
 
 const Wrapper = styled.div``
 
@@ -83,10 +84,11 @@ class Tabs extends React.Component {
     const { selected: selectedIndex } = this.props
 
     return (
-      <Wrapper>
+      <Wrapper {...Automation('tabs')}>
         <TabLinkGroup>
           {this.tabs.map((tab, index) => (
             <TabLink
+              {...Automation('tabs.item')}
               onClick={() => this.changeTab(index)}
               key={index}
               selected={selectedIndex === index}
@@ -105,7 +107,7 @@ Tabs.Tab = TabContent
 
 Tabs.propTypes = {
   /** Children should be an array of Tabs.Tab */
-  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  children: PropTypes.node.isRequired,
   /** Selected should be the index of the desired selected tab */
   selected: PropTypes.number.isRequired,
   /** onSelect will be called with the new index when a new tab is selected by the user */

--- a/internal/docs/app.js
+++ b/internal/docs/app.js
@@ -12,6 +12,7 @@ import ContributionGuide from './contribution-guide'
 import FAQS from './faqs'
 import Changes from './changes'
 import Overview from './overview'
+import AutomationGlossary from './automation-glossary'
 import Playground from './playground'
 import Navigation from './docs-components/navigation'
 
@@ -111,6 +112,7 @@ class App extends React.Component {
               <Route exact path="/contribution-guide" component={ContributionGuide} />
               <Route exact path="/faqs" component={FAQS} />
               <Route exact path="/changes" component={Changes} />
+              <Route exact path="/automation" component={AutomationGlossary} />
               <Route exact path="/playground" component={Playground} />
               <Route exact path="/component/:componentName" component={Spec} />
               <Route exact path="/" component={Home} />

--- a/internal/docs/automation-glossary.js
+++ b/internal/docs/automation-glossary.js
@@ -1,0 +1,185 @@
+import React from 'react'
+import styled from 'styled-components'
+import Helmet from 'react-helmet'
+import { Table, Paragraph, Code } from '@auth0/cosmos'
+
+import { Heading1, Heading2 } from './docs-components/typography'
+
+const Container = styled.div``
+
+class AutomationGlossary extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Automation Glossary &mdash; Cosmos" />
+        <Container>
+          <Heading1>Automation Glossary</Heading1>
+          <Paragraph>
+            The goal of the automation glossary is to help you to write automation tests when
+            writing them with tools like Webdriver.io or Chrome Puppeteer by providing{' '}
+            <Code>data-cosmos-key</Code>
+            attribute.
+          </Paragraph>
+
+          <Table
+            items={[
+              {
+                component: 'Alert',
+                selectors: [
+                  '$(\'div[data-cosmos-key="alert"]\')',
+                  '$(\'div[data-cosmos-key="alert"] a[data-cosmos-key="alert.dismiss"\')'
+                ]
+              },
+              {
+                component: 'Breadcrumb',
+                selectors: [
+                  '$(\'div[data-cosmos-key="breadcrumb"]\')',
+                  '$(\'div[data-cosmos-key="breadcrumb"] a[data-cosmos-key="link"]\')'
+                ]
+              },
+              {
+                component: 'Button',
+                selectors: ['$(\'button[data-cosmos-key="button"]\')']
+              },
+              {
+                component: 'Checkbox',
+                selectors: [
+                  '$(\'label[data-cosmos-key="checkbox"] input\')',
+                  '$(\'div[data-cosmos-key="checkbox.group"]\')'
+                ]
+              },
+              {
+                component: 'Radio',
+                selectors: [
+                  '$(\'div[data-cosmos-key="radio"]\')',
+                  '$(\'div[data-cosmos-key="radio"] input[data-cosmos-key="radio.option"\')'
+                ]
+              },
+              {
+                component: 'Select',
+                selectors: [
+                  '$(\'select[data-cosmos-key="select"]\')',
+                  '$(\'select[data-cosmos-key="select"] option[data-cosmos-key="select.option"]\')'
+                ]
+              },
+              {
+                component: 'switch',
+                selectors: ['$(\'span[data-cosmos-key="switch"] input\')']
+              },
+              {
+                component: 'Tag',
+                selectors: [
+                  '$(\'span[data-cosmos-key="tag"]\')',
+                  '$(\'span[data-cosmos-key="tag"] a[data-cosmos-key="tag.remove"]\')',
+                  '$(\'div[data-cosmos-key="tag.group"]\')'
+                ]
+              },
+              {
+                component: 'TextInput',
+                selectors: ['$(\'input[data-cosmos-key="text-input"]\')']
+              },
+              {
+                component: 'TextArea',
+                selectors: ['$(\'textarea[data-cosmos-key="text-area"]\')']
+              },
+              {
+                component: 'ButtonGroup',
+                selectors: ['$(\'div[data-cosmos-key="button-group"]\')']
+              },
+              {
+                component: 'Dialog',
+                selectors: [
+                  '$(\'div[data-cosmos-key="dialog"]\')',
+                  '$(\'div[data-cosmos-key="dialog"] div[data-cosmos-key="dialog.title"]\')',
+                  '$(\'div[data-cosmos-key="dialog"] div[data-cosmos-key="dialog.body"]\')',
+                  '$(\'div[data-cosmos-key="dialog"] div[data-cosmos-key="dialog.footer"]\')'
+                ]
+              },
+              {
+                component: 'EmptyState',
+                selectors: ['$(\'div[data-cosmos-key="empty-state"]\')']
+              },
+              {
+                component: 'FormGroup',
+                selectors: ['$(\'div[data-cosmos-key="form-group"]\')']
+              },
+              {
+                component: 'Form',
+                selectors: [
+                  '$(\'form[data-cosmos-key="form"]\')',
+                  '$(\'form[data-cosmos-key="form"] div[data-cosmos-key="form.field"]\')',
+                  '$(\'form[data-cosmos-key="form"] fieldset[data-cosmos-key="form.fieldset"]\')'
+                ]
+              },
+              {
+                component: 'List',
+                selectors: [
+                  '$(\'div[data-cosmos-key="list"]\')',
+                  '$(\'div[data-cosmos-key="list"] div[data-cosmos-key="list.item"]\')'
+                ]
+              },
+              {
+                component: 'PageHeader',
+                selectors: ['$(\'div[data-cosmos-key="page-header"]\')']
+              },
+              {
+                component: 'Pager',
+                selectors: ['$(\'div[data-cosmos-key="pager"]\')']
+              },
+              {
+                component: 'PaginationToolbar',
+                selectors: ['$(\'div[data-cosmos-key="pagination-toolbar"]\')']
+              },
+              {
+                component: 'Pagination',
+                selectors: ['$(\'div[data-cosmos-key="pagination"]\')']
+              },
+              {
+                component: 'ResourceList',
+                selectors: [
+                  '$(\'ul[data-cosmos-key="resource-list"]\')',
+                  '$(\'ul[data-cosmos-key="resource-list"] li[data-cosmos-key="resource-list.item"]\')'
+                ]
+              },
+              {
+                component: 'Sidebar',
+                selectors: ['$(\'div[data-cosmos-key="sidebar"]\')']
+              },
+              {
+                component: 'Stack',
+                selectors: [
+                  '$(\'div[data-cosmos-key="stack"]\')',
+                  '$(\'div[data-cosmos-key="stack"] div[data-cosmos-key="stack.item"]\')'
+                ]
+              },
+              {
+                component: 'Table',
+                selectors: [
+                  '$(\'table[data-cosmos-key="table"]\')',
+                  '$(\'table[data-cosmos-key="table"] thead[data-cosmos-key="table.header"]\')',
+                  '$(\'table[data-cosmos-key="table"] tbody[data-cosmos-key="table.body"]\')',
+                  '$(\'table[data-cosmos-key="table"] tbody[data-cosmos-key="table.body"] tr[data-cosmos-key="table.row"]\')'
+                ]
+              },
+              {
+                component: 'tabs',
+                selectors: [
+                  '$(\'div[data-cosmos-key="tabs"]\')',
+                  '$(\'div[data-cosmos-key="tabs"] a[data-cosmos-key="tabs.item"]\')'
+                ]
+              }
+            ]}
+          >
+            <Table.Column field="component" title="Component" width="75px" />
+            <Table.Column field="selectors" title="Selectors">
+              {item => <ul>{item.selectors.map(i => <li>{i}</li>)}</ul>}
+            </Table.Column>
+          </Table>
+        </Container>
+      </div>
+    )
+  }
+}
+
+export default AutomationGlossary
+// $('div[data-cosmos-key="alert"] a[data-cosmos-key="alert.dismiss"')

--- a/internal/docs/sidebar/list.js
+++ b/internal/docs/sidebar/list.js
@@ -71,6 +71,11 @@ const List = props => {
           </NavLink>
         </StyledLink>
         <StyledLink>
+          <NavLink to="/automation" activeClassName="selected">
+            Automation Glossary
+          </NavLink>
+        </StyledLink>
+        <StyledLink>
           <NavLink to="/playground" activeClassName="selected">
             Cosmos playground
           </NavLink>

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -57,6 +57,14 @@ module.exports = {
       chromatic: {
         script: 'chromatic test --storybook-addon --script-name=sandbox --exit-zero-on-changes',
         description: 'Run chromatic visual tests in CI'
+      },
+      snapshot: {
+        script: 'cd test && yarn test-snapshot',
+        description: 'Run snapshot tests'
+      },
+      unit: {
+        script: 'cd test && yarn test-unit',
+        description: 'Run unit tests'
       }
     },
     metadata: {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "internal/docs",
     "examples/manage",
     "examples/webpack-hello-world",
-    "examples/perf-tests"
+    "examples/perf-tests",
+    "test"
   ],
   "scripts": {
     "scripts": "nps -s",

--- a/test/jestPreprocess.js
+++ b/test/jestPreprocess.js
@@ -1,0 +1,3 @@
+const babelOptions = { presets: ['env'] }
+
+module.exports = require('babel-jest').createTransformer(require('../core/babel-preset'))

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@auth0/cosmos-tests",
+  "description": "Tests for Auth0 Cosmos",
+  "version": "0.4.0",
+  "repository": "auth0/cosmos",
+  "author": "siddharthkp",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest --no-cache",
+    "test-snapshot": "jest snapshot --no-cache",
+    "test-unit": "jest unit --no-cache"
+  },
+  "jest": {
+    "verbose": true,
+    "transform": {
+      "^.+\\.js?$": "<rootDir>/jestPreprocess.js"
+    }
+  },
+  "devDependencies": {
+    "@auth0/cosmos": "0.4.0",
+    "babel-jest": "^23.4.2",
+    "enzyme": "^3.4.4",
+    "enzyme-adapter-react-16": "^1.2.0",
+    "jest": "^23.5.0",
+    "jest-styled-components": "^6.1.1"
+  }
+}

--- a/test/snapshot/__snapshots__/alert.test.js.snap
+++ b/test/snapshot/__snapshots__/alert.test.js.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alert renders with automation attribute 1`] = `
+.c0 {
+  padding: 16px 16px;
+  background-color: #F0F0F0;
+  border-radius: 3px;
+  position: relative;
+}
+
+.c0 .c1 {
+  margin: 0;
+  color: #333;
+}
+
+.c0 .sc-EHOje {
+  color: #333;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 .sc-EHOje:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 .c3 {
+  position: absolute;
+  right: 0;
+  top: 0;
+  color: #333;
+  padding: 16px 16px;
+}
+
+.c2 {
+  margin: 1em 0;
+  color: #212121;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.c4 {
+  cursor: pointer;
+  font-size: 1.5em;
+  line-height: 1;
+}
+
+.c4:after {
+  content: '×';
+}
+
+<div
+  className="c0"
+  data-cosmos-key="alert"
+  type="default"
+>
+  <p
+    className="c1 c2"
+  >
+    <em />
+     
+    Text
+  </p>
+  <a
+    className="c3 c4"
+    data-cosmos-key="alert.dismiss"
+    onClick={[Function]}
+  />
+</div>
+`;

--- a/test/snapshot/__snapshots__/breadcrumb.test.js.snap
+++ b/test/snapshot/__snapshots__/breadcrumb.test.js.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Breadcrumb renders with automation attribute 1`] = `
+.c0 .c1 {
+  color: #676767;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.c0 .c1:hover {
+  cursor: pointer;
+  color: #0a84ae;
+}
+
+.c0 .c1:hover .sc-gzVnrw path {
+  fill: #0a84ae;
+}
+
+.c0 .c1:last-child {
+  color: #333;
+  cursor: default;
+}
+
+.c0 .c1:first-child {
+  color: #676767;
+  cursor: pointer;
+}
+
+.c0 .c1:first-child:hover {
+  color: #0a84ae;
+}
+
+.c0 .sc-gzVnrw,
+.c0 .c3 {
+  position: relative;
+  top: -2px;
+}
+
+.c0 .c1:last-child .c3 {
+  display: none;
+}
+
+.c0 .sc-gzVnrw {
+  top: -2px;
+}
+
+.c0 .c3 {
+  top: -1px;
+}
+
+.c0 .c1:last-child .c3 {
+  display: none;
+}
+
+.c2 {
+  color: #0a84ae;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2:hover {
+  color: #053b4e;
+}
+
+.c4 {
+  margin: 0 16px;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.c6 {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
+}
+
+.c6 path {
+  fill: #A8A8A8;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="breadcrumb"
+>
+  <a
+    className="c1 c2"
+    data-cosmos-key="link"
+    href="/home"
+    target="_self"
+  >
+    Home
+    <i
+      className="c3 c4 c5"
+      color="grayMedium"
+      name="chevron-right-fill"
+      size={12}
+    >
+      <svg
+        className="c6"
+        color="#A8A8A8"
+        height={12}
+        viewBox="0 0 20 20"
+        width={12}
+      >
+        <path
+          d="M7.903 2L6 3.88 12.18 10 6 16.12 7.903 18 16 10z"
+        />
+      </svg>
+    </i>
+  </a>
+</div>
+`;

--- a/test/snapshot/__snapshots__/button-group.test.js.snap
+++ b/test/snapshot/__snapshots__/button-group.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonGroup renders with automation attribute 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c0 .cosmos-tooltip {
+  left: 40%;
+}
+
+.c0 .sc-gqjmRU {
+  margin-right: 8px;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="button-group"
+/>
+`;

--- a/test/snapshot/__snapshots__/button.test.js.snap
+++ b/test/snapshot/__snapshots__/button.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button renders with automation attribute 1`] = `
+.c0 {
+  display: inline-block;
+  min-height: 42px;
+  line-height: 42px;
+  min-width: 96px;
+  box-sizing: border-box;
+  text-transform: uppercase;
+  text-align: center;
+  white-space: nowrap;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-size: 13px;
+  font-weight: 500;
+  background: #F1F1F1;
+  border: 1px solid;
+  border-color: #F1F1F1;
+  border-radius: 3px;
+  color: #333;
+  padding: 0 16px;
+  opacity: 1;
+  cursor: pointer;
+  -webkit-transition: border-color 0.25s,background 0.25s;
+  transition: border-color 0.25s,background 0.25s;
+}
+
+.c0 .sc-bwzfXH,
+.c0 .sc-dnqmqq {
+  position: relative;
+  top: -1px;
+  margin-right: 0;
+}
+
+.c0 .sc-bwzfXH {
+  color: #333;
+}
+
+.c0:hover {
+  color: #333;
+  background: #E9E8E8;
+  border-color: #E9E8E8;
+}
+
+.c0:focus {
+  background: #E9E8E8;
+  border-color: #E9E8E8;
+  outline: none;
+}
+
+.c0:active {
+  background: #DADADA;
+  border-color: #DADADA;
+  outline: none;
+}
+
+<button
+  className="c0"
+  data-cosmos-key="button"
+  disabled={false}
+  icon={null}
+  size="default"
+/>
+`;

--- a/test/snapshot/__snapshots__/checkbox.test.js.snap
+++ b/test/snapshot/__snapshots__/checkbox.test.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Checkbox renders with automation attribute group of checkboxs 1`] = `
+.c0 .c1 {
+  display: table;
+}
+
+.c0 .c1:last-child {
+  margin: 0;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="checkbox.group"
+  name="cosmos"
+/>
+`;
+
+exports[`Checkbox renders with automation attribute single checkbox 1`] = `
+.c0 {
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+}
+
+.c0 input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.c0 .c1 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  height: 16px;
+  width: 16px;
+  background-color: #FFF;
+  border: 1px solid #BEBEBE;
+  box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.20);
+  border-radius: 2px;
+}
+
+.c0:hover input ~ .c1 {
+  box-shadow: inset 0 1px 4px 0 rgba(0,0,0,0.20);
+}
+
+.c0 input:checked ~ .c1 {
+  background-color: #3B99FC;
+  border: 1px solid #2C90FC;
+}
+
+.c0 .c1:after {
+  content: '';
+  position: absolute;
+  display: none;
+}
+
+.c0 input:checked ~ .c1:after {
+  display: block;
+}
+
+.c0 .c1:after {
+  width: 4px;
+  height: 8px;
+  border: solid #FFF;
+  border-width: 0 2px 2px 0;
+  -webkit-transform: rotate(45deg) translate(-50%,-50%);
+  -ms-transform: rotate(45deg) translate(-50%,-50%);
+  transform: rotate(45deg) translate(-50%,-50%);
+  left: 20%;
+  top: 50%;
+}
+
+<label
+  className="c0"
+  data-cosmos-key="checkbox"
+>
+  <input
+    name="cosmos"
+    readOnly={true}
+    type="checkbox"
+  />
+  <span
+    className="c1 "
+  />
+  <span
+    className=""
+  />
+</label>
+`;

--- a/test/snapshot/__snapshots__/form-group.test.js.snap
+++ b/test/snapshot/__snapshots__/form-group.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormGroup renders with automation attribute 1`] = `
+<div
+  className=""
+  data-cosmos-key="form-group"
+/>
+`;

--- a/test/snapshot/__snapshots__/list.test.js.snap
+++ b/test/snapshot/__snapshots__/list.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`List renders with automation attribute 1`] = `
+.c0 {
+  margin: 32px 0;
+}
+
+.c1 {
+  border-top: 1px solid #DDD;
+  padding: 16px 8px;
+}
+
+.c1:hover {
+  background: #FAFAFA;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="list"
+>
+  <div
+    className="c1"
+    data-cosmos-key="list.item"
+  >
+    <div>
+      element
+    </div>
+  </div>
+</div>
+`;

--- a/test/snapshot/__snapshots__/page-header.test.js.snap
+++ b/test/snapshot/__snapshots__/page-header.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageHeader renders with automation attribute 1`] = `
+.c0 {
+  margin-bottom: 32px;
+}
+
+.c0 .c1 {
+  float: right;
+}
+
+.c0 .c3 {
+  margin: 0;
+  margin-bottom: 8px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c2 .cosmos-tooltip {
+  left: 58%;
+}
+
+.c2 .sc-gqjmRU {
+  margin-left: 8px;
+}
+
+.c4 {
+  margin: 1em 0;
+  color: #212121;
+  font-weight: 400;
+  line-height: 1.3;
+  font-size: 36px;
+}
+
+.c5 {
+  margin-top: 32px;
+  margin-bottom: 0;
+}
+
+.c5:hover .sc-dfVpRl {
+  border-color: transparent transparent transparent #053b4e;
+}
+
+.c5:hover .sc-gzOgki {
+  color: #053b4e;
+}
+
+.c6 {
+  margin: 1em 0;
+  color: #212121;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="page-header"
+>
+  <div
+    className="c1 c2"
+    data-cosmos-key="button-group"
+  />
+  <h1
+    className="c3 c4"
+    size={1}
+  >
+    
+  </h1>
+  <p
+    className="c5 c6"
+  >
+    description
+     
+  </p>
+</div>
+`;

--- a/test/snapshot/__snapshots__/pager.test.js.snap
+++ b/test/snapshot/__snapshots__/pager.test.js.snap
@@ -1,0 +1,203 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pager renders with automation attribute 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 {
+  padding-right: 11px;
+  padding-left: 7px;
+  padding-top: 2px;
+}
+
+.c1 .c4 {
+  margin: 0;
+}
+
+.c8 {
+  padding-left: 11px;
+  padding-right: 7px;
+  padding-top: 2px;
+}
+
+.c8 .c4 {
+  margin: 0;
+}
+
+.c2 {
+  display: inline-block;
+  min-height: 34px;
+  line-height: 34px;
+  min-width: auto;
+  box-sizing: border-box;
+  text-transform: uppercase;
+  text-align: center;
+  white-space: nowrap;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-size: 13px;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid;
+  border-color: #D0D2D3;
+  border-radius: 3px;
+  color: #333;
+  padding: 0 16px;
+  opacity: 1;
+  cursor: pointer;
+  -webkit-transition: border-color 0.25s,background 0.25s;
+  transition: border-color 0.25s,background 0.25s;
+}
+
+.c2 .c4,
+.c2 .sc-dnqmqq {
+  position: relative;
+  top: -1px;
+  margin-right: 8px;
+}
+
+.c2 .c4 {
+  color: #333;
+}
+
+.c2:hover {
+  color: #333;
+  background: rgba(0,0,0,0.05);
+  border-color: #B5B7B8;
+}
+
+.c2:focus {
+  background: rgba(0,0,0,0.05);
+  border-color: #B5B7B8;
+  outline: none;
+}
+
+.c2:active {
+  background: #DADADA;
+  border-color: #DADADA;
+  outline: none;
+}
+
+.c3 {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.c6 {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
+}
+
+.c6 path {
+  fill: #333;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="pager"
+>
+  <button
+    className="c1 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      <i
+        className="c4 c5"
+        color="default"
+        name="chevron-left"
+        size={20}
+      >
+        <svg
+          className="c6"
+          color="#333"
+          height={20}
+          viewBox="0 0 20 20"
+          width={20}
+        >
+          <path
+            d="M6 9.659a.524.524 0 0 0 .152.394c.024.024.06.017.086.035l6.618 6.072a.53.53 0 0 0 .748-.749L7.331 9.657l6.274-5.755a.528.528 0 1 0-.748-.747L6.24 9.223c-.028.02-.065.013-.09.038a.522.522 0 0 0-.15.398z"
+          />
+        </svg>
+      </i>
+       Newer
+    </span>
+  </button>
+  <div
+    className="c7"
+  >
+    Showing 21 - 30 of 20372
+  </div>
+  <button
+    className="c8 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      Older 
+      <i
+        className="c4 c5"
+        color="default"
+        name="chevron-right"
+        size={20}
+      >
+        <svg
+          className="c6"
+          color="#333"
+          height={20}
+          viewBox="0 0 20 20"
+          width={20}
+        >
+          <path
+            d="M13.76 9.659a.524.524 0 0 1-.152.394c-.024.024-.06.017-.087.035L6.903 16.16a.53.53 0 0 1-.747-.749l6.273-5.754-6.274-5.755a.528.528 0 1 1 .748-.747l6.616 6.068c.028.02.065.013.09.038.11.109.156.254.15.398z"
+          />
+        </svg>
+      </i>
+    </span>
+  </button>
+</div>
+`;

--- a/test/snapshot/__snapshots__/pagination-toolbar.test.js.snap
+++ b/test/snapshot/__snapshots__/pagination-toolbar.test.js.snap
@@ -1,0 +1,278 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaginationToolbar renders with automation attribute 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 > * {
+  margin-right: 5px;
+}
+
+.c1 > *:last-child {
+  margin-right: 0;
+}
+
+.c1 .c2 {
+  width: 58px;
+}
+
+.c3 {
+  width: 100%;
+  box-sizing: border-box;
+  background: #FFF;
+  border: 1px solid;
+  border-color: #CCCCCC;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: inherit;
+  color: #555;
+  padding: 10px 16px;
+  cursor: auto;
+  -webkit-transition: border-color 0.25s,box-shadow 0.25s;
+  transition: border-color 0.25s,box-shadow 0.25s;
+  height: 36px;
+}
+
+.c3:hover {
+  border-color: #B7B7B7;
+}
+
+.c3:focus {
+  border-color: #0a84ae;
+  box-shadow: 0px 0px 0 1px #0a84ae;
+  outline: none;
+}
+
+.c3::-webkit-input-placeholder {
+  color: #B2B2B2;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c4 .cosmos-tooltip {
+  left: 40%;
+}
+
+.c4 .c6 {
+  margin-right: 0;
+}
+
+.c4 .c6:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c4 .c6:last-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.c4 .c6:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.c5 .c9 {
+  margin: 0;
+}
+
+.c7 {
+  display: inline-block;
+  min-height: 34px;
+  line-height: 34px;
+  min-width: auto;
+  box-sizing: border-box;
+  text-transform: uppercase;
+  text-align: center;
+  white-space: nowrap;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-size: 13px;
+  font-weight: 500;
+  background: #F1F1F1;
+  border: 1px solid;
+  border-color: #F1F1F1;
+  border-radius: 3px;
+  color: #333;
+  padding: 0 16px;
+  opacity: 1;
+  cursor: pointer;
+  -webkit-transition: border-color 0.25s,background 0.25s;
+  transition: border-color 0.25s,background 0.25s;
+}
+
+.c7 .c9,
+.c7 .sc-dnqmqq {
+  position: relative;
+  top: -1px;
+  margin-right: 8px;
+}
+
+.c7 .c9 {
+  color: #333;
+}
+
+.c7:hover {
+  color: #333;
+  background: #E9E8E8;
+  border-color: #E9E8E8;
+}
+
+.c7:focus {
+  background: #E9E8E8;
+  border-color: #E9E8E8;
+  outline: none;
+}
+
+.c7:active {
+  background: #DADADA;
+  border-color: #DADADA;
+  outline: none;
+}
+
+.c8 {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.c10 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
+}
+
+.c11 path {
+  fill: #333;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="pagination-toolbar"
+>
+  <div
+    className="c1"
+  >
+    <div>
+      Page
+    </div>
+    <input
+      className="c2 c3"
+      data-cosmos-key="text-input"
+      onChange={[Function]}
+      readOnly={false}
+      size="compressed"
+      type="number"
+      value="3"
+    />
+    <div>
+      of 
+      2038
+    </div>
+  </div>
+  <div
+    className="c4"
+    data-cosmos-key="button-group"
+  >
+    <button
+      className="c5 c6 c7"
+      data-cosmos-key="button"
+      disabled={false}
+      icon={null}
+      onClick={[Function]}
+      size="compressed"
+    >
+      <span
+        className="c8"
+      >
+        <i
+          className="c9 c10"
+          color="default"
+          name="chevron-left"
+          size={20}
+        >
+          <svg
+            className="c11"
+            color="#333"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M6 9.659a.524.524 0 0 0 .152.394c.024.024.06.017.086.035l6.618 6.072a.53.53 0 0 0 .748-.749L7.331 9.657l6.274-5.755a.528.528 0 1 0-.748-.747L6.24 9.223c-.028.02-.065.013-.09.038a.522.522 0 0 0-.15.398z"
+            />
+          </svg>
+        </i>
+      </span>
+    </button>
+    <button
+      className="c5 c6 c7"
+      data-cosmos-key="button"
+      disabled={false}
+      icon={null}
+      onClick={[Function]}
+      size="compressed"
+    >
+      <span
+        className="c8"
+      >
+        <i
+          className="c9 c10"
+          color="default"
+          name="chevron-right"
+          size={20}
+        >
+          <svg
+            className="c11"
+            color="#333"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M13.76 9.659a.524.524 0 0 1-.152.394c-.024.024-.06.017-.087.035L6.903 16.16a.53.53 0 0 1-.747-.749l6.273-5.754-6.274-5.755a.528.528 0 1 1 .748-.747l6.616 6.068c.028.02.065.013.09.038.11.109.156.254.15.398z"
+            />
+          </svg>
+        </i>
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/test/snapshot/__snapshots__/pagination.test.js.snap
+++ b/test/snapshot/__snapshots__/pagination.test.js.snap
@@ -1,0 +1,413 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination renders with automation attribute 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  margin-right: 16px;
+  position: relative;
+  min-width: 95px;
+  padding-left: 40px;
+}
+
+.c1:last-child {
+  margin-right: 0;
+}
+
+.c1 .c4 {
+  position: absolute;
+  margin: 0;
+  padding-top: 10px;
+  height: calc(36px - 2px);
+  width: 20px;
+  left: 4px;
+  padding-right: 4px;
+  border-right: 1px solid #D9D9D9;
+}
+
+.c1 .c4 svg {
+  width: 15px;
+  height: 15px;
+}
+
+.c8 {
+  margin-right: 16px;
+  position: relative;
+  min-width: 16px;
+}
+
+.c8:last-child {
+  margin-right: 0;
+}
+
+.c8 .c4 {
+  position: absolute;
+  margin: 0;
+  padding-top: 10px;
+  height: calc(36px - 2px);
+  width: 20px;
+}
+
+.c8 .c4 svg {
+  width: 15px;
+  height: 15px;
+}
+
+.c9 {
+  margin-right: 16px;
+  position: relative;
+  min-width: 16px;
+  background-color: rgba(0,0,0,0.2);
+}
+
+.c9:last-child {
+  margin-right: 0;
+}
+
+.c9 .c4 {
+  position: absolute;
+  margin: 0;
+  padding-top: 10px;
+  height: calc(36px - 2px);
+  width: 20px;
+}
+
+.c9 .c4 svg {
+  width: 15px;
+  height: 15px;
+}
+
+.c10 {
+  margin-right: 16px;
+  position: relative;
+  min-width: 95px;
+  padding-right: 40px;
+}
+
+.c10:last-child {
+  margin-right: 0;
+}
+
+.c10 .c4 {
+  position: absolute;
+  margin: 0;
+  padding-top: 10px;
+  height: calc(36px - 2px);
+  width: 20px;
+  right: calc(4px);
+  padding-left: 4px;
+  border-left: 1px solid #D9D9D9;
+}
+
+.c10 .c4 svg {
+  width: 15px;
+  height: 15px;
+}
+
+.c2 {
+  display: inline-block;
+  min-height: 34px;
+  line-height: 34px;
+  min-width: auto;
+  box-sizing: border-box;
+  text-transform: uppercase;
+  text-align: center;
+  white-space: nowrap;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-size: 13px;
+  font-weight: 500;
+  background: #F1F1F1;
+  border: 1px solid;
+  border-color: #F1F1F1;
+  border-radius: 3px;
+  color: #333;
+  padding: 0 16px;
+  opacity: 1;
+  cursor: pointer;
+  -webkit-transition: border-color 0.25s,background 0.25s;
+  transition: border-color 0.25s,background 0.25s;
+}
+
+.c2 .c4,
+.c2 .sc-dnqmqq {
+  position: relative;
+  top: -1px;
+  margin-right: 8px;
+}
+
+.c2 .c4 {
+  color: #333;
+}
+
+.c2:hover {
+  color: #333;
+  background: #E9E8E8;
+  border-color: #E9E8E8;
+}
+
+.c2:focus {
+  background: #E9E8E8;
+  border-color: #E9E8E8;
+  outline: none;
+}
+
+.c2:active {
+  background: #DADADA;
+  border-color: #DADADA;
+  outline: none;
+}
+
+.c3 {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.c5 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.c6 {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
+}
+
+.c6 path {
+  fill: #333;
+}
+
+.c7 {
+  margin-right: 16px;
+  min-width: 16px;
+  padding-left: 8px;
+  padding-right: 0;
+}
+
+.c7 .c4 {
+  padding-top: 3px;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="pagination"
+>
+  <button
+    className="c1 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      <span>
+        <i
+          className="c4 c5"
+          color="default"
+          name="chevron-left"
+          size={20}
+        >
+          <svg
+            className="c6"
+            color="#333"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M6 9.659a.524.524 0 0 0 .152.394c.024.024.06.017.086.035l6.618 6.072a.53.53 0 0 0 .748-.749L7.331 9.657l6.274-5.755a.528.528 0 1 0-.748-.747L6.24 9.223c-.028.02-.065.013-.09.038a.522.522 0 0 0-.15.398z"
+            />
+          </svg>
+        </i>
+         First
+      </span>
+    </span>
+  </button>
+  <button
+    className="c7 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      <i
+        className="c4 c5"
+        color="default"
+        name="chevron-left"
+        size={20}
+      >
+        <svg
+          className="c6"
+          color="#333"
+          height={20}
+          viewBox="0 0 20 20"
+          width={20}
+        >
+          <path
+            d="M6 9.659a.524.524 0 0 0 .152.394c.024.024.06.017.086.035l6.618 6.072a.53.53 0 0 0 .748-.749L7.331 9.657l6.274-5.755a.528.528 0 1 0-.748-.747L6.24 9.223c-.028.02-.065.013-.09.038a.522.522 0 0 0-.15.398z"
+          />
+        </svg>
+      </i>
+    </span>
+  </button>
+  <button
+    className="c8 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    selected={false}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      1
+    </span>
+  </button>
+  <button
+    className="c8 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    selected={false}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      2
+    </span>
+  </button>
+  <button
+    className="c9 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    selected={true}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      3
+    </span>
+  </button>
+  <button
+    className="c8 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    selected={false}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      4
+    </span>
+  </button>
+  <button
+    className="c8 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    selected={false}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      5
+    </span>
+  </button>
+  <button
+    className="c7 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      <i
+        className="c4 c5"
+        color="default"
+        name="chevron-right"
+        size={20}
+      >
+        <svg
+          className="c6"
+          color="#333"
+          height={20}
+          viewBox="0 0 20 20"
+          width={20}
+        >
+          <path
+            d="M13.76 9.659a.524.524 0 0 1-.152.394c-.024.024-.06.017-.087.035L6.903 16.16a.53.53 0 0 1-.747-.749l6.273-5.754-6.274-5.755a.528.528 0 1 1 .748-.747l6.616 6.068c.028.02.065.013.09.038.11.109.156.254.15.398z"
+          />
+        </svg>
+      </i>
+    </span>
+  </button>
+  <button
+    className="c10 c2"
+    data-cosmos-key="button"
+    disabled={false}
+    icon={null}
+    onClick={[Function]}
+    size="compressed"
+  >
+    <span
+      className="c3"
+    >
+      <span>
+        Last 
+        <i
+          className="c4 c5"
+          color="default"
+          name="chevron-right"
+          size={20}
+        >
+          <svg
+            className="c6"
+            color="#333"
+            height={20}
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M13.76 9.659a.524.524 0 0 1-.152.394c-.024.024-.06.017-.087.035L6.903 16.16a.53.53 0 0 1-.747-.749l6.273-5.754-6.274-5.755a.528.528 0 1 1 .748-.747l6.616 6.068c.028.02.065.013.09.038.11.109.156.254.15.398z"
+            />
+          </svg>
+        </i>
+      </span>
+    </span>
+  </button>
+</div>
+`;

--- a/test/snapshot/__snapshots__/radio.test.js.snap
+++ b/test/snapshot/__snapshots__/radio.test.js.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Radio renders with automation attribute 1`] = `
+.c0 .c1 {
+  display: table;
+  margin-bottom: 16px;
+}
+
+.c0 .c1:last-child {
+  margin: 0;
+}
+
+.c2 {
+  position: relative;
+  cursor: pointer;
+  padding-left: 24px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+}
+
+.c2 input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.c2 .c3 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  height: 16px;
+  width: 16px;
+  background-color: #FFF;
+  border: 1px solid #BEBEBE;
+  box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.20);
+  border-radius: 50%;
+}
+
+.c2:hover input ~ .c3 {
+  box-shadow: inset 0 1px 4px 0 rgba(0,0,0,0.20);
+}
+
+.c2 input:checked ~ .c3 {
+  background-color: #3B99FC;
+  border: 1px solid #2C90FC;
+}
+
+.c2 .c3:after {
+  content: '';
+  position: absolute;
+  display: none;
+}
+
+.c2 input:checked ~ .c3:after {
+  display: block;
+}
+
+.c2 .c3:after {
+  background-color: #FFF;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px 0 rgba(0,0,0,0.20);
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+<div
+  className="c0"
+  data-cosmos-key="radio"
+  name="cosmos"
+>
+  <label
+    className="c1 c2"
+  >
+    <input
+      checked={false}
+      data-cosmos-key="radio.option"
+      name="cosmos"
+      pepe="test"
+      readOnly={true}
+      type="radio"
+      value="one"
+    />
+    <span
+      className="c3 "
+    />
+    <span
+      className=""
+    >
+      Option
+    </span>
+  </label>
+</div>
+`;

--- a/test/snapshot/__snapshots__/resource-list.test.js.snap
+++ b/test/snapshot/__snapshots__/resource-list.test.js.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResourceList renders with automation attribute 1`] = `
+.c0 {
+  margin: 32px 0;
+  padding: 0;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  border-top: 1px solid #DDD;
+  padding: 16px 8px;
+  cursor: pointer;
+}
+
+.c1:hover {
+  background: #FAFAFA;
+}
+
+.c2 {
+  -webkit-flex-basis: 40%;
+  -ms-flex-preferred-size: 40%;
+  flex-basis: 40%;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 .sc-bxivhb {
+  margin-right: 16px;
+}
+
+.c3 {
+  margin-top: 8px;
+  display: block;
+}
+
+.c4 {
+  font-size: 12px;
+  color: #757575;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.c5 {
+  -webkit-flex-basis: 40%;
+  -ms-flex-preferred-size: 40%;
+  flex-basis: 40%;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  -webkit-flex-basis: 20%;
+  -ms-flex-preferred-size: 20%;
+  flex-basis: 20%;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c7 .cosmos-tooltip {
+  left: 58%;
+}
+
+.c7 .sc-gqjmRU {
+  margin-left: 8px;
+}
+
+<ul
+  className="c0"
+  data-cosmos-key="resource-list"
+>
+  <li
+    className="c1"
+    data-cosmos-key="resource-list.item"
+    onClick={[Function]}
+  >
+    <div
+      className="c2"
+    >
+      <div>
+        Item 1
+        <span
+          className="c3 c4"
+        >
+          Native
+        </span>
+      </div>
+    </div>
+    <div
+      className="c5"
+    />
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+        data-cosmos-key="button-group"
+      />
+    </div>
+  </li>
+</ul>
+`;

--- a/test/snapshot/__snapshots__/select.test.js.snap
+++ b/test/snapshot/__snapshots__/select.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select renders with automation attribute 1`] = `
+.c0 {
+  width: 100%;
+  box-sizing: border-box;
+  background: #FFF;
+  border: 1px solid;
+  border-color: #CCCCCC;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: inherit;
+  color: #555;
+  padding: 10px 16px;
+  cursor: auto;
+  -webkit-transition: border-color 0.25s,box-shadow 0.25s;
+  transition: border-color 0.25s,box-shadow 0.25s;
+  height: 44px;
+}
+
+.c0:hover {
+  border-color: #B7B7B7;
+}
+
+.c0:focus {
+  border-color: #0a84ae;
+  box-shadow: 0px 0px 0 1px #0a84ae;
+  outline: none;
+}
+
+.c0::-webkit-input-placeholder {
+  color: #B2B2B2;
+}
+
+<select
+  className="c0"
+  data-cosmos-key="select"
+  readOnly={false}
+>
+  <option
+    data-cosmos-key="select.option"
+    value={1}
+  >
+    One
+  </option>
+</select>
+`;

--- a/test/snapshot/__snapshots__/sidebar.test.js.snap
+++ b/test/snapshot/__snapshots__/sidebar.test.js.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sidebar renders with automation attribute 1`] = `
+.c0 {
+  float: left;
+  width: 160px;
+}
+
+.c0 .c2 {
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+.c1 {
+  display: block;
+  cursor: pointer;
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1;
+  padding: calc(8px / 2) 0;
+  margin-bottom: 10px;
+}
+
+.c1:hover {
+  color: #FF3E00;
+}
+
+.c1:hover .c2 path {
+  fill: #FF3E00;
+}
+
+.c1 .c2 {
+  margin-right: 8px;
+}
+
+.c1 span {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.c3 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.c4 {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
+}
+
+.c4 path {
+  fill: #333;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="sidebar"
+>
+  <a
+    className="c1"
+    data-cosmos-key="sidebar.link"
+    onClick={[Function]}
+  >
+    <i
+      className="c2 c3"
+      color="default"
+      name="clients"
+      size={18}
+    >
+      <svg
+        className="c4"
+        color="#333"
+        height={18}
+        viewBox="0 0 20 20"
+        width={18}
+      >
+        <path
+          d="M17.654 15.68V4.33a2.22 2.22 0 0 0-2.22-2.22H4.084A3.309 3.309 0 0 1 6.551 1h8.882a3.33 3.33 0 0 1 3.331 3.33v8.883c0 .983-.434 1.857-1.11 2.467zM13.213 3.22a3.331 3.331 0 0 1 3.33 3.331v8.883a3.33 3.33 0 0 1-3.33 3.33H4.33A3.33 3.33 0 0 1 1 15.435V6.552A3.33 3.33 0 0 1 4.33 3.22h8.883zM2.11 15.435a2.22 2.22 0 0 0 2.22 2.22h8.883a2.22 2.22 0 0 0 2.22-2.22V8.772H2.11v6.662zm0-8.883v1.11h13.323v-1.11a2.22 2.22 0 0 0-2.22-2.22H4.33a2.22 2.22 0 0 0-2.22 2.22zm8.882 0H3.22v-1.11h7.772v1.11zm2.22 0h-1.11v-1.11h1.11v1.11z"
+        />
+      </svg>
+    </i>
+    <span>
+      Clients
+    </span>
+  </a>
+</div>
+`;

--- a/test/snapshot/__snapshots__/stack.test.js.snap
+++ b/test/snapshot/__snapshots__/stack.test.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stack renders with automation attribute 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c0 > * {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  margin-right: 8px;
+}
+
+.c0 > *:last-child {
+  margin-right: 0;
+}
+
+.c1 {
+  -webkit-flex-basis: 0%;
+  -ms-flex-preferred-size: 0%;
+  flex-basis: 0%;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="stack"
+>
+  <div
+    className="c1"
+    data-cosmos-key="stack.item"
+    width={0}
+  >
+    <div>
+      element
+    </div>
+  </div>
+</div>
+`;

--- a/test/snapshot/__snapshots__/switch.test.js.snap
+++ b/test/snapshot/__snapshots__/switch.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Switch renders with automation attribute 1`] = `
+.c0 {
+  display: inline-block;
+  vertical-align: middle;
+  height: 32px;
+  position: relative;
+}
+
+.c1 {
+  width: 0;
+  opacity: 0;
+  position: absolute;
+}
+
+.c2 {
+  display: inline-block;
+  width: 55px;
+  height: 32px;
+  border-radius: 21px;
+  background: #D9D9D9;
+  cursor: pointer;
+  position: relative;
+}
+
+.c2:before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  height: 24px;
+  width: 24px;
+  border-radius: 24px;
+  background: #FFF;
+  box-shadow: 0 0 1px 0 rgba(0,0,0,0.25),0 4px 11px 0 rgba(0,0,0,0.08), -1px 3px 3px 0 rgba(0,0,0,0.14);
+  -webkit-transition: -webkit-transform 0.25s ease,width 0.25s, left 0.25s;
+  -webkit-transition: transform 0.25s ease,width 0.25s, left 0.25s;
+  transition: transform 0.25s ease,width 0.25s, left 0.25s;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+}
+
+.c2:active:before {
+  width: 30px;
+  left: 6px;
+}
+
+.c3 {
+  vertical-align: top;
+  line-height: 32px;
+  font-size: 13px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #757575;
+  padding-left: 16px;
+}
+
+<span
+  className="c0"
+  data-cosmos-key="switch"
+  onClick={[Function]}
+>
+  <input
+    checked={false}
+    className="c1"
+    readOnly={true}
+    type="checkbox"
+  />
+  <span
+    className="c2"
+    readOnly={false}
+  />
+  <label
+    className="c3"
+  >
+    Disabled
+  </label>
+</span>
+`;

--- a/test/snapshot/__snapshots__/table.test.js.snap
+++ b/test/snapshot/__snapshots__/table.test.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table renders with automation attribute 1`] = `
+.c0 {
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.c1 {
+  padding: 8px;
+  border-bottom: 2px solid #D9D9D9;
+  text-align: left;
+  vertical-align: bottom;
+  line-height: 2;
+  cursor: auto;
+}
+
+.c1:hover {
+  color: inherit;
+}
+
+.c2 {
+  padding-left: 8px;
+  visibility: hidden;
+}
+
+.c3 {
+  cursor: inherit;
+}
+
+.c3:hover {
+  background: #FAFAFA;
+}
+
+.c4 {
+  padding: 8px;
+  border-top: 1px solid #D9D9D9;
+  text-align: left;
+  vertical-align: middle;
+  line-height: 2;
+  width: 30%;
+}
+
+<table
+  className="c0"
+  data-cosmos-key="table"
+>
+  <thead
+    className=""
+    data-cosmos-key="table.header"
+  >
+    <tr
+      className=""
+    >
+      <th
+        className="c1"
+        onClick={[Function]}
+      >
+        Name
+        <span
+          className="c2"
+          display={false}
+        >
+          ↑
+        </span>
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    className=""
+    data-cosmos-key="table.body"
+  >
+    <tr
+      className="c3"
+      data-cosmos-key="table.row"
+      onClick={null}
+    >
+      <td
+        className="c4"
+      >
+        john
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/test/snapshot/__snapshots__/tabs.test.js.snap
+++ b/test/snapshot/__snapshots__/tabs.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tabs renders with automation attribute 1`] = `
+.c0 {
+  border-bottom: 1px solid #D9D9D9;
+}
+
+.c0 .c1:last-child {
+  margin-right: 0;
+}
+
+.c2 {
+  display: inline-block;
+  padding: 16px 0;
+  margin-right: 32px;
+  color: #0a84ae;
+  cursor: pointer;
+  border-bottom: 1px solid transparent;
+  margin-bottom: -1px;
+}
+
+.c2:hover {
+  color: #053b4e;
+}
+
+<div
+  className=""
+  data-cosmos-key="tabs"
+>
+  <div
+    className="c0"
+  >
+    <a
+      className="c1 c2"
+      data-cosmos-key="tabs.item"
+      onClick={[Function]}
+      selected={false}
+    >
+      Tab 1
+    </a>
+  </div>
+</div>
+`;

--- a/test/snapshot/__snapshots__/tag.test.js.snap
+++ b/test/snapshot/__snapshots__/tag.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tag renders with automation attribute group of Tags 1`] = `
+.c0 .c1 {
+  margin-right: 8px;
+}
+
+.c0 .c1:last-child {
+  margin-right: 0;
+}
+
+<div
+  className="c0"
+  data-cosmos-key="tag.group"
+/>
+`;
+
+exports[`Tag renders with automation attribute single Tag 1`] = `
+.c0 {
+  display: inline-block;
+  font-size: 13px;
+  color: #3BC0F2;
+  line-height: 1;
+  padding: 4px 8px;
+  background: #DBF4FD;
+  border: 1px solid #3BC0F2;
+  border-radius: 3px;
+  cursor: inherit;
+}
+
+.c0 .sc-bwzfXH {
+  cursor: pointer;
+  stroke: #3BC0F2;
+  margin-left: 8px;
+}
+
+<span
+  className="c0"
+  data-cosmos-key="tag"
+/>
+`;

--- a/test/snapshot/__snapshots__/text-area.test.js.snap
+++ b/test/snapshot/__snapshots__/text-area.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextArea renders with automation attribute 1`] = `
+.c0 {
+  width: 100%;
+  box-sizing: border-box;
+  background: #FFF;
+  border: 1px solid;
+  border-color: #CCCCCC;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: inherit;
+  color: #555;
+  padding: 10px 16px;
+  cursor: auto;
+  -webkit-transition: border-color 0.25s,box-shadow 0.25s;
+  transition: border-color 0.25s,box-shadow 0.25s;
+  resize: vertical;
+  font-size: inherit;
+}
+
+.c0:hover {
+  border-color: #B7B7B7;
+}
+
+.c0:focus {
+  border-color: #0a84ae;
+  box-shadow: 0px 0px 0 1px #0a84ae;
+  outline: none;
+}
+
+.c0::-webkit-input-placeholder {
+  color: #B2B2B2;
+}
+
+<textarea
+  className="c0"
+  data-cosmos-key="text-area"
+  onChange={null}
+  readOnly={false}
+  rows={3}
+/>
+`;

--- a/test/snapshot/__snapshots__/text-input.test.js.snap
+++ b/test/snapshot/__snapshots__/text-input.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextInput renders with automation attribute 1`] = `
+.c0 {
+  width: 100%;
+  box-sizing: border-box;
+  background: #FFF;
+  border: 1px solid;
+  border-color: #CCCCCC;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: inherit;
+  color: #555;
+  padding: 10px 16px;
+  cursor: auto;
+  -webkit-transition: border-color 0.25s,box-shadow 0.25s;
+  transition: border-color 0.25s,box-shadow 0.25s;
+  height: 44px;
+}
+
+.c0:hover {
+  border-color: #B7B7B7;
+}
+
+.c0:focus {
+  border-color: #0a84ae;
+  box-shadow: 0px 0px 0 1px #0a84ae;
+  outline: none;
+}
+
+.c0::-webkit-input-placeholder {
+  color: #B2B2B2;
+}
+
+<input
+  className="c0"
+  data-cosmos-key="text-input"
+  onChange={null}
+  readOnly={false}
+  size="default"
+  type="text"
+/>
+`;

--- a/test/snapshot/alert.test.js
+++ b/test/snapshot/alert.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Alert } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Alert', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<Alert dismissible>Text</Alert>).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/breadcrumb.test.js
+++ b/test/snapshot/breadcrumb.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Breadcrumb } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Breadcrumb', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <Breadcrumb>
+          <Breadcrumb.Link href="/home">Home</Breadcrumb.Link>
+        </Breadcrumb>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/button-group.test.js
+++ b/test/snapshot/button-group.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { ButtonGroup } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('ButtonGroup', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<ButtonGroup />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/button.test.js
+++ b/test/snapshot/button.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Button } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Button', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<Button />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/checkbox.test.js
+++ b/test/snapshot/checkbox.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Checkbox } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Checkbox', () => {
+  describe('renders with automation attribute', () => {
+    it('single checkbox', () => {
+      const tree = renderer.create(<Checkbox name="cosmos" />).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('group of checkboxs', () => {
+      const tree = renderer.create(<Checkbox.Group name="cosmos" />).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+  })
+})

--- a/test/snapshot/form-group.test.js
+++ b/test/snapshot/form-group.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { FormGroup } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('FormGroup', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<FormGroup />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/list.test.js
+++ b/test/snapshot/list.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { List } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('List', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <List>
+          <div>element</div>
+        </List>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/page-header.test.js
+++ b/test/snapshot/page-header.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { PageHeader } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('PageHeader', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<PageHeader description="description" />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/pager.test.js
+++ b/test/snapshot/pager.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Pager } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Pager', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<Pager page={3} perPage={10} items={20372} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/pagination-toolbar.test.js
+++ b/test/snapshot/pagination-toolbar.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { PaginationToolbar } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('PaginationToolbar', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<PaginationToolbar page={3} perPage={10} items={20372} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/pagination.test.js
+++ b/test/snapshot/pagination.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Pagination } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Pagination', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<Pagination page={3} perPage={10} items={20372} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/radio.test.js
+++ b/test/snapshot/radio.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Radio } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Radio', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <Radio name="cosmos">
+          <Radio.Option value="one">Option</Radio.Option>
+        </Radio>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/resource-list.test.js
+++ b/test/snapshot/resource-list.test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { ResourceList } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('ResourceList', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <ResourceList
+          items={[
+            {
+              title: 'Item 1',
+              subtitle: 'Native'
+            }
+          ]}
+          actions={[]}
+          onItemClick={() => {}}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/select.test.js
+++ b/test/snapshot/select.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Select } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Select', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<Select options={[{ text: 'One', value: 1 }]} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/sidebar.test.js
+++ b/test/snapshot/sidebar.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Sidebar } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Sidebar', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <Sidebar>
+          <Sidebar.Link icon="clients" label="Clients" onClick={() => {}} />
+        </Sidebar>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/stack.test.js
+++ b/test/snapshot/stack.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Stack } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Stack', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <Stack>
+          <div>element</div>
+        </Stack>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/switch.test.js
+++ b/test/snapshot/switch.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Switch } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Switch', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<Switch />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/table.test.js
+++ b/test/snapshot/table.test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Table } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Table', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <Table
+          items={[
+            {
+              name: 'john'
+            }
+          ]}
+        >
+          <Table.Column field="name" title="Name" width="30%" />
+        </Table>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/tabs.test.js
+++ b/test/snapshot/tabs.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Tabs } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Tabs', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer
+      .create(
+        <Tabs onSelect={() => {}} selected={1}>
+          <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
+        </Tabs>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/tag.test.js
+++ b/test/snapshot/tag.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { Tag } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('Tag', () => {
+  describe('renders with automation attribute', () => {
+    it('single Tag', () => {
+      const tree = renderer.create(<Tag />).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('group of Tags', () => {
+      const tree = renderer.create(<Tag.Group />).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+  })
+})

--- a/test/snapshot/text-area.test.js
+++ b/test/snapshot/text-area.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { TextArea } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('TextArea', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<TextArea />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/snapshot/text-input.test.js
+++ b/test/snapshot/text-input.test.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { TextInput } from '@auth0/cosmos'
+import 'jest-styled-components'
+
+describe('TextInput', () => {
+  it('renders with automation attribute', () => {
+    const tree = renderer.create(<TextInput />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/unit/automation-attributes.test.js
+++ b/test/unit/automation-attributes.test.js
@@ -1,0 +1,302 @@
+import React from 'react'
+import Enzyme, { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import {
+  Alert,
+  Breadcrumb,
+  Button,
+  Checkbox,
+  Radio,
+  Select,
+  Switch,
+  Tag,
+  TextInput,
+  TextArea,
+  ButtonGroup,
+  Dialog,
+  EmptyState,
+  FormGroup,
+  Form,
+  List,
+  PageHeader,
+  Pager,
+  PaginationToolbar,
+  Pagination,
+  ResourceList,
+  Sidebar,
+  Stack,
+  Table,
+  Tabs
+} from '@auth0/cosmos'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+describe('Automation data attributes', () => {
+  it('Alert', () => {
+    const alert = shallow(<Alert dismissible>Text</Alert>)
+
+    expect(alert.prop('data-cosmos-key')).toEqual('alert')
+    expect(
+      alert
+        .children()
+        .last()
+        .prop('data-cosmos-key')
+    ).toEqual('alert.dismiss')
+  })
+
+  it('Breadcrumb', () => {
+    const breadcrumb = shallow(<Breadcrumb />)
+
+    expect(breadcrumb.prop('data-cosmos-key')).toEqual('breadcrumb')
+  })
+
+  it('Button', () => {
+    const button = shallow(<Button />)
+
+    expect(button.prop('data-cosmos-key')).toEqual('button')
+  })
+
+  describe('Checkbox', () => {
+    it('single element', () => {
+      const checkbox = shallow(<Checkbox name="cosmos" />)
+
+      expect(checkbox.prop('data-cosmos-key')).toEqual('checkbox')
+    })
+
+    it('group of elements', () => {
+      const checkbox = shallow(<Checkbox.Group name="cosmos" />)
+
+      expect(checkbox.prop('data-cosmos-key')).toEqual('checkbox.group')
+    })
+  })
+
+  it('Radio', () => {
+    const radio = shallow(
+      <Radio name="cosmos">
+        <Radio.Option value="one">Option</Radio.Option>
+      </Radio>
+    )
+
+    expect(radio.prop('data-cosmos-key')).toEqual('radio')
+  })
+
+  it('Select', () => {
+    const select = shallow(<Select options={[{ text: 'One', value: 1 }]} />)
+
+    expect(select.prop('data-cosmos-key')).toEqual('select')
+    expect(select.children().prop('data-cosmos-key')).toEqual('select.option')
+  })
+
+  it('Switch', () => {
+    const cSwitch = shallow(<Switch />)
+
+    expect(cSwitch.prop('data-cosmos-key')).toEqual('switch')
+  })
+
+  describe('Tag', () => {
+    it('single element', () => {
+      const tag = shallow(<Tag>Tag</Tag>)
+
+      expect(tag.prop('data-cosmos-key')).toEqual('tag')
+    })
+
+    it('group of elements', () => {
+      const tagGroup = shallow(
+        <Tag.Group>
+          <Tag>One</Tag>
+        </Tag.Group>
+      )
+
+      expect(tagGroup.prop('data-cosmos-key')).toEqual('tag.group')
+    })
+  })
+
+  it('TextInput', () => {
+    const textInput = shallow(<TextInput />)
+
+    expect(textInput.prop('data-cosmos-key')).toEqual('text-input')
+  })
+
+  it('TextArea', () => {
+    const textArea = shallow(<TextArea />)
+
+    expect(textArea.prop('data-cosmos-key')).toEqual('text-area')
+  })
+
+  it('ButtonGroup', () => {
+    const buttonGroup = shallow(<ButtonGroup />)
+
+    expect(buttonGroup.prop('data-cosmos-key')).toEqual('button-group')
+  })
+
+  it('Dialog', () => {
+    const dialog = shallow(<Dialog open actions={[]} title="Dialog" onClose={() => {}} />)
+
+    expect(dialog.children().prop('data-cosmos-key')).toEqual('dialog')
+    expect(
+      dialog
+        .children()
+        .first()
+        .childAt(0)
+        .prop('data-cosmos-key')
+    ).toEqual('dialog.title')
+    expect(
+      dialog
+        .children()
+        .first()
+        .childAt(1)
+        .prop('data-cosmos-key')
+    ).toEqual('dialog.body')
+    expect(
+      dialog
+        .children()
+        .first()
+        .childAt(2)
+        .prop('data-cosmos-key')
+    ).toEqual('dialog.footer')
+  })
+
+  it('EmptyState', () => {
+    const emptyState = shallow(
+      <EmptyState
+        title="state"
+        icon="analytics"
+        action={{
+          icon: 'plus',
+          label: 'Create Client',
+          handler: function() {}
+        }}
+      />
+    )
+
+    expect(emptyState.prop('data-cosmos-key')).toEqual('empty-state')
+  })
+
+  it('FormGroup', () => {
+    const formGroup = shallow(<FormGroup />)
+
+    expect(formGroup.prop('data-cosmos-key')).toEqual('form-group')
+  })
+
+  it('Form', () => {
+    const form = shallow(
+      <Form layout="label-on-left">
+        <Form.FieldSet label="Fieldset Label" />
+      </Form>
+    )
+
+    expect(form.children().prop('data-cosmos-key')).toEqual('form')
+  })
+
+  it('List', () => {
+    const list = shallow(
+      <List>
+        <div>element</div>
+      </List>
+    )
+
+    expect(list.prop('data-cosmos-key')).toEqual('list')
+    expect(list.children().prop('data-cosmos-key')).toEqual('list.item')
+  })
+
+  it('PageHeader', () => {
+    const pageHeader = shallow(<PageHeader description="description" />)
+
+    expect(pageHeader.prop('data-cosmos-key')).toEqual('page-header')
+  })
+
+  it('Pager', () => {
+    const pager = shallow(<Pager page={3} perPage={10} items={20372} />)
+
+    expect(pager.prop('data-cosmos-key')).toEqual('pager')
+  })
+
+  it('PaginationToolbar', () => {
+    const paginationToolbar = shallow(<PaginationToolbar page={3} perPage={10} items={20372} />)
+
+    expect(paginationToolbar.prop('data-cosmos-key')).toEqual('pagination-toolbar')
+  })
+
+  it('Pagination', () => {
+    const pagination = shallow(<Pagination page={3} perPage={10} items={20372} />)
+
+    expect(pagination.prop('data-cosmos-key')).toEqual('pagination')
+  })
+
+  it('ResourceList', () => {
+    const resourceList = shallow(
+      <ResourceList
+        items={[
+          {
+            title: 'Item 1',
+            subtitle: 'Native'
+          }
+        ]}
+        actions={[]}
+        onItemClick={() => {}}
+      />
+    )
+
+    expect(resourceList.prop('data-cosmos-key')).toEqual('resource-list')
+  })
+
+  it('Sidebar', () => {
+    const sidebar = shallow(
+      <Sidebar>
+        <Sidebar.Link icon="clients" label="Clients" onClick={() => {}} />
+      </Sidebar>
+    )
+
+    expect(sidebar.prop('data-cosmos-key')).toEqual('sidebar')
+  })
+
+  it('Stack', () => {
+    const stack = shallow(
+      <Stack>
+        <div>element</div>
+      </Stack>
+    )
+
+    expect(stack.prop('data-cosmos-key')).toEqual('stack')
+    expect(stack.children().prop('data-cosmos-key')).toEqual('stack.item')
+  })
+
+  it('Table', () => {
+    const table = shallow(
+      <Table
+        items={[
+          {
+            name: 'john'
+          }
+        ]}
+      >
+        <Table.Column field="name" title="Name" width="30%" />
+      </Table>
+    )
+
+    expect(table.prop('data-cosmos-key')).toEqual('table')
+    expect(table.childAt(1).prop('data-cosmos-key')).toEqual('table.body')
+    expect(
+      table
+        .childAt(1)
+        .children()
+        .prop('data-cosmos-key')
+    ).toEqual('table.row')
+  })
+
+  it('Tabs', () => {
+    const tabs = shallow(
+      <Tabs onSelect={() => {}} selected={1}>
+        <Tabs.Tab label="Tab 1">This is tab 1</Tabs.Tab>
+      </Tabs>
+    )
+
+    expect(tabs.prop('data-cosmos-key')).toEqual('tabs')
+    expect(
+      tabs
+        .children()
+        .children()
+        .prop('data-cosmos-key')
+    ).toEqual('tabs.item')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,12 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.42"
 
+"@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz#12b6daeb408238360744649d16c0e9fa7ab3859e"
+  dependencies:
+    "@babel/highlight" "7.0.0-rc.2"
+
 "@babel/helper-module-imports@7.0.0-beta.40":
   version "7.0.0-beta.40"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.40.tgz#251cbb6404599282e8f7356a5b32c9381bef5d2d"
@@ -22,6 +28,14 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+"@babel/highlight@7.0.0-rc.2":
+  version "7.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-rc.2.tgz#0af688a69e3709d9cf392e1837cda18c08d34d4f"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
 
 "@babel/types@7.0.0-beta.40":
   version "7.0.0-beta.40"
@@ -352,6 +366,10 @@
     react-lifecycles-compat "^3.0.4"
     react-modal "^3.4.5"
 
+"@types/node@*":
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.1.tgz#06f002136fbcf51e730995149050bb3c45ee54e6"
+
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.13.tgz#81155a570bd5803a30ec31436bc2c9c0ede38f25"
@@ -584,9 +602,21 @@ ajv@^6.1.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.1"
 
+align-text@^0.1.1, align-text@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
+  dependencies:
+    kind-of "^3.0.2"
+    longest "^1.0.1"
+    repeat-string "^1.5.2"
+
 alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
+
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
 ansi-align@^2.0.0:
   version "2.0.0"
@@ -663,6 +693,12 @@ app-root-dir@^1.0.2:
 app-root-path@^2.0.1:
   version "2.1.0"
   resolved "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz#98bf6599327ecea199309866e8140368fd2e646a"
+
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  dependencies:
+    default-require-extensions "^2.0.0"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -826,6 +862,10 @@ ast-types@0.11.5:
   version "0.11.5"
   resolved "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz#9890825d660c03c28339f315e9fa0a360e31ec28"
 
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -834,7 +874,7 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
-async@^1.5.2:
+async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -918,7 +958,7 @@ babel-code-frame@6.26.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@6.26.3, babel-core@^6.26.0:
+babel-core@6.26.3, babel-core@^6.0.0, babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:
@@ -942,7 +982,7 @@ babel-core@6.26.3, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-generator@^6.26.0:
+babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
   dependencies:
@@ -1109,6 +1149,13 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-jest@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
+
 babel-loader@7.1.4, babel-loader@^7.1.4:
   version "7.1.4"
   resolved "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz#e3463938bd4e6d55d1c174c5485d406a188ed015"
@@ -1145,6 +1192,19 @@ babel-plugin-emotion@^9.2.4:
     mkdirp "^0.5.1"
     source-map "^0.5.7"
     touch "^1.0.0"
+
+babel-plugin-istanbul@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.2.2:
   version "2.2.2"
@@ -1273,7 +1333,7 @@ babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-s
   version "6.18.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -1708,6 +1768,13 @@ babel-preset-flow@^6.23.0:
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
 babel-preset-minify@0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.1.tgz#40e3edad743bb107dd63c7cfb21c604dccd83674"
@@ -1801,7 +1868,7 @@ babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -1811,7 +1878,7 @@ babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -1825,7 +1892,7 @@ babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1984,6 +2051,12 @@ browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
 
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  dependencies:
+    resolve "1.1.7"
+
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
@@ -2056,6 +2129,12 @@ browserslist@^3.2.6, browserslist@^3.2.8:
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
+
+bser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
+  dependencies:
+    node-int64 "^0.4.0"
 
 buble@^0.19.3:
   version "0.19.3"
@@ -2157,6 +2236,10 @@ call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
 
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+
 camel-case@3.0.x:
   version "3.0.0"
   resolved "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -2170,6 +2253,10 @@ camelcase-keys@^2.0.0:
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
+
+camelcase@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
 camelcase@^2.0.0:
   version "2.1.1"
@@ -2200,6 +2287,12 @@ caniuse-lite@^1.0.30000815, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.300008
   version "1.0.30000864"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000864.tgz#7a08c78da670f23c06f11aa918831b8f2dd60ddc"
 
+capture-exit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
+  dependencies:
+    rsvp "^3.3.3"
+
 case-sensitive-paths-webpack-plugin@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz#c899b52175763689224571dad778742e133f0192"
@@ -2207,6 +2300,13 @@ case-sensitive-paths-webpack-plugin@^2.1.2:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+center-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
+  dependencies:
+    align-text "^0.1.3"
+    lazy-cache "^1.0.3"
 
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -2258,6 +2358,17 @@ chardet@^0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz#fe3ac73c00c3d865ffcc02a0682e2c20b6a06029"
 
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@2.0.4, chokidar@^2.0.0, chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
@@ -2301,6 +2412,10 @@ chrome-trace-event@^1.0.0:
   resolved "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48"
   dependencies:
     tslib "^1.9.0"
+
+ci-info@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.4.0.tgz#4841d53cad49f11b827b648ebde27a6e189b412f"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -2383,6 +2498,14 @@ clipboardy@1.2.3:
   dependencies:
     arch "^2.1.0"
     execa "^0.8.0"
+
+cliui@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+  dependencies:
+    center-align "^0.1.1"
+    right-align "^0.1.1"
+    wordwrap "0.0.2"
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -2473,6 +2596,10 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
+
 colors@^1.1.2:
   version "1.3.0"
   resolved "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz#5f20c9fef6945cb1134260aab33bfbdc8295e04e"
@@ -2506,6 +2633,10 @@ common-tags@^1.4.0, common-tags@^1.8.0:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+compare-versions@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.1.tgz#1ede3172b713c15f7c7beb98cb74d2d82576dad3"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -2597,7 +2728,7 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -2828,7 +2959,7 @@ css-select-base-adapter@~0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz#0102b3d14630df86c3eb9fa9f5456270106cf990"
 
-css-select@^1.1.0:
+css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -2883,6 +3014,15 @@ css-url-regex@^1.1.0:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+css@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.5.1"
+    urix "^0.1.0"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -3008,7 +3148,7 @@ debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -3037,6 +3177,12 @@ deep-extend@^0.6.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
+  dependencies:
+    strip-bom "^3.0.0"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -3130,6 +3276,10 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
 detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
@@ -3148,6 +3298,10 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
+diff@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -3162,6 +3316,10 @@ dir-glob@^2.0.0:
   dependencies:
     arrify "^1.0.1"
     path-type "^3.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -3203,7 +3361,7 @@ dom-iterator@^1.0.0:
     component-props "1.1.1"
     component-xor "0.0.4"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -3397,6 +3555,49 @@ env-ci@^1.5.0:
     execa "^0.10.0"
     java-properties "^0.2.9"
 
+enzyme-adapter-react-16@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.2.0.tgz#c6e80f334e0a817873262d7d01ee9e4747e3c97e"
+  dependencies:
+    enzyme-adapter-utils "^1.5.0"
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.2"
+    react-is "^16.4.2"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.5.0.tgz#a020ab3ae79bb1c85e1d51f48f35e995e0eed810"
+  dependencies:
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    prop-types "^15.6.2"
+
+enzyme@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.4.4.tgz#92c7c6b9e59d4ef0c3d36a75dccc0e41a5c14d21"
+  dependencies:
+    array.prototype.flat "^1.2.1"
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.1.0"
+    has "^1.0.3"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.4"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
+    is-subset "^0.1.1"
+    lodash "^4.17.4"
+    object-inspect "^1.6.0"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    raf "^3.4.0"
+    rst-selector-parser "^2.2.3"
+
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -3562,6 +3763,12 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+exec-sh@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
+  dependencies:
+    merge "^1.2.0"
+
 execa@0.10.0, execa@^0.10.0:
   version "0.10.0"
   resolved "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
@@ -3618,6 +3825,10 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -3647,6 +3858,17 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   resolved "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
   dependencies:
     homedir-polyfill "^1.0.1"
+
+expect@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.5.0.tgz#18999a0eef8f8acf99023fde766d9c323c2562ed"
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^23.5.0"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
 
 express@^4.16.2, express@^4.16.3:
   version "4.16.3"
@@ -3792,6 +4014,12 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fb-watchman@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
+  dependencies:
+    bser "^2.0.0"
+
 fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
@@ -3831,6 +4059,13 @@ file-type@^3.6.0:
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+
+fileset@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
+  dependencies:
+    glob "^7.0.3"
+    minimatch "^3.0.3"
 
 filesize@3.5.11:
   version "3.5.11"
@@ -4015,7 +4250,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0, fsevents@^1.2.2:
+fsevents@^1.0.0, fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
@@ -4131,7 +4366,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -4240,6 +4475,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
 gzip-size@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
@@ -4256,6 +4495,16 @@ gzip-size@4.1.0:
 handle-thing@^1.2.5:
   version "1.2.5"
   resolved "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
+
+handlebars@^4.0.3:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -4335,7 +4584,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
@@ -4453,7 +4702,7 @@ html-webpack-plugin@^3.2.0:
     toposort "^1.0.0"
     util.promisify "1.0.0"
 
-htmlparser2@3.9.2:
+htmlparser2@3.9.2, htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -4755,6 +5004,10 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -4765,9 +5018,15 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.1, is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
+is-ci@^1.0.10:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.0.tgz#3f4a08d6303a09882cef3f0fb97439c5f5ce2d53"
+  dependencies:
+    ci-info "^1.3.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -4853,6 +5112,10 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-generator-fn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -4870,6 +5133,10 @@ is-glob@^4.0.0:
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -4961,6 +5228,14 @@ is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+
 is-svg@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
@@ -5020,6 +5295,70 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
+istanbul-api@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
+  dependencies:
+    async "^2.1.4"
+    compare-versions "^3.1.0"
+    fileset "^2.0.2"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-hook "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-report "^1.1.4"
+    istanbul-lib-source-maps "^1.2.4"
+    istanbul-reports "^1.3.0"
+    js-yaml "^3.7.0"
+    mkdirp "^0.5.1"
+    once "^1.4.0"
+
+istanbul-lib-coverage@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
+
+istanbul-lib-hook@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz#f614ec45287b2a8fc4f07f5660af787575601805"
+  dependencies:
+    append-transform "^1.0.0"
+
+istanbul-lib-instrument@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.2.0"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
+  dependencies:
+    istanbul-lib-coverage "^1.2.0"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
+istanbul-lib-source-maps@^1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.2.0"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
+  dependencies:
+    handlebars "^4.0.3"
+
 isurl@^1.0.0-alpha5:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
@@ -5031,9 +5370,271 @@ java-properties@^0.2.9:
   version "0.2.10"
   resolved "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz#2551560c25fa1ad94d998218178f233ad9b18f60"
 
+jest-changed-files@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
+  dependencies:
+    throat "^4.0.0"
+
+jest-cli@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.5.0.tgz#d316b8e34a38a610a1efc4f0403d8ef8a55e4492"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    import-local "^1.0.0"
+    is-ci "^1.0.10"
+    istanbul-api "^1.3.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-source-maps "^1.2.4"
+    jest-changed-files "^23.4.2"
+    jest-config "^23.5.0"
+    jest-environment-jsdom "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve-dependencies "^23.5.0"
+    jest-runner "^23.5.0"
+    jest-runtime "^23.5.0"
+    jest-snapshot "^23.5.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.5.0"
+    jest-watcher "^23.4.0"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    node-notifier "^5.2.1"
+    prompts "^0.1.9"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    yargs "^11.0.0"
+
+jest-config@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.5.0.tgz#3770fba03f7507ee15f3b8867c742e48f31a9773"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^23.4.2"
+    chalk "^2.0.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^23.4.0"
+    jest-environment-node "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.5.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.5.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.5.0"
+    micromatch "^2.3.11"
+    pretty-format "^23.5.0"
+
+jest-diff@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.5.0.tgz#250651a433dd0050290a07642946cc9baaf06fba"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.5.0"
+
+jest-docblock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
+  dependencies:
+    detect-newline "^2.1.0"
+
+jest-each@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.5.0.tgz#77f7e2afe6132a80954b920006e78239862b10ba"
+  dependencies:
+    chalk "^2.0.1"
+    pretty-format "^23.5.0"
+
+jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+    jsdom "^11.5.1"
+
+jest-environment-node@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+
+jest-haste-map@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.5.0.tgz#d4ca618188bd38caa6cb20349ce6610e194a8065"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    invariant "^2.2.4"
+    jest-docblock "^23.2.0"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+
+jest-jasmine2@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz#05fe7f1788e650eeb5a03929e6461ea2e9f3db53"
+  dependencies:
+    babel-traverse "^6.0.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^23.5.0"
+    is-generator-fn "^1.0.0"
+    jest-diff "^23.5.0"
+    jest-each "^23.5.0"
+    jest-matcher-utils "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-snapshot "^23.5.0"
+    jest-util "^23.4.0"
+    pretty-format "^23.5.0"
+
+jest-leak-detector@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.5.0.tgz#14ac2a785bd625160a2ea968fd5d98b7dcea3e64"
+  dependencies:
+    pretty-format "^23.5.0"
+
+jest-matcher-utils@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz#0e2ea67744cab78c9ab15011c4d888bdd3e49e2a"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.5.0"
+
+jest-message-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
+
+jest-mock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
+
+jest-regex-util@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
+
+jest-resolve-dependencies@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.5.0.tgz#10c4d135beb9d2256de1fedc7094916c3ad74af7"
+  dependencies:
+    jest-regex-util "^23.3.0"
+    jest-snapshot "^23.5.0"
+
+jest-resolve@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.5.0.tgz#3b8e7f67e84598f0caf63d1530bd8534a189d0e6"
+  dependencies:
+    browser-resolve "^1.11.3"
+    chalk "^2.0.1"
+    realpath-native "^1.0.0"
+
+jest-runner@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.5.0.tgz#570f7a044da91648b5bb9b6baacdd511076c71d7"
+  dependencies:
+    exit "^0.1.2"
+    graceful-fs "^4.1.11"
+    jest-config "^23.5.0"
+    jest-docblock "^23.2.0"
+    jest-haste-map "^23.5.0"
+    jest-jasmine2 "^23.5.0"
+    jest-leak-detector "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-runtime "^23.5.0"
+    jest-util "^23.4.0"
+    jest-worker "^23.2.0"
+    source-map-support "^0.5.6"
+    throat "^4.0.0"
+
+jest-runtime@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.5.0.tgz#eb503525a196dc32f2f9974e3482d26bdf7b63ce"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-plugin-istanbul "^4.1.6"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-config "^23.5.0"
+    jest-haste-map "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.5.0"
+    jest-snapshot "^23.5.0"
+    jest-util "^23.4.0"
+    jest-validate "^23.5.0"
+    micromatch "^2.3.11"
+    realpath-native "^1.0.0"
+    slash "^1.0.0"
+    strip-bom "3.0.0"
+    write-file-atomic "^2.1.0"
+    yargs "^11.0.0"
+
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
+
+jest-snapshot@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.5.0.tgz#cc368ebd8513e1175e2a7277f37a801b7358ae79"
+  dependencies:
+    babel-types "^6.0.0"
+    chalk "^2.0.1"
+    jest-diff "^23.5.0"
+    jest-matcher-utils "^23.5.0"
+    jest-message-util "^23.4.0"
+    jest-resolve "^23.5.0"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^23.5.0"
+    semver "^5.5.0"
+
+jest-styled-components@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.1.1.tgz#2b9b6e3ded212b43ea71df72e82d55b856e9d1ed"
+  dependencies:
+    css "^2.2.1"
+
+jest-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^23.4.0"
+    mkdirp "^0.5.1"
+    slash "^1.0.0"
+    source-map "^0.6.0"
 
 jest-validate@^23.0.0:
   version "23.3.0"
@@ -5043,6 +5644,36 @@ jest-validate@^23.0.0:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^23.2.0"
+
+jest-validate@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.5.0.tgz#f5df8f761cf43155e1b2e21d6e9de8a2852d0231"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    leven "^2.1.0"
+    pretty-format "^23.5.0"
+
+jest-watcher@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
+  dependencies:
+    merge-stream "^1.0.1"
+
+jest@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.5.0.tgz#80de353d156ea5ea4a7332f7962ac79135fbc62e"
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^23.5.0"
 
 js-base64@^2.1.9:
   version "2.4.5"
@@ -5061,7 +5692,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.9.0:
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -5236,11 +5871,19 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+kleur@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.1.tgz#7cc64b0d188d0dcbc98bdcdfdda2cc10619ddce8"
+
 latest-version@4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/latest-version/-/latest-version-4.0.0.tgz#9542393ac55a585861a4c4ebc02389a0b4a9c332"
   dependencies:
     package-json "^5.0.0"
+
+lazy-cache@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -5489,7 +6132,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.10"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5530,6 +6173,10 @@ long@4.0.0:
 long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+
+longest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
@@ -5584,6 +6231,12 @@ make-dir@^1.0.0:
 make-error@^1.3.4:
   version "1.3.4"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
+
+makeerror@1.0.x:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  dependencies:
+    tmpl "1.0.x"
 
 mamacro@^0.0.3:
   version "0.0.3"
@@ -5673,15 +6326,25 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
+    readable-stream "^2.0.1"
+
 merge2@^1.2.1:
   version "1.2.2"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz#03212e3da8d86c4d8523cebd6318193414f94e34"
+
+merge@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5, micromatch@^2.3.7:
+micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -5768,7 +6431,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5784,9 +6447,13 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 minipass@^2.2.1, minipass@^2.3.3:
   version "2.3.3"
@@ -5828,6 +6495,10 @@ mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -5883,9 +6554,23 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
 ncp@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+
+nearley@^2.7.10:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.15.1.tgz#965e4e6ec9ed6b80fc81453e161efbcebb36d247"
+  dependencies:
+    moo "^0.4.3"
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 needle@^2.2.0:
   version "2.2.1"
@@ -5948,6 +6633,10 @@ node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
 
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+
 node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
@@ -5976,6 +6665,15 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
+node-notifier@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
+  dependencies:
+    growly "^1.3.0"
+    semver "^5.4.1"
+    shellwords "^0.1.1"
+    which "^1.3.0"
+
 node-pre-gyp@^0.10.0:
   version "0.10.2"
   resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz#e8945c20ef6795a20aac2b44f036eb13cf5146e3"
@@ -5997,6 +6695,13 @@ nomnom@^1.8.1:
   dependencies:
     chalk "~0.4.0"
     underscore "~1.6.0"
+
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -6169,6 +6874,14 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
@@ -6288,6 +7001,13 @@ opn@^4.0.0:
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
+
+optimist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
 
 optionator@^0.8.1:
   version "0.8.2"
@@ -6471,6 +7191,12 @@ parse-passwd@^1.0.0:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -6944,6 +7670,13 @@ pretty-format@^23.2.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^23.5.0:
+  version "23.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.5.0.tgz#0f9601ad9da70fe690a269cd3efca732c210687c"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 prettycli@1.4.3:
   version "1.4.3"
   resolved "https://registry.npmjs.org/prettycli/-/prettycli-1.4.3.tgz#b28ec2aad9de07ae1fd75ef294fb54cbdee07ed5"
@@ -6989,6 +7722,13 @@ promise@^7.1.1:
   resolved "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
+
+prompts@^0.1.9:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
+  dependencies:
+    kleur "^2.0.1"
+    sisteransi "^0.1.1"
 
 prop-types@15.6.1:
   version "15.6.1"
@@ -7118,6 +7858,23 @@ querystring@0.2.0, querystring@^0.2.0:
 querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
+
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^3.0.0:
   version "3.0.0"
@@ -7320,6 +8077,10 @@ react-inspector@^2.3.0:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
+react-is@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -7343,6 +8104,15 @@ react-modal@^3.4.5:
     prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
+
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-router-dom@4.2.2:
   version "4.2.2"
@@ -7388,6 +8158,15 @@ react-style-proptype@^3.0.0:
   resolved "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.1.tgz#7cfeb9b87ec7ab9dcbde9715170ed10c11fb86aa"
   dependencies:
     prop-types "^15.5.4"
+
+react-test-renderer@^16.0.0-0:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.2.tgz#4e03eca9359bb3210d4373f7547d1364218ef74e"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.4.2"
 
 react-textarea-autosize@^6.1.0:
   version "6.1.0"
@@ -7492,6 +8271,12 @@ readdirp@^2.0.0:
 readline-sync@^1.4.7:
   version "1.4.9"
   resolved "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz#3eda8e65f23cd2a17e61301b1f0003396af5ecda"
+
+realpath-native@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.1.tgz#07f40a0cce8f8261e2e8b7ebebf5c95965d7b633"
+  dependencies:
+    util.promisify "^1.0.0"
 
 recast@^0.12.6:
   version "0.12.9"
@@ -7756,6 +8541,10 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
 resolve@^1.1.6:
   version "1.8.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
@@ -7786,6 +8575,12 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
+right-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
+  dependencies:
+    align-text "^0.1.1"
+
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -7802,6 +8597,17 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
+
+rsvp@^3.3.3:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -7859,6 +8665,21 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
+sane@^2.0.0:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
+  dependencies:
+    anymatch "^2.0.0"
+    capture-exit "^1.2.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^2.0.0"
+    micromatch "^3.1.4"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.18.0"
+  optionalDependencies:
+    fsevents "^1.2.3"
+
 sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -7891,6 +8712,10 @@ semver-compare@^1.0.0:
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.4.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 send@0.16.2:
   version "0.16.2"
@@ -8053,6 +8878,10 @@ shelljs@^0.8.2:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+
 sigmund@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -8060,6 +8889,10 @@ sigmund@^1.0.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sisteransi@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -8134,7 +8967,7 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.1:
   version "0.5.2"
   resolved "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
@@ -8150,15 +8983,34 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.6:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
+
+source-map@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  dependencies:
+    amdefine ">=0.0.4"
+
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -8263,6 +9115,10 @@ stable@~0.1.6:
   version "0.1.8"
   resolved "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
 
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
 staged-git-files@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
@@ -8331,6 +9187,13 @@ strict-uri-encode@^1.0.0:
 string-argv@^0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
+
+string-length@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^4.0.0"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -8407,15 +9270,15 @@ strip-ansi@~0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
 
+strip-bom@3.0.0, strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
-
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -8468,7 +9331,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.2.3:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -8582,9 +9445,23 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+test-exclude@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^3.1.8"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
 text-table@0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+throat@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
 through2@^2.0.0:
   version "2.0.3"
@@ -8620,6 +9497,10 @@ tmp@^0.0.33:
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmpl@1.0.x:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -8759,6 +9640,19 @@ uglify-js@3.4.x:
     commander "~2.16.0"
     source-map "~0.6.1"
 
+uglify-js@^2.6:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
+uglify-to-browserify@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
 uglifyjs-webpack-plugin@^1.2.4:
   version "1.2.7"
   resolved "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz#57638dd99c853a1ebfe9d97b42160a8a507f9d00"
@@ -8775,6 +9669,10 @@ uglifyjs-webpack-plugin@^1.2.4:
 underscore@1.8.x:
   version "1.8.3"
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
 
 underscore@~1.6.0:
   version "1.6.0"
@@ -8915,7 +9813,7 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util.promisify@1.0.0, util.promisify@~1.0.0:
+util.promisify@1.0.0, util.promisify@^1.0.0, util.promisify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
   dependencies:
@@ -9024,6 +9922,12 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
+walker@~1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  dependencies:
+    makeerror "1.0.x"
+
 warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
@@ -9035,6 +9939,13 @@ warning@^4.0.1:
   resolved "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz#66ce376b7fbfe8a887c22bdf0e7349d73d397745"
   dependencies:
     loose-envify "^1.0.0"
+
+watch@~0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
 
 watchpack@^1.5.0:
   version "1.6.0"
@@ -9221,7 +10132,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.0, which@^1.2.10, which@^1.2.14, which@^1.2.9:
+which@^1.2.0, which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
@@ -9238,6 +10149,18 @@ widest-line@^2.0.0:
   resolved "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
   dependencies:
     string-width "^2.1.1"
+
+window-size@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+wordwrap@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wordwrap@~1.0.0:
   version "1.0.0"
@@ -9267,6 +10190,14 @@ write-file-atomic@^1.2.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
+
+write-file-atomic@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
 
 ws@^4.0.0:
   version "4.1.0"
@@ -9359,7 +10290,7 @@ yargs@6.6.0:
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
 
-yargs@^11.1.0:
+yargs@^11.0.0, yargs@^11.1.0:
   version "11.1.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   dependencies:
@@ -9393,3 +10324,12 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+yargs@~3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
+  dependencies:
+    camelcase "^1.0.2"
+    cliui "^2.1.0"
+    decamelize "^1.0.0"
+    window-size "0.1.0"


### PR DESCRIPTION
This PR introduces the `data-cosmos-key` attribute that will help with automation scripts.

### Tasks

- [x] Enable `data-cosmos-key` attribute to the components that will be used commonly in automation scripts
- [x] Add snapshot test to ensure that `data-cosmos-key` is being added
- [x] Add a new section in Cosmos docs to expose the Automation glossary

### Example

![image](https://user-images.githubusercontent.com/302314/44496368-9016bc80-a64a-11e8-93c7-dc26fb7bebf3.png)

#### Sample queries

- `$('div[data-cosmos-key=breadcrumb]')` => selecting the breadcrumb container
- `$('div[data-cosmos-key=breadcrumb] a[data-cosmos-key=link]')` => selecting a breadcrumb link

### Implementation details

As you see the `data-attribute` is being added manually, this is because, IMHO, it does not make any sense to add something like [babel-plugin-react-add-property](https://github.com/alanbsmith/babel-plugin-react-add-property) to automatically add those attributes, since we don't need to add the attribute to every single component. Also, by adding the attribute manually we can control which components have it and if need add more in the future.

### Automation glossary

![docs-automation](https://user-images.githubusercontent.com/302314/44631031-b08d9200-a93c-11e8-90ce-445c807d4cdb.png)
