### PR TITLE
Move @deprecation logic to handler

### DIFF
--- a/internal/docs/spec/props.js
+++ b/internal/docs/spec/props.js
@@ -67,14 +67,6 @@ class Props extends React.Component {
       if (propData[key]) propData[key].value = defaultsFromDocs[key]
     })
 
-    /* mark deprecations */
-    Object.keys(propData).forEach(key => {
-      if (propData[key].description && propData[key].description.includes('@deprecated')) {
-        propData[key].deprecated = true
-        propData[key].description = propData[key].description.replace('@deprecated', '')
-      }
-    })
-
     this.state = { propData: propData }
     this.props.onPropsChange(propData)
   }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "proptypes-to-ts-declarations": "0.8.3",
     "react-chromatic": "0.8.4",
     "react-docgen": "2.21.0",
+    "react-docgen-deprecation-handler": "1.0.0",
     "react-docgen-displayname-handler": "2.1.0",
     "read-pkg": "4.0.1",
     "svgo": "1.0.5"

--- a/tooling/component-metadata.js
+++ b/tooling/component-metadata.js
@@ -1,7 +1,10 @@
 const fs = require('fs-extra')
 const glob = require('glob')
+
 const docgen = require('react-docgen')
 const { createDisplayNameHandler } = require('react-docgen-displayname-handler')
+const deprecationHandler = require('react-docgen-deprecation-handler')
+
 const chokidar = require('chokidar')
 const { info, warn } = require('prettycli')
 const camelCase = require('lodash.camelcase')
@@ -35,7 +38,9 @@ const run = () => {
         if (!path.includes(`${directoryName}.js`)) return
 
         /* append display name handler to handlers list */
-        const handlers = docgen.defaultHandlers.concat(createDisplayNameHandler(path))
+        const handlers = docgen.defaultHandlers
+          .concat(createDisplayNameHandler(path))
+          .concat(deprecationHandler)
 
         /* read file to get source code */
         const code = fs.readFileSync(path, 'utf8')

--- a/yarn.lock
+++ b/yarn.lock
@@ -8118,6 +8118,10 @@ react-dev-utils@^5.0.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
+react-docgen-deprecation-handler@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/react-docgen-deprecation-handler/-/react-docgen-deprecation-handler-1.0.0.tgz#2dcc39f92ee787a4ffd75d6ec3b46eeb4a2a26f6"
+
 react-docgen-displayname-handler@2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/react-docgen-displayname-handler/-/react-docgen-displayname-handler-2.1.0.tgz#2efed6a3459ef7f7feefd6ff513c770d89b11062"


### PR DESCRIPTION
Reduce the amount of weird logic in our docs 

```
Component.propTypes = {
  /** @deprecated dont use this prop */
  old: PropTypes.any,
  /** this isn't deprecated, use it */
  new: PropTypes.any
}
```
⬇️

{
  displayName: "Component",
  props: {
    old: {
      type: { name: 'any' },
      required: false,
      description: "dont use this prop",
👉    deprecated: true
    },
    new: {
      type: { name: 'any' },
      required: false,
      description: "this isn't deprecated, use it"
    }
  }
}