### PR TITLE
Allow icon component instance as prop in Alert

### DIFF
--- a/core/components/_helpers/custom-validations.js
+++ b/core/components/_helpers/custom-validations.js
@@ -20,10 +20,22 @@ const numberOfValues = (elements, expectedCount) => {
   }
 }
 
-const deprecate = (props, { name, replacement }) => {
-  let message = `'Hi 👋, ${name}' prop will be deprecated in 1.0.0`
-  if (replacement) message += ` You might want to use '${replacement}' instead.`
-  if (props[name]) return new Error(message)
+const deprecate = (props, ...deprecatedProps) => {
+  for (let i = 0; i < deprecatedProps.length; i++) {
+    const { name, replacement, type, typeReplacement } = deprecatedProps[i];
+
+    let nameWithType = `'${name}' prop`;
+    if (type) nameWithType += ` with type '${type}'`;
+    let message = `Hi 👋, ${nameWithType} will be deprecated in 1.0.0.`
+    if (replacement || typeReplacement) {
+      let replacementOrType = `'${replacement}'`;
+      if (typeReplacement) replacementOrType = `type '${typeReplacement}'`
+
+      message += ` You might want to use ${replacementOrType} instead.`
+    }
+    const hasDeprecatedProp = type ? typeof props[name] === type : props[name];
+    if (hasDeprecatedProp) return new Error(message)
+  }
 }
 
 export { onlyOneOf, sumOfElements, numberOfValues, deprecate }

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -148,8 +148,8 @@ Alert.propTypes = {
   /** Style of alert to show */
   type: PropTypes.oneOf(['default', 'information', 'success', 'warning', 'danger']).isRequired,
 
-  /** Name of icon */
-  icon: PropTypes.oneOfType([PropTypes.oneOf(__ICONNAMES__), PropTypes.element]),
+  /** Icon element or name of Icon*/
+  icon: PropTypes.oneOfType([PropTypes.element, PropTypes.oneOf(__ICONNAMES__)]),
 
   /** Title text (in bold) */
   title: PropTypes.string,
@@ -169,7 +169,12 @@ Alert.propTypes = {
   /** Automatically dismiss after N seconds */
   dismissAfterSeconds: PropTypes.number,
 
-  _error: props => deprecate(props, { name: 'text', replacement: 'children' })
+  _error: props =>
+    deprecate(
+      props,
+      { name: 'text', replacement: 'children' },
+      { name: 'icon', type: 'string', typeReplacement: 'element' }
+    )
 }
 
 Alert.defaultProps = {

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -11,8 +11,10 @@ import Automation from '../../_helpers/automation-attribute'
 import Icon, { __ICONNAMES__ } from '../icon'
 
 const createIconForAlert = (icon, color) => {
-  // We also support passing raw <Icon> components and need to override the
-  // color prop in that case.
+  const iconIsName = typeof icon === 'string'
+  if (iconIsName) {
+    return <Icon name={icon} color={color} />
+  }
 
   return React.cloneElement(icon, { color })
 }
@@ -57,20 +59,13 @@ class Alert extends React.Component {
 
   render() {
     if (this.state.visible) {
-      const iconIsName = typeof this.props.icon === 'string'
-
       return (
         <Alert.Element
           type={this.props.type}
           dismissible={this.props.dismissible}
           {...Automation('alert')}
         >
-          {this.props.icon &&
-            (iconIsName ? (
-              <Icon name={this.props.icon} color={iconColorMap[this.props.type]} />
-            ) : (
-              createIconForAlert(this.props.icon, iconColorMap[this.props.type])
-            ))}
+          {this.props.icon && createIconForAlert(this.props.icon, iconColorMap[this.props.type])}
           <Paragraph>
             <Text type="strong">{this.props.title}</Text> <FreeText {...this.props} />
             {this.props.link && (

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -10,6 +10,13 @@ import { deprecate } from '../../_helpers/custom-validations'
 import Automation from '../../_helpers/automation-attribute'
 import Icon, { __ICONNAMES__ } from '../icon'
 
+const createIconForAlert = (icon, color) => {
+  // We also support passing raw <Icon> components and need to override the
+  // color prop in that case.
+
+  return React.cloneElement(icon, { color })
+}
+
 const ReadMoreLink = styled(Link)`
   color: ${props => colors.alert[props.type].text};
   text-decoration: underline;
@@ -50,13 +57,20 @@ class Alert extends React.Component {
 
   render() {
     if (this.state.visible) {
+      const iconIsName = typeof this.props.icon === 'string'
+
       return (
         <Alert.Element
           type={this.props.type}
           dismissible={this.props.dismissible}
           {...Automation('alert')}
         >
-          {this.props.icon && <Icon name={this.props.icon} color={iconColorMap[this.props.type]} />}
+          {this.props.icon &&
+            (iconIsName ? (
+              <Icon name={this.props.icon} color={iconColorMap[this.props.type]} />
+            ) : (
+              createIconForAlert(this.props.icon, iconColorMap[this.props.type])
+            ))}
           <Paragraph>
             <Text type="strong">{this.props.title}</Text> <FreeText {...this.props} />
             {this.props.link && (
@@ -140,7 +154,7 @@ Alert.propTypes = {
   type: PropTypes.oneOf(['default', 'information', 'success', 'warning', 'danger']).isRequired,
 
   /** Name of icon */
-  icon: PropTypes.oneOf(__ICONNAMES__),
+  icon: PropTypes.oneOfType([PropTypes.oneOf(__ICONNAMES__), PropTypes.element]),
 
   /** Title text (in bold) */
   title: PropTypes.string,

--- a/core/components/atoms/alert/alert.md
+++ b/core/components/atoms/alert/alert.md
@@ -9,7 +9,7 @@
 The `Alert` component should be used to draw the user's attention to a message.
 
 ```jsx
-<Alert {props} defaults={{type: "warning", icon:"warning", title: "Notice!"}}>This is an important message!</Alert>
+<Alert icon={<Icon name="warning" />} {props} defaults={{type: "warning", title: "Notice!"}}>This is an important message!</Alert>
 ```
 
 ## Examples
@@ -20,23 +20,23 @@ There are multiple alert types for different situations
 
 ```js
 <div>
-  <Alert icon="notes" type="default" title="FYI!">
+  <Alert icon={<Icon name="notes" />} type="default" title="FYI!">
     Just a regular message
   </Alert>
   <br />
-  <Alert icon="megaphone" type="information" title="Hi!">
+  <Alert icon={<Icon name="megaphone" />} type="information" title="Hi!">
     You should probably know this
   </Alert>
   <br />
-  <Alert icon="check-circle" type="success" title="Good job!">
+  <Alert icon={<Icon name="check-circle" />} type="success" title="Good job!">
     You did the thing!
   </Alert>
   <br />
-  <Alert icon="danger" type="danger" title="Oh no!">
+  <Alert icon={<Icon name="danger" />} type="danger" title="Oh no!">
     We've got bad news
   </Alert>
   <br />
-  <Alert icon="warning" type="warning" title="Notice!">
+  <Alert icon={<Icon name="warning" />} type="warning" title="Notice!">
     You should pay attention
   </Alert>
 </div>

--- a/core/components/atoms/alert/alert.story.js
+++ b/core/components/atoms/alert/alert.story.js
@@ -74,7 +74,7 @@ storiesOf('Alert').add('with icon', () => (
 storiesOf('Alert').add('with icon component', () => (
   <Example>
     {types.map(type => (
-      <Alert type={type} title="A title" link="/test" icon={<Icon name="check" />} key={type}>
+      <Alert type={type} title="A title" link="/test" icon={<Icon name="hourglass" />} key={type}>
         This is the <Text type="strong">alert</Text>
       </Alert>
     ))}

--- a/core/components/atoms/alert/alert.story.js
+++ b/core/components/atoms/alert/alert.story.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { storiesOf } from '@storybook/react'
 import { Example as ExampleHelper } from '@auth0/cosmos/_helpers/story-helpers'
 import { Alert, Link, Text } from '@auth0/cosmos'
+import Icon, { __ICONNAMES__ } from '../icon'
 
 const Example = styled(ExampleHelper)`
   ${Alert.Element} {
@@ -64,6 +65,16 @@ storiesOf('Alert').add('with icon', () => (
   <Example>
     {types.map(type => (
       <Alert type={type} title="A title" link="/test" icon="hourglass" key={type}>
+        This is the <Text type="strong">alert</Text>
+      </Alert>
+    ))}
+  </Example>
+))
+
+storiesOf('Alert').add('with icon component', () => (
+  <Example>
+    {types.map(type => (
+      <Alert type={type} title="A title" link="/test" icon={<Icon name="check" />} key={type}>
         This is the <Text type="strong">alert</Text>
       </Alert>
     ))}


### PR DESCRIPTION
Hey 👋 

I saw #972 and hope this goes into the right direction. This PR updates the `Alert` component to also accept a React element as an `icon` prop. This is part of the migration to support component instances as props.

### Questions:
- ~Should there be a validation to only accept instances of `Icon`?~
- Should usage of the string `icon` prop be deprecated?

### Todo's
- [ ] Update `Alert` docs