### PR TITLE
Selector for cosmos components

### DIFF
--- a/core/codemods/index.js
+++ b/core/codemods/index.js
@@ -1,3 +1,3 @@
-const namedIndex = require('./named-index')
+const namedIndex = require('./replace-styled-components')
 
 module.exports = namedIndex

--- a/core/codemods/replace-styled-components.js
+++ b/core/codemods/replace-styled-components.js
@@ -1,0 +1,15 @@
+const transformer = (file, api) => {
+  const j = api.jscodeshift
+
+  return j(file.source)
+    .find(j.ImportDeclaration)
+    .forEach(path => {
+      path.value.source.value = path.value.source.value.replace(
+        'styled-components',
+        '@auth0/cosmos/styled'
+      )
+    })
+    .toSource()
+}
+
+export default transformer

--- a/core/components/_helpers/center.js
+++ b/core/components/_helpers/center.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 const Center = styled.div`
   text-align: center;

--- a/core/components/_helpers/float.js
+++ b/core/components/_helpers/float.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 const Left = styled.div`
   float: left;

--- a/core/components/_helpers/free-text.js
+++ b/core/components/_helpers/free-text.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import Paragraph from '../atoms/paragraph'
 
 const StyledText = styled(Paragraph)`

--- a/core/components/_helpers/globals.js
+++ b/core/components/_helpers/globals.js
@@ -90,12 +90,9 @@ if (includeGlobals) {
 
   /*
     The only difference between the resets styleguide and cosmos is line-height
-    We want cosmos components to have our line-height, but not break everything else,
-    hence as a hack, we're setting it on styled-components elements.
-
-    Note: This will break on applications that already use styled-components
+    We want cosmos components to have our line-height.
   */
-  [class^="sc-"] {
+  .cs {
     line-height: ${misc.lineHeight};
   }
 
@@ -169,7 +166,7 @@ if (includeGlobals) {
     }
 
     /* Cosmos globals */
-    [class^="sc-"] {
+    .cs {
       line-height: 1.6;
     }
 

--- a/core/components/_helpers/grid.js
+++ b/core/components/_helpers/grid.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 const Grid = styled.div`
   display: flex;

--- a/core/components/_helpers/story-example.js
+++ b/core/components/_helpers/story-example.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors } from '@auth0/cosmos/tokens'
 
 const Title = styled.div`

--- a/core/components/_helpers/story-stack.js
+++ b/core/components/_helpers/story-stack.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { spacing } from '@auth0/cosmos-tokens'
 import { sumOfElements, numberOfValues } from './custom-validations'

--- a/core/components/atoms/_box/_box.js
+++ b/core/components/atoms/_box/_box.js
@@ -13,7 +13,7 @@
 */
 
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 import { colors, misc } from '@auth0/cosmos-tokens'

--- a/core/components/atoms/_overlay/overlay.js
+++ b/core/components/atoms/_overlay/overlay.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 // TODO: create tokens?
 const layers = {

--- a/core/components/atoms/_styled-input/_styled-input.js
+++ b/core/components/atoms/_styled-input/_styled-input.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { colors, fonts, spacing, misc } from '@auth0/cosmos-tokens'
 

--- a/core/components/atoms/_well/_well.js
+++ b/core/components/atoms/_well/_well.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { colors, spacing } from '@auth0/cosmos-tokens'
 

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import Link, { StyledLink } from '../link'
 import Paragraph, { StyledParagraph } from '../paragraph'

--- a/core/components/atoms/alert/alert.story.js
+++ b/core/components/atoms/alert/alert.story.js
@@ -5,7 +5,7 @@ import { Alert, Link } from '@auth0/cosmos'
 
 const alertForTypes = props => {
   const types = ['default', 'information', 'success', 'warning', 'danger']
-  return <Example>{types.map(type => <Alert type={type} {...props} />)}</Example>
+  return <Example>{types.map(type => <Alert key={type} type={type} {...props} />)}</Example>
 }
 
 storiesOf('Alert').add('default', () =>

--- a/core/components/atoms/avatar/avatar.js
+++ b/core/components/atoms/avatar/avatar.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import { Image } from '@auth0/cosmos'
 import { colors, misc, spacing } from '@auth0/cosmos-tokens'

--- a/core/components/atoms/badge/badge.js
+++ b/core/components/atoms/badge/badge.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, fonts } from '@auth0/cosmos-tokens'
 
 const StyledBadge = styled.span`

--- a/core/components/atoms/breadcrumb/breadcrumb.js
+++ b/core/components/atoms/breadcrumb/breadcrumb.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import Automation from '../../_helpers/automation-attribute'
 

--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 import { subtract } from '../../_helpers/pixel-calc'

--- a/core/components/atoms/checkbox/checkbox.js
+++ b/core/components/atoms/checkbox/checkbox.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import Automation from '../../_helpers/automation-attribute'
 

--- a/core/components/atoms/code/code.js
+++ b/core/components/atoms/code/code.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { colors, fonts } from '@auth0/cosmos-tokens'
 

--- a/core/components/atoms/heading/heading.js
+++ b/core/components/atoms/heading/heading.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, fonts } from '@auth0/cosmos-tokens'
 
 const BaseHeading = styled.h1`

--- a/core/components/atoms/icon/icon.js
+++ b/core/components/atoms/icon/icon.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 import { colors } from '@auth0/cosmos-tokens'

--- a/core/components/atoms/image/image.js
+++ b/core/components/atoms/image/image.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 const StyledImage = styled.img`

--- a/core/components/atoms/label/label.js
+++ b/core/components/atoms/label/label.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { StyledTextAllCaps } from '@auth0/cosmos/atoms/text'
 import { colors, misc } from '@auth0/cosmos-tokens'
 

--- a/core/components/atoms/link/link.js
+++ b/core/components/atoms/link/link.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import propTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import Automation from '../../_helpers/automation-attribute'
 
 import { colors } from '@auth0/cosmos-tokens'

--- a/core/components/atoms/logo/logo.js
+++ b/core/components/atoms/logo/logo.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 const LogoWrapper = styled.span`
   display: inline-block;

--- a/core/components/atoms/paragraph/paragraph.js
+++ b/core/components/atoms/paragraph/paragraph.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { colors, fonts } from '@auth0/cosmos-tokens'
 

--- a/core/components/atoms/radio/radio.js
+++ b/core/components/atoms/radio/radio.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import Automation from '../../_helpers/automation-attribute'
 

--- a/core/components/atoms/spinner/spinner.js
+++ b/core/components/atoms/spinner/spinner.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled, { keyframes } from 'styled-components'
+import styled, { keyframes } from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 const rotate = keyframes`

--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled, { css } from 'styled-components'
+import styled, { css } from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import Automation from '../../_helpers/automation-attribute'
 

--- a/core/components/atoms/tag/tag.js
+++ b/core/components/atoms/tag/tag.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import Icon from '../icon'
 import { spacing, fonts, colors, misc } from '@auth0/cosmos-tokens'
 import Automation from '../../_helpers/automation-attribute'

--- a/core/components/atoms/text/text.js
+++ b/core/components/atoms/text/text.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { colors, fonts } from '@auth0/cosmos-tokens'
 

--- a/core/components/atoms/tooltip/tooltip.js
+++ b/core/components/atoms/tooltip/tooltip.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled, { css } from 'styled-components'
+import styled, { css } from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 import { colors, spacing, misc } from '@auth0/cosmos-tokens'

--- a/core/components/molecules/_action-input/_action-input.js
+++ b/core/components/molecules/_action-input/_action-input.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 import TextInput from '../../atoms/text-input'
@@ -26,10 +26,10 @@ const Wrapper = styled.div`
   ${StyledButtonGroup} {
     position: absolute;
     right: 4px;
-    top: 0; 
+    top: 0;
 
     ${Button.Element} {
-      height: ${(props) => misc.input[props.size].height};
+      height: ${props => misc.input[props.size].height};
       margin: 0;
     }
   }

--- a/core/components/molecules/avatar-block/avatar-block.js
+++ b/core/components/molecules/avatar-block/avatar-block.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import { Avatar, Link } from '@auth0/cosmos'
 import { colors, fonts, spacing } from '@auth0/cosmos-tokens'

--- a/core/components/molecules/button-group/button-group.js
+++ b/core/components/molecules/button-group/button-group.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled, { css } from '@auth0/cosmos/styled'
 import Automation from '../../_helpers/automation-attribute'
 
 import Button from '../../atoms/button'

--- a/core/components/molecules/danger-zone/danger-zone.js
+++ b/core/components/molecules/danger-zone/danger-zone.js
@@ -4,7 +4,7 @@ import Button from '../../atoms/button'
 import Paragraph from '../../atoms/paragraph'
 import Stack from '../stack'
 import { colors, spacing, misc } from '@auth0/cosmos-tokens'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 
 const Container = styled.div`

--- a/core/components/molecules/dialog/dialog.js
+++ b/core/components/molecules/dialog/dialog.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import Button from '../../atoms/button'
 import ButtonGroup from '../../molecules/button-group'
 import Overlay from '../../atoms/_overlay'

--- a/core/components/molecules/dialog/dialog.story.js
+++ b/core/components/molecules/dialog/dialog.story.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 import { Dialog, Form } from '@auth0/cosmos'

--- a/core/components/molecules/empty-state/empty-state.js
+++ b/core/components/molecules/empty-state/empty-state.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import Icon, { __ICONNAMES__ } from '../../atoms/icon'

--- a/core/components/molecules/form-group/form-group.js
+++ b/core/components/molecules/form-group/form-group.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import Automation from '../../_helpers/automation-attribute'
 

--- a/core/components/molecules/form/actions/actions.js
+++ b/core/components/molecules/form/actions/actions.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { spacing } from '@auth0/cosmos-tokens'
 import getLayoutValues from '../layout'

--- a/core/components/molecules/form/error.js
+++ b/core/components/molecules/form/error.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { spacing, colors } from '@auth0/cosmos-tokens'
 

--- a/core/components/molecules/form/field/field.js
+++ b/core/components/molecules/form/field/field.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { spacing, misc } from '@auth0/cosmos-tokens'
 import getLayoutValues from '../layout'

--- a/core/components/molecules/form/fieldset/divider.js
+++ b/core/components/molecules/form/fieldset/divider.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { fonts, spacing, colors } from '@auth0/cosmos-tokens'
 

--- a/core/components/molecules/form/fieldset/fieldset.js
+++ b/core/components/molecules/form/fieldset/fieldset.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { spacing } from '@auth0/cosmos-tokens'
 import StyledDivider from './divider'

--- a/core/components/molecules/form/help-text.js
+++ b/core/components/molecules/form/help-text.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { spacing, colors } from '@auth0/cosmos-tokens'
 

--- a/core/components/molecules/form/label.js
+++ b/core/components/molecules/form/label.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { fonts, colors } from '@auth0/cosmos-tokens'
 

--- a/core/components/molecules/list/list.js
+++ b/core/components/molecules/list/list.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import Automation from '../../_helpers/automation-attribute'
 

--- a/core/components/molecules/page-header/description.js
+++ b/core/components/molecules/page-header/description.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { colors, spacing } from '@auth0/cosmos-tokens'
 

--- a/core/components/molecules/page-header/page-header.js
+++ b/core/components/molecules/page-header/page-header.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import Automation from '../../_helpers/automation-attribute'
 
 import { spacing } from '@auth0/cosmos-tokens'

--- a/core/components/molecules/pager/pager.js
+++ b/core/components/molecules/pager/pager.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import Automation from '../../_helpers/automation-attribute'
 
 import Button from '../../atoms/button'

--- a/core/components/molecules/pagination-toolbar/pagination-toolbar.js
+++ b/core/components/molecules/pagination-toolbar/pagination-toolbar.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { misc, colors, spacing } from '@auth0/cosmos-tokens'
 import TextInput from '../../atoms/text-input'
 import Button from '../../atoms/button'

--- a/core/components/molecules/pagination/pagination.js
+++ b/core/components/molecules/pagination/pagination.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import { spacing, colors, misc } from '@auth0/cosmos-tokens'
 import Button from '../../atoms/button'

--- a/core/components/molecules/resource-list/item/item.js
+++ b/core/components/molecules/resource-list/item/item.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { Button, ButtonGroup, Link } from '@auth0/cosmos'
 import Avatar, { StyledAvatar } from '@auth0/cosmos/atoms/avatar'
 import { StyledTextAllCaps } from '@auth0/cosmos/atoms/text'

--- a/core/components/molecules/resource-list/resource-list.js
+++ b/core/components/molecules/resource-list/resource-list.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import ResourceListItem from './item'
 import { spacing } from '@auth0/cosmos-tokens'
 import { actionShapeWithRequiredIcon } from '@auth0/cosmos/_helpers/action-shape'

--- a/core/components/molecules/sidebar/sidebar-link-group.js
+++ b/core/components/molecules/sidebar/sidebar-link-group.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import SidebarLink from './sidebar-link'
 import { __ICONNAMES__ } from '@auth0/cosmos/atoms/icon'

--- a/core/components/molecules/sidebar/sidebar-link.js
+++ b/core/components/molecules/sidebar/sidebar-link.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import Automation from '../../_helpers/automation-attribute'
 

--- a/core/components/molecules/sidebar/sidebar.js
+++ b/core/components/molecules/sidebar/sidebar.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import SidebarLink from './sidebar-link'
 import SidebarLinkGroup from './sidebar-link-group'
 import Automation from '../../_helpers/automation-attribute'

--- a/core/components/molecules/stack/stack.js
+++ b/core/components/molecules/stack/stack.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import Automation from '../../_helpers/automation-attribute'
 
 import { spacing } from '@auth0/cosmos-tokens'

--- a/core/components/molecules/table/table-header.js
+++ b/core/components/molecules/table/table-header.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import TableColumn from './table-column'
 import Automation from '../../_helpers/automation-attribute'

--- a/core/components/molecules/table/table.js
+++ b/core/components/molecules/table/table.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import TableColumn from './table-column'
 import TableHeader from './table-header'

--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 import makeId from '../../_helpers/uniqueId'
 import Automation from '../../_helpers/automation-attribute'

--- a/core/components/styled.js
+++ b/core/components/styled.js
@@ -6,11 +6,16 @@ import styled, {
   ThemeProvider
 } from 'styled-components'
 
-export default styled
-export {
-  keyframes,
-  css,
-  injectGlobal,
-  StyledComponent,
-  ThemeProvider
-}
+import domElements from 'styled-components/src/utils/domElements'
+
+/* Always add cs class to component */
+const BaseComponent = styled.div.attrs({ className: 'cs' })``
+
+/* modify styled so that it always uses BaseComponent under the hood */
+let modified = styled
+domElements.forEach(domElement => {
+  modified[domElement] = BaseComponent.withComponent(domElement).extend
+})
+
+export default modified
+export { keyframes, css, injectGlobal, StyledComponent, ThemeProvider }

--- a/core/components/styled.js
+++ b/core/components/styled.js
@@ -12,7 +12,8 @@ import domElements from 'styled-components/src/utils/domElements'
 const BaseComponent = styled.div.attrs({ className: 'cs' })``
 
 /* modify styled so that it always uses BaseComponent under the hood */
-let modified = styled
+
+let modified = tag => styled(tag)
 domElements.forEach(domElement => {
   modified[domElement] = BaseComponent.withComponent(domElement).extend
 })

--- a/examples/manage/components/application-list.js
+++ b/examples/manage/components/application-list.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { Code, ResourceList } from '@auth0/cosmos'
 import { spacing } from '@auth0/cosmos-tokens'

--- a/examples/manage/components/application-page-header.js
+++ b/examples/manage/components/application-page-header.js
@@ -10,7 +10,7 @@ import { StyledHeading } from '@auth0/cosmos/atoms/heading'
 
 const StyledApplicationPageHeader = styled.div`
   margin-bottom: ${spacing.large};
-
+  line-height: 1.6;
   ${StyledHeading[1]} {
     margin: 0;
     margin-bottom: ${spacing.xsmall};

--- a/examples/manage/components/application-page-header.js
+++ b/examples/manage/components/application-page-header.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { spacing, colors } from '@auth0/cosmos-tokens'
 import { Breadcrumb, Code, Heading } from '@auth0/cosmos'
@@ -10,7 +10,7 @@ import { StyledHeading } from '@auth0/cosmos/atoms/heading'
 
 const StyledApplicationPageHeader = styled.div`
   margin-bottom: ${spacing.large};
-  line-height: 1.6;
+
   ${StyledHeading[1]} {
     margin: 0;
     margin-bottom: ${spacing.xsmall};

--- a/examples/manage/components/connection-list.js
+++ b/examples/manage/components/connection-list.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { List, Switch, Stack, Icon } from '@auth0/cosmos'
 import { spacing } from '@auth0/cosmos-tokens'

--- a/examples/manage/components/container.js
+++ b/examples/manage/components/container.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 const StyledContainer = styled.div`
   max-width: 1034px;

--- a/examples/manage/components/top-navigation.js
+++ b/examples/manage/components/top-navigation.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import {
   Dummy as Dropdown,

--- a/examples/manage/components/welcome-card.js
+++ b/examples/manage/components/welcome-card.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { Image, Paragraph } from '@auth0/cosmos'
 

--- a/examples/manage/pages/application-detail/connections.js
+++ b/examples/manage/pages/application-detail/connections.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled from '@auth0/cosmos/styled'
 
 import { Paragraph } from '@auth0/cosmos'
 

--- a/examples/manage/pages/applications/create-application-dialog.js
+++ b/examples/manage/pages/applications/create-application-dialog.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled, { css } from '@auth0/cosmos/styled'
 import { Dialog, Form, Paragraph, Stack } from '@auth0/cosmos'
 import { colors, misc, spacing } from '@auth0/cosmos/tokens'
 import { StyledHeading } from '@auth0/cosmos/atoms/heading'


### PR DESCRIPTION
Right now, we have attach `line-height: 1.6` to all components created with styled-components using a `sc-^` selector (the styleguide uses a different `line-height`)

This also spills over to the components in the application created with `styled-components` that are not from cosmos.


With this PR, we add a class to all cosmos components (`cs`) and use that to add `line-height: 1.6` to that

Even though this is a bug fix, it is also a breaking change because `line-height: 1.6` is no longer applied to the application's styled-components. If an application depended on this, this might (will?) change some styles

- [x] Add className "cs" to all cosmos components
- [x] Replace sc-^ with cs in globals

Links:

1. [Chromatic build for manage example out of the box](https://www.chromaticqa.com/snapshot?appId=5aba7f6a07f95800202658ff&id=5b95e15c645723002436ed86) ❗️
2. [Chromatic build for manage example with auth0/cosmos/styled instead of styled-components](https://www.chromaticqa.com/build?appId=5aba7f6a07f95800202658ff&number=839) ✅