### PR TITLE
More prominent version switcher for docs

### DIFF
--- a/internal/docs/docs-components/navigation.js
+++ b/internal/docs/docs-components/navigation.js
@@ -50,6 +50,17 @@ const Navigation = styled.nav`
   }
 `
 
+const LogoName = styled.h1`
+  font-size: 14px;
+  letter-spacing: 1.4px;
+  display: inline-block;
+  color: ${colors.base.grayLightest};
+  font-weight: 700;
+  margin-left: 16px;
+  margin-right: 0.75em;
+  text-transform: uppercase;
+`
+
 const LogoContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -60,6 +71,7 @@ export default () => (
   <Navigation>
     <LogoContainer>
       <Logo />
+      <LogoName>Cosmos</LogoName>
       <VersionSwitcher />
     </LogoContainer>
     <ul>

--- a/internal/docs/docs-components/version-switcher.js
+++ b/internal/docs/docs-components/version-switcher.js
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { colors } from '@auth0/cosmos/tokens'
 
+import { Icon } from '@auth0/cosmos'
 import { changelog } from '@auth0/cosmos/meta/changelog'
 
 /* grab lines that start with ## */
@@ -12,26 +13,53 @@ let versions = lines.map(line => line.split('## ')[1].split(' [')[0])
 /* remove versions older than 0.5.1 */
 versions = versions.filter(version => version > '0.5.0')
 
+const StyledVersionSwitcher = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`
+
+const StyledIcon = styled(Icon).attrs({
+  name: 'dropdown-fill',
+  color: 'grayLightest',
+  size: '10'
+})`
+  position: absolute;
+  right: 0.5em;
+`
+
 const StyledSelect = styled.select`
   background: transparent;
-  border: 1px solid #8e8e8e;
+  border: none;
   font-size: 13px;
+  border: 1px solid #8e8e8e;
+  border-radius: 5px;
+  appearance: none;
+  padding: 0.15em 0.5em;
+  padding-right: 1.75em;
   color: ${colors.base.grayLight};
+  position: relative;
+  option {
+    color: black;
+  }
 `
 
 const VersionSwitcher = () => (
-  <StyledSelect
-    onChange={event => {
-      const version = event.target.value.replace(/\./g, '-')
-      window.location.href = `https://auth0-cosmos-${version}.now.sh`
-    }}
-  >
-    {versions.map(v => (
-      <option key={v} value={v}>
-        {v}
-      </option>
-    ))}
-  </StyledSelect>
+  <StyledVersionSwitcher>
+    <StyledIcon />
+    <StyledSelect
+      onChange={event => {
+        const version = event.target.value.replace(/\./g, '-')
+        window.location.href = `https://auth0-cosmos-${version}.now.sh`
+      }}
+    >
+      {versions.map(v => (
+        <option key={v} value={v}>
+          {v}
+        </option>
+      ))}
+    </StyledSelect>
+  </StyledVersionSwitcher>
 )
 
 export default VersionSwitcher

--- a/internal/docs/docs-components/version-switcher.js
+++ b/internal/docs/docs-components/version-switcher.js
@@ -12,38 +12,26 @@ let versions = lines.map(line => line.split('## ')[1].split(' [')[0])
 /* remove versions older than 0.5.1 */
 versions = versions.filter(version => version > '0.5.0')
 
-const Wrapper = styled.span`
-  font-size: 14px;
-  letter-spacing: 1.4px;
-  1display: inline-block;
-  color: ${colors.base.grayLightest};
-  font-weight: 700;
-  margin-left: 16px;
-
-  select {
-    background: transparent;
-    border: none;
-    font-size: 12px;
-    color: ${colors.base.grayLight};
-  }
+const StyledSelect = styled.select`
+  background: transparent;
+  border: 1px solid #8e8e8e;
+  font-size: 13px;
+  color: ${colors.base.grayLight};
 `
 
 const VersionSwitcher = () => (
-  <Wrapper>
-    COSMOS
-    <select
-      onChange={event => {
-        const version = event.target.value.replace(/\./g, '-')
-        window.location.href = `https://auth0-cosmos-${version}.now.sh`
-      }}
-    >
-      {versions.map(v => (
-        <option key={v} value={v}>
-          {v}
-        </option>
-      ))}
-    </select>
-  </Wrapper>
+  <StyledSelect
+    onChange={event => {
+      const version = event.target.value.replace(/\./g, '-')
+      window.location.href = `https://auth0-cosmos-${version}.now.sh`
+    }}
+  >
+    {versions.map(v => (
+      <option key={v} value={v}>
+        {v}
+      </option>
+    ))}
+  </StyledSelect>
 )
 
 export default VersionSwitcher


### PR DESCRIPTION
Improved the switcher to be more prominent :)

<img width="623" alt="screen shot 2018-09-28 at 19 47 13" src="https://user-images.githubusercontent.com/239215/46236881-693d5b80-c357-11e8-866a-0b1b54f1fdfa.png">
