### PR TITLE
Fix sidebar scrolling in Firefox (fixes #994)

### DIFF
--- a/internal/docs/app.js
+++ b/internal/docs/app.js
@@ -19,6 +19,8 @@ import Navigation from './docs-components/navigation'
 const SideContent = styled.div`
   width: 19rem;
   position: fixed;
+  height: calc(100vh - 80px);
+  overflow-y: auto;
   transition: width 0.25s;
 
   @media (max-width: 800px) {

--- a/internal/docs/sidebar/index.js
+++ b/internal/docs/sidebar/index.js
@@ -10,8 +10,6 @@ import { metadata as components } from '@auth0/cosmos/meta/metadata.json'
 
 const StyledSidebar = styled.div`
   background: ${colors.base.grayLightest};
-  height: 100vh;
-  overflow: scroll;
   padding-bottom: calc(2rem + 80px);
 `
 


### PR DESCRIPTION
This PR fixes a scrolling bug in the sidebar, it now works as expected in Firefox:
![image](https://user-images.githubusercontent.com/3057302/47059219-c9792d80-d19e-11e8-8c45-dbe184b5472a.png)
