### PR TITLE
Match alert close button styling to styleguide - Issue #942

### DIFF
--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -122,7 +122,8 @@ Alert.Element = styled.div`
     opacity: .2;
     padding: ${spacing.small} ${spacing.small};
     &:hover {
-      color: rgba(0,0,0,0.50);
+      color: rgba(0,0,0,0);
+      opacity: 0;
     }
   }
 `

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -119,7 +119,11 @@ Alert.Element = styled.div`
     right: 0;
     top: 0;
     color: ${props => colors.alert[props.type].text};
+    opacity: .2;
     padding: ${spacing.small} ${spacing.small};
+    &:hover {
+      color: rgba(0,0,0,0.50);
+    }
   }
 `
 

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -122,8 +122,8 @@ Alert.Element = styled.div`
     opacity: .2;
     padding: ${spacing.small} ${spacing.small};
     &:hover {
-      color: rgba(0,0,0,0);
-      opacity: 0;
+      color: rgba(0,0,0);
+      opacity: 0.5;
     }
   }
 `

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -122,7 +122,6 @@ Alert.Element = styled.div`
     opacity: .2;
     padding: ${spacing.small} ${spacing.small};
     &:hover {
-      color: rgba(0,0,0);
       opacity: 0.5;
     }
   }


### PR DESCRIPTION
Addresses the issue: "Match Alert close button to styleguide #942" by setting the close icon to 20% opacity and black with 50% opacity on hover.