### PR TITLE
Test cosmos with styled-components@v4.0.0-beta.8

### DIFF
--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -258,7 +258,7 @@ Button.Text = styled.span`
   vertical-align: middle;
 `
 
-Button.LinkElement = Button.Element.withComponent('a').extend`
+Button.LinkElement = styled(Button.Element.withComponent('a'))`
   display: table;
   text-decoration: none;
 

--- a/core/components/atoms/heading/heading.js
+++ b/core/components/atoms/heading/heading.js
@@ -12,21 +12,21 @@ const BaseHeading = styled.h1`
 
 const StyledHeading = []
 
-StyledHeading[1] = BaseHeading.withComponent('h1').extend`
+StyledHeading[1] = styled(BaseHeading.withComponent('h1'))`
   font-size: 36px;
 `
 
-StyledHeading[2] = BaseHeading.withComponent('h2').extend`
+StyledHeading[2] = styled(BaseHeading.withComponent('h2'))`
   font-size: 24px;
   font-weight: ${fonts.weight.medium};
 `
 
-StyledHeading[3] = BaseHeading.withComponent('h3').extend`
+StyledHeading[3] = styled(BaseHeading.withComponent('h3'))`
   font-size: 18px; /* TO-DO: tokenize */
   font-weight: ${fonts.weight.bold};
 `
 
-StyledHeading[4] = BaseHeading.withComponent('h4').extend`
+StyledHeading[4] = styled(BaseHeading.withComponent('h4'))`
   font-size: 14px;
   font-weight: ${fonts.weight.medium};
 `

--- a/core/components/atoms/select/select.js
+++ b/core/components/atoms/select/select.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Automation from '../../_helpers/automation-attribute'
+import styled from 'styled-components'
 
 import { misc } from '@auth0/cosmos-tokens'
 import { StyledInput } from '../_styled-input'
 
-const StyledSelect = StyledInput.withComponent('select').extend`
+import Automation from '../../_helpers/automation-attribute'
+
+const StyledSelect = styled(StyledInput.withComponent('select'))`
   height: ${misc.input.default.height};
 `
 

--- a/core/components/atoms/spinner/spinner.js
+++ b/core/components/atoms/spinner/spinner.js
@@ -1,10 +1,14 @@
 import React from 'react'
-import styled, { keyframes } from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 import PropTypes from 'prop-types'
 
 const rotate = keyframes`
   0% { transform: rotate(0deg) }
   100% { transform: rotate(1turn) }
+`
+
+const animationRule = css`
+  ${rotate} 0.8s infinite linear;
 `
 
 const getColor = (props, highlight) => {
@@ -29,7 +33,7 @@ const StyledSpinner = styled.span`
   width: 1em;
   height: 1em;
   vertical-align: text-bottom;
-  animation: ${rotate} 0.8s infinite linear;
+  animation: ${animationRule};
 `
 
 const Spinner = props => <StyledSpinner {...props} />

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 import { misc } from '@auth0/cosmos-tokens'
 import { StyledInput } from '../_styled-input'
@@ -30,7 +31,7 @@ const TextInput = ({ defaultValue, type, ...props }) => {
   )
 }
 
-TextInput.Element = StyledInput.extend`
+TextInput.Element = styled(StyledInput)`
   height: ${props => misc.input[props.size].height};
 `
 

--- a/core/components/atoms/textarea/textarea.js
+++ b/core/components/atoms/textarea/textarea.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 import { StyledInput } from '../_styled-input'
 import { deprecate } from '../../_helpers/custom-validations'
 import Automation from '../../_helpers/automation-attribute'
 
-const StyledTextArea = StyledInput.withComponent('textarea').extend`
+const StyledTextArea = styled(StyledInput.withComponent('textarea'))`
   resize: ${props => (props.resizable ? 'vertical' : 'none')};
   font-size: ${props => (props.code ? '13px' : 'inherit')};
 `

--- a/core/components/package.json
+++ b/core/components/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@auth0/cosmos-tokens": "0.5.0",
     "prop-types": "15.6.1",
-    "styled-components": "3.1.6"
+    "styled-components": "4.0.0-beta.8"
   },
   "peerDependencies": {
     "react": ">=16.3.0",

--- a/internal/docs/overview/examples/empty-states.js
+++ b/internal/docs/overview/examples/empty-states.js
@@ -10,8 +10,7 @@ const EmptyStates = () => (
       <EmptyState
         icon="clients"
         title="Clients"
-        text="No items have been added to this section."
-        helpUrl="https://auth0.com"
+        link="https://auth0.com"
         action={{
           icon: 'plus',
           label: 'Create Client',
@@ -19,7 +18,9 @@ const EmptyStates = () => (
             /*...*/
           }
         }}
-      />
+      >
+        No items have been added to this section.
+      </EmptyState>
     </Example>
   </Section>
 )

--- a/internal/docs/spec/props.js
+++ b/internal/docs/spec/props.js
@@ -43,9 +43,11 @@ const Type = styled.div`
   left: -${spacing.xsmall};
 `
 
-const Deprecated = Type.withComponent('span').extend`
+const Deprecated = styled(Type.withComponent('span'))`
   color: ${colors.text.error};
-  &:after { content: '(deprecated)' }
+  &:after {
+    content: '(deprecated)';
+  }
 `
 
 const Required = styled.span`

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,9 +160,19 @@
   dependencies:
     "@emotion/memoize" "^0.6.3"
 
+"@emotion/is-prop-valid@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
+  dependencies:
+    "@emotion/memoize" "^0.6.6"
+
 "@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.3":
   version "0.6.3"
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.3.tgz#64379a1d6af6f8d4fe8bd6efe9d9e824ea4b22d8"
+
+"@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
 
 "@emotion/serialize@^0.8.3":
   version "0.8.3"
@@ -2270,13 +2280,6 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-buffer@^5.0.3:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -6453,6 +6456,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memoize-one@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -8230,6 +8237,10 @@ react-inspector@^2.3.0:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
+react-is@^16.3.1:
+  version "16.5.2"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
+
 react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
@@ -9452,33 +9463,27 @@ style-loader@0.21.0, style-loader@^0.21.0:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
-styled-components@3.1.6:
-  version "3.1.6"
-  resolved "https://registry.npmjs.org/styled-components/-/styled-components-3.1.6.tgz#9c443146fa82c6659a9f64dd493bf2202480342e"
+styled-components@4.0.0-beta.8:
+  version "4.0.0-beta.8"
+  resolved "https://registry.npmjs.org/styled-components/-/styled-components-4.0.0-beta.8.tgz#90430b172ca96915481c0009db1dd76f024cf02a"
   dependencies:
-    buffer "^5.0.3"
+    "@emotion/is-prop-valid" "^0.6.8"
     css-to-react-native "^2.0.3"
-    fbjs "^0.8.9"
-    hoist-non-react-statics "^1.2.0"
-    is-plain-object "^2.0.1"
+    memoize-one "^4.0.0"
     prop-types "^15.5.4"
-    stylis "^3.4.0"
-    stylis-rule-sheet "^0.0.7"
-    supports-color "^3.2.3"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
 
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
 
-stylis-rule-sheet@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.7.tgz#5c51dc879141a61821c2094ba91d2cbcf2469c6c"
-
 stylis@^3.0.0:
   version "3.5.3"
   resolved "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
 
-stylis@^3.4.0, stylis@^3.5.0:
+stylis@^3.5.0:
   version "3.5.1"
   resolved "https://registry.npmjs.org/stylis/-/stylis-3.5.1.tgz#fd341d59f57f9aeb412bc14c9d8a8670b438e03b"
 


### PR DESCRIPTION
Major changes:

1. The API to extend is slightly different now:


```diff
- const Heading1 = BaseHeading.withComponent('h1').extend``
+ const Heading1 = styled(BaseHeading.withComponent('h1'))``
```

2. Peer dependency on >16.3.0

We have the same dependency in cosmos so that we can use the new context API