### PR TITLE
Made secondary button's border darker

### DIFF
--- a/core/tokens/colors.js
+++ b/core/tokens/colors.js
@@ -98,7 +98,7 @@ const colors = {
       backgroundActive: '#DADADA',
       text: '#333',
       icon: 'default',
-      border: '#D0D2D3',
+      border: '#696969',
       borderHover: '#B5B7B8',
       borderFocus: '#B5B7B8',
       borderActive: '#DADADA'


### PR DESCRIPTION
Since secondary button's border was too light and therefore did not play well with some grey backgrounds, as suggested I have made the border darker.

fixes #823 