### PR TITLE
Add deprecated tag in docs

### DIFF
--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -105,8 +105,7 @@ Alert.propTypes = {
   /** Title text (in bold) */
   title: PropTypes.string,
 
-  /** Details */
-  // @deprecated
+  /** @deprecated Details */
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /** Link to documentation */

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -27,7 +27,7 @@ TextInput.propTypes = {
   code: PropTypes.bool,
   /** Pass hasError to show error state */
   hasError: PropTypes.bool,
-  /** Pass error string directly to show error state */
+  /** @deprecated Pass error string directly to show error state */
   error: PropTypes.string,
   /** onChange transparently passed to the input */
   onChange: PropTypes.func,

--- a/internal/docs/docs-components/tag.js
+++ b/internal/docs/docs-components/tag.js
@@ -4,11 +4,17 @@ import PropTypes from 'prop-types'
 
 import { colors, fonts } from '@auth0/cosmos-tokens'
 
+const getColor = props => {
+  if (props.warning) return colors.base.orangeLighter
+  else if (props.error) return colors.base.red
+  else return colors.base.gray
+}
+
 const StyledTag = styled.span`
   display: inline-block;
-  color: ${props => (props.warning ? colors.base.orangeLighter : colors.base.gray)};
+  color: ${props => getColor(props)};
   border: 1px solid;
-  border-color: ${props => (props.warning ? colors.base.orangeLighter : colors.base.gray)};
+  border-color: ${props => getColor(props)};
   border-radius: 5px;
   min-width: 10px;
   padding: 4px 8px;

--- a/internal/docs/spec/props.js
+++ b/internal/docs/spec/props.js
@@ -43,6 +43,11 @@ const Type = styled.div`
   left: -${spacing.xsmall};
 `
 
+const Deprecated = Type.withComponent('span').extend`
+  color: ${colors.text.error};
+  &:after { content: '(deprecated)' }
+`
+
 const Required = styled.span`
   color: ${colors.base.orange};
   &:after {
@@ -60,6 +65,14 @@ class Props extends React.Component {
     const defaultsFromDocs = props.defaultsFromDocs
     Object.keys(defaultsFromDocs).forEach(key => {
       if (propData[key]) propData[key].value = defaultsFromDocs[key]
+    })
+
+    /* mark deprecations */
+    Object.keys(propData).forEach(key => {
+      if (propData[key].description && propData[key].description.includes('@deprecated')) {
+        propData[key].deprecated = true
+        propData[key].description = propData[key].description.replace('@deprecated', '')
+      }
     })
 
     this.state = { propData: propData }
@@ -102,7 +115,10 @@ class Props extends React.Component {
           {keys.map(key => (
             <tr key={key}>
               <td>
-                <Code>{key}</Code>
+                <Code style={{ color: propData[key].deprecated ? colors.text.error : 'inherit' }}>
+                  {key}
+                </Code>
+                {propData[key].deprecated && <Deprecated />}
                 {propData[key].required && <Required />}
               </td>
               <td>


### PR DESCRIPTION
Fixed https://github.com/auth0/cosmos/issues/789

Syntax: Start the comment with `@deprecated`

```js
/** Pass hasError to show error state */
hasError: PropTypes.bool,
/** @deprecated Pass error string directly to show error state */
error: PropTypes.string
```

![image](https://user-images.githubusercontent.com/1863771/44513021-e3841b80-a6d9-11e8-8a13-5c914f0aab69.png)


```js
/** @deprecated Details */
text: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
```


![image](https://user-images.githubusercontent.com/1863771/44513027-e7b03900-a6d9-11e8-824a-d05104feb609.png)
