### PR TITLE
Enforced icon size to fix icon vertical alignment

### DIFF
--- a/core/components/atoms/icon/icon.js
+++ b/core/components/atoms/icon/icon.js
@@ -14,12 +14,7 @@ const Icon = props => {
 
   return (
     <Icon.Element {...props}>
-      <Image
-        width={props.size}
-        height={props.size}
-        viewBox={`0 0 ${icon.width} ${icon.height}`}
-        color={color}
-      >
+      <Image size={props.size} viewBox={`0 0 ${icon.width} ${icon.height}`} color={color}>
         {icon.paths.map((path, index) => <path key={index} d={path} />)}
       </Image>
     </Icon.Element>
@@ -29,17 +24,17 @@ const Icon = props => {
 Icon.Element = styled.i`
   display: inline-block;
   line-height: 1;
-  width: ${props => props.size};
-  height: ${props => props.size};
+  width: ${props => props.size}px;
+  height: ${props => props.size}px;
 `
 const Image = styled.svg`
   display: inline-block;
   vertical-align: middle;
   line-height: 1;
-  width: ${props => props.size};
-  height: ${props => props.size};
+  width: ${imageProps => imageProps.size}px;
+  height: ${imageProps => imageProps.size}px;
   path {
-    fill: ${props => props.color};
+    fill: ${imageProps => imageProps.color};
   }
 `
 

--- a/core/components/atoms/icon/icon.js
+++ b/core/components/atoms/icon/icon.js
@@ -14,7 +14,12 @@ const Icon = props => {
 
   return (
     <Icon.Element {...props}>
-      <Image size={props.size} viewBox={`0 0 ${icon.width} ${icon.height}`} color={color}>
+      <Image
+        width={props.size}
+        height={props.size}
+        viewBox={`0 0 ${icon.width} ${icon.height}`}
+        color={color}
+      >
         {icon.paths.map((path, index) => <path key={index} d={path} />)}
       </Image>
     </Icon.Element>
@@ -31,8 +36,8 @@ const Image = styled.svg`
   display: inline-block;
   vertical-align: middle;
   line-height: 1;
-  width: ${imageProps => imageProps.size}px;
-  height: ${imageProps => imageProps.size}px;
+  width: ${imageProps => imageProps.width}px;
+  height: ${imageProps => imageProps.height}px;
   path {
     fill: ${imageProps => imageProps.color};
   }

--- a/core/components/atoms/icon/icon.js
+++ b/core/components/atoms/icon/icon.js
@@ -29,11 +29,15 @@ const Icon = props => {
 Icon.Element = styled.i`
   display: inline-block;
   line-height: 1;
+  width: ${props => props.size};
+  height: ${props => props.size};
 `
 const Image = styled.svg`
   display: inline-block;
   vertical-align: middle;
   line-height: 1;
+  width: ${props => props.size};
+  height: ${props => props.size};
   path {
     fill: ${props => props.color};
   }


### PR DESCRIPTION
Both the `i` container and `svg` now have width and height props