### PR TITLE
Fix icon position overrides

### DIFF
--- a/core/components/molecules/pagination/pagination.js
+++ b/core/components/molecules/pagination/pagination.js
@@ -27,8 +27,8 @@ const StyledPaginationItem = styled(Button)`
 
   min-width: ${props => (props.left || props.right ? '95px' : spacing.small)};
 
-  ${props => props.left && `padding-left: ${spacing.xlarge};`} 
-  ${props => props.right && `padding-right: ${spacing.xlarge};`} 
+  ${props => props.left && `padding-left: ${spacing.xlarge};`}
+  ${props => props.right && `padding-right: ${spacing.xlarge};`}
   ${props => props.iconOnly && `padding-left: 0;`}
 
   ${props => props.selected && `background-color: rgba(0,0,0,0.2);`}
@@ -39,7 +39,7 @@ const StyledPaginationItem = styled(Button)`
     padding-top: 10px;
     height: calc(${misc.button.compressed.height} - 2px);
     width: 20px;
-    
+
     svg {
       width: 15px;
       height: 15px;
@@ -67,9 +67,9 @@ const IconButton = styled(Button)`
   min-width: ${spacing.small};
   padding-left: ${spacing.xsmall};
   padding-right: 0;
-
   ${Icon.Element} {
-    padding-top: 3px;
+    position: relative;
+    top: 1px;
   }
 `
 


### PR DESCRIPTION
----


### _Revisit after merging https://github.com/auth0/cosmos/pull/947_

----


The chevrons icons was not centered in the button because it had a component override for the position. 

Before: 
<img width="1160" alt="screen shot 2018-09-25 at 12 07 46" src="https://user-images.githubusercontent.com/239215/46023762-bbfae700-c0bb-11e8-83d7-59c3ece3eeda.png">


After:
<img width="746" alt="screen shot 2018-09-25 at 12 05 01" src="https://user-images.githubusercontent.com/239215/46023551-41ca6280-c0bb-11e8-83cf-f5ef76c69198.png">
