### PR TITLE
Fix problems with cosmos + styleguide setup

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,3 +5,6 @@
   }
 }
 </style>
+<link rel="stylesheet" href="https://cdn.auth0.com/styleguide/core/2.0.5/core.min.css" />
+<link rel="stylesheet" href="https://cdn.auth0.com/styleguide/components/2.0.0/components.min.css" />
+<link rel="preload" href="https://cdn.auth0.com/styleguide/core/2.0.1/fonts/fakt/FaktPro-Normal.woff2" as="font" type="font/woff2" crossorigin="">

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -8,6 +8,11 @@ module.exports = storybookBaseConfig => {
   //     'process.env': { SKETCH: process.env.SKETCH }
   //   })
   // )
+  plugins.push(
+    new webpack.EnvironmentPlugin({
+      COSMOS_DISABLE_RESETS: true
+    })
+  )
   const newConfig = { ...storybookBaseConfig }
 
   // Export bundles as libraries so we can access them on page scope.

--- a/core/components/_helpers/globals.js
+++ b/core/components/_helpers/globals.js
@@ -185,6 +185,17 @@ if (includeGlobals) {
     }
 
     @font-face {
+      font-family: fakt-web;
+      src: url(https://cdn.auth0.com/website/ds/fonts/fakt/FaktPro-SemiBold.woff2)
+          format('woff2'),
+        url(https://cdn.auth0.com/website/ds/fonts/fakt/FaktPro-SemiBold.woff) format('woff'),
+        url(https://cdn.auth0.com/website/ds/fonts/fakt/FaktPro-SemiBold_web.ttf)
+          format('truetype');
+      font-weight: ${fonts.weight.bold};
+      font-style: normal;
+    }
+
+    @font-face {
       font-family: 'Roboto Mono';
       font-style: normal;
       font-weight: ${fonts.weight.semibold};


### PR DESCRIPTION
Just to see the visual diff

Found 2 bugs here: 
- We don't load semibold 
- Tabs has an invalid token

Tasks:
- Add styleguide + overview tests


Use https://github.com/auth0/cosmos/pull/879