### PR TITLE
Added color for hover on the selected tab

### DIFF
--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -17,7 +17,7 @@ const TabLink = styled.a`
   margin-bottom: -1px;
 
   &:hover {
-    color: ${props => (!props.selected ? colors.link.defaultHover : null)};
+    color: ${props => (!props.selected ? colors.link.defaultHover : colors.text.default)};
   }
 `
 


### PR DESCRIPTION
Fixes: https://github.com/auth0/cosmos/issues/896

Checked this in the PoC (which has styleguide as the base global styles)

**Before:**
<img width="998" alt="screen shot 2018-09-06 at 09 33 13" src="https://user-images.githubusercontent.com/239215/45158128-75e7ed00-b1b9-11e8-9a94-55bf67a6ee22.png">

**After:**
<img width="1287" alt="screen shot 2018-09-06 at 09 44 12" src="https://user-images.githubusercontent.com/239215/45158164-8e580780-b1b9-11e8-9dce-85bdec0242ab.png">


