### PR TITLE
Table columns can now be passed as external children

### DIFF
--- a/core/components/molecules/table/table.js
+++ b/core/components/molecules/table/table.js
@@ -90,7 +90,7 @@ class Table extends React.Component {
   }
 
   render() {
-    const columns = this.inferColumnsFromChildren(this.props.children)
+    let columns = this.inferColumnsFromChildren(this.props.children)
     let sortedItems, sortingColumn, sortDirection, onSort
     const { loading } = this.props
 
@@ -112,6 +112,15 @@ class Table extends React.Component {
         sortDirection,
         sortingColumn
       })
+    }
+
+    // If columns are passed as a variable or as a child to <div> element
+    if (columns[0].children != undefined && columns[0].children.length > 1) {
+      let nestedColumns = []
+      columns[0].children.map(column => {
+        nestedColumns.push(column.props)
+      })
+      columns = nestedColumns
     }
 
     const rows = sortedItems.map((item, index) => (

--- a/core/components/molecules/table/table.story.js
+++ b/core/components/molecules/table/table.story.js
@@ -34,12 +34,6 @@ const items = [
   }
 ]
 
-const columns = (<div>
-  <Table.Column field="name" title="Name" />
-  <Table.Column field="born" title="Born" />
-  <Table.Column field="died" title="Died" />
-</div>)
-
 storiesOf('Table').add('default', () => (
   <Example title="default">
     <Table items={items}>
@@ -50,13 +44,22 @@ storiesOf('Table').add('default', () => (
   </Example>
 ))
 
-storiesOf('Table').add('column as variable', () => (
-  <Example title="default">
-    <Table items={items}>
-      {columns}
-    </Table>
-  </Example>
-))
+storiesOf('Table').add('column as variable', () => {
+  const columns = (
+    <React.Fragment>
+      <Table.Column field="name" title="Name" />
+      <Table.Column field="born" title="Born" />
+      <Table.Column field="died" title="Died" />
+    </React.Fragment>
+  )
+
+  return (
+    <Example title="default">
+      <Table items={items}>{columns}</Table>
+    </Example>
+  )
+})
+
 storiesOf('Table').add('explicit widths', () => (
   <Example title="default">
     <Table items={items}>
@@ -151,7 +154,7 @@ storiesOf('Table').add('with no items', () => (
           action={{
             icon: 'plus',
             label: 'Create one manually',
-            handler: function () {
+            handler: function() {
               /*...*/
             }
           }}

--- a/core/components/molecules/table/table.story.js
+++ b/core/components/molecules/table/table.story.js
@@ -34,6 +34,12 @@ const items = [
   }
 ]
 
+const columns = (<div>
+  <Table.Column field="name" title="Name" />
+  <Table.Column field="born" title="Born" />
+  <Table.Column field="died" title="Died" />
+</div>)
+
 storiesOf('Table').add('default', () => (
   <Example title="default">
     <Table items={items}>
@@ -44,6 +50,13 @@ storiesOf('Table').add('default', () => (
   </Example>
 ))
 
+storiesOf('Table').add('column as variable', () => (
+  <Example title="default">
+    <Table items={items}>
+      {columns}
+    </Table>
+  </Example>
+))
 storiesOf('Table').add('explicit widths', () => (
   <Example title="default">
     <Table items={items}>
@@ -138,7 +151,7 @@ storiesOf('Table').add('with no items', () => (
           action={{
             icon: 'plus',
             label: 'Create one manually',
-            handler: function() {
+            handler: function () {
               /*...*/
             }
           }}


### PR DESCRIPTION
Now you can store all the columns in a variable and pass that children as a variable, albeit as first-child only. Fixes- #893 

```jsx
const defaultItems = [
  {
    name: 'Harry Kane',
    goals: 6,
    assists: 0,
    country: '🇬🇧',
    image: 'https://twitter-avatar.now.sh/HKane'
  },
  {
    name: 'Romelu Lukaku',
    goals: 4,
    assists: 1,
    country: '🇧🇪',
    image: 'https://twitter-avatar.now.sh/Romelu_lukaku9'
  },
  {
    name: 'Antoine Griezmann',
    goals: 4,
    assists: 2,
    country: '🇫🇷',
    image: 'https://twitter-avatar.now.sh/AntoGriezmann'
  },
  {
    name: 'Ivan Perišić',
    goals: 3,
    assists: 1,
    country: '🇭🇷',
    image: 'https://twitter-avatar.now.sh/ivanperisic44'
  }
]

const columns = (<div>
      <Table.Column field="image" width="50px">
        {item => <Avatar type="user" image={item.image} />}
      </Table.Column>
      <Table.Column field="name" title="Name" width="30%" />
      <Table.Column field="country" title="Country" />
      <Table.Column field="goals" title="Goals" />
      <Table.Column field="assists" title="Assists" />
</div>)


const Example = () => {
  return <Table items={defaultItems}>{columns}</Table>
}

render(Example)
```