### PR TITLE
Docs: Add version switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
 cache: yarn
 after_success:
   - cp tooling/deployment-package.json build/package.json
-  - cd build && npx now-cd --team auth0-design --alias "master=auth0-cosmos-master.now.sh" --alias "stable=auth0-cosmos.now.sh"
+  - cd build && npx now-cd --team auth0-design --alias "docs-switcher=auth0-cosmos-docs-switcher.now.sh" --alias "auth0-cosmos-docs-switcher-two.now.sh" --alias "master=auth0-cosmos-master.now.sh" --alias "stable=auth0-cosmos.now.sh"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
 cache: yarn
 after_success:
   - cp tooling/deployment-package.json build/package.json
-  - cd build && npx now-cd --team auth0-design --alias "docs-switcher=auth0-cosmos-docs-switcher.now.sh" --alias "auth0-cosmos-docs-switcher-two.now.sh" --alias "master=auth0-cosmos-master.now.sh" --alias "stable=auth0-cosmos.now.sh"
+  - cd build && npx now-cd --team auth0-design --alias "master=auth0-cosmos-master.now.sh" --alias "stable=auth0-cosmos.now.sh"
 notifications:
   email: false

--- a/internal/docs/docs-components/navigation.js
+++ b/internal/docs/docs-components/navigation.js
@@ -6,8 +6,7 @@ import { StyledLabel } from '../../../core/components/atoms/label'
 import { colors, spacing } from '@auth0/cosmos/tokens'
 import IconSketch from './sketch-icon'
 import IconGithub from './github-icon'
-
-import { version } from '@auth0/cosmos/package.json'
+import VersionSwitcher from './version-switcher'
 
 const Navigation = styled.nav`
   position: fixed;
@@ -55,27 +54,13 @@ const LogoContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  h1 {
-    font-size: 14px;
-    letter-spacing: 1.4px;
-    display: inline-block;
-    color: ${colors.base.grayLightest};
-    font-weight: 700;
-    margin-left: 12px;
-  }
-  h1 > span {
-    font-size: 0.85em;
-    color: ${colors.base.grayLight};
-  }
 `
 
 export default () => (
   <Navigation>
     <LogoContainer>
       <Logo />
-      <h1>
-        COSMOS <span>v{version}</span>
-      </h1>
+      <VersionSwitcher />
     </LogoContainer>
     <ul>
       <li>

--- a/internal/docs/docs-components/version-switcher.js
+++ b/internal/docs/docs-components/version-switcher.js
@@ -2,7 +2,17 @@ import React from 'react'
 import styled from 'styled-components'
 import { colors } from '@auth0/cosmos/tokens'
 
-const versions = ['0.5.2', '0.5.1']
+import { changelog } from '@auth0/cosmos/meta/changelog'
+
+/* grab lines that start with ## */
+const regex = /^## (.*)$/gm
+const lines = changelog.match(regex)
+let versions = lines.map(line => line.split('## ')[1].split(' [')[0])
+
+/* remove versions older than 0.5.1 */
+console.log(versions)
+versions = versions.filter(version => version > '0.5.0')
+console.log(versions)
 
 const Wrapper = styled.span`
   font-size: 14px;

--- a/internal/docs/docs-components/version-switcher.js
+++ b/internal/docs/docs-components/version-switcher.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import styled from 'styled-components'
+import { colors } from '@auth0/cosmos/tokens'
+
+const versions = ['0.5.2', '0.5.1']
+
+const Wrapper = styled.span`
+  font-size: 14px;
+  letter-spacing: 1.4px;
+  1display: inline-block;
+  color: ${colors.base.grayLightest};
+  font-weight: 700;
+  margin-left: 16px;
+
+  select {
+    background: transparent;
+    border: none;
+    font-size: 12px;
+    color: ${colors.base.grayLight};
+  }
+`
+
+const VersionSwitcher = () => (
+  <Wrapper>
+    COSMOS
+    <select
+      onChange={event => {
+        window.location.href = `https:auth0-cosmos-${event.target.value.replace(/\./g, '-')}.now.sh`
+      }}
+    >
+      {versions.map(v => <option value={v}>{v}</option>)}
+    </select>
+  </Wrapper>
+)
+
+export default VersionSwitcher


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1863771/46085363-4014a380-c17c-11e8-83a5-8ad0eb0abe83.png)


It relies on a standard alias to exist:

`auth0-cosmos-{version}.now.sh`

example: `auth0-cosmos-0-5-2.now.sh`