### PR TITLE
Add accesibility to Tabs

### DIFF
--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -80,6 +80,12 @@ class Tabs extends React.Component {
     }
   }
 
+  handleKeyPress(e, index) {
+    if (e.key === 'Enter') {
+      this.changeTab(index)
+    }
+  }
+
   render() {
     const { selected: selectedIndex } = this.props
 
@@ -92,6 +98,8 @@ class Tabs extends React.Component {
               onClick={() => this.changeTab(index)}
               key={index}
               selected={selectedIndex === index}
+              tabIndex="0"
+              onKeyPress={e => this.handleKeyPress(e, index)}
             >
               {tab.props.label}
             </TabLink>

--- a/internal/test/unit/__snapshots__/tabs.test.js.snap
+++ b/internal/test/unit/__snapshots__/tabs.test.js.snap
@@ -9,19 +9,25 @@ exports[`Tabs only render one tab title as selected 1`] = `
       data-cosmos-key="tabs.item"
       key="0"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={true}
+      tabIndex="0"
     />
     <styled.a
       data-cosmos-key="tabs.item"
       key="1"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={false}
+      tabIndex="0"
     />
     <styled.a
       data-cosmos-key="tabs.item"
       key="2"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={false}
+      tabIndex="0"
     />
   </styled.div>
   <styled.div
@@ -44,19 +50,25 @@ exports[`Tabs only render one tab title as selected 2`] = `
       data-cosmos-key="tabs.item"
       key="0"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={false}
+      tabIndex="0"
     />
     <styled.a
       data-cosmos-key="tabs.item"
       key="1"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={true}
+      tabIndex="0"
     />
     <styled.a
       data-cosmos-key="tabs.item"
       key="2"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={false}
+      tabIndex="0"
     />
   </styled.div>
   <styled.div
@@ -79,19 +91,25 @@ exports[`Tabs only render one tab title as selected 3`] = `
       data-cosmos-key="tabs.item"
       key="0"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={false}
+      tabIndex="0"
     />
     <styled.a
       data-cosmos-key="tabs.item"
       key="1"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={false}
+      tabIndex="0"
     />
     <styled.a
       data-cosmos-key="tabs.item"
       key="2"
       onClick={[Function]}
+      onKeyPress={[Function]}
       selected={true}
+      tabIndex="0"
     />
   </styled.div>
   <styled.div


### PR DESCRIPTION
The Tabs can now be navigated using the keyboard by hitting tab

Fixes: https://github.com/auth0/cosmos/issues/923

[x] tests passes