### PR TITLE
Truncate tab lable name when it's too big - Issue #987

### DIFF
--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -15,7 +15,10 @@ export const TabLink = styled.a`
   cursor: ${props => (props.selected ? 'default' : 'pointer')};
   border-bottom: 1px solid ${props => (props.selected ? colors.base.text : 'transparent')};
   margin-bottom: -1px;
-
+  word-wrap: break-word;
+  word-break: break-all;
+  hyphens: auto;
+  
   &:hover {
     color: ${props => (!props.selected ? colors.link.defaultHover : colors.text.default)};
   }


### PR DESCRIPTION
Fix issue #987 