### PR TITLE
Disable babel-sc plugin until we fix targetting problem

### DIFF
--- a/core/babel-preset/dev.js
+++ b/core/babel-preset/dev.js
@@ -1,6 +1,6 @@
 /* Add custom plugins for dev mode */
 
 const config = require('./index')
-config.plugins.push('babel-plugin-styled-components')
+// config.plugins.push('babel-plugin-styled-components')
 
 module.exports = config


### PR DESCRIPTION
Adding [`babel-plugin-styled-components`](https://github.com/styled-components/babel-plugin-styled-components) removed `sc-` classes in dev mode. This is a problem because dev and prod should look the same, otherwise we don't know what we're shipping

We rely on these classes to set `line-height` in [globals](https://github.com/auth0/cosmos/blob/master/core/components/_helpers/globals.js#L98)

We'll have first find a better way of targeting cosmos components before bringing this plugin back