### PR TITLE
Pager buttons alignment fix

### DIFF
--- a/core/components/molecules/pager/pager.js
+++ b/core/components/molecules/pager/pager.js
@@ -22,12 +22,6 @@ const StyledPageSelector = styled.div`
 const StyledButton = styled(Button)`
   ${props => (props.position === 'left' ? 'padding-right' : 'padding-left')}: 11px;
   ${props => (props.position === 'left' ? 'padding-left' : 'padding-right')}: 7px;
-
-  padding-top: 2px;
-
-  ${Icon.Element} {
-    margin: 0;
-  }
 `
 
 const Pager = ({ onPageChanged, page, perPage, items }) => (

--- a/core/components/molecules/pager/pager.js
+++ b/core/components/molecules/pager/pager.js
@@ -22,6 +22,9 @@ const StyledPageSelector = styled.div`
 const StyledButton = styled(Button)`
   ${props => (props.position === 'left' ? 'padding-right' : 'padding-left')}: 11px;
   ${props => (props.position === 'left' ? 'padding-left' : 'padding-right')}: 7px;
+  ${Icon.Element} {
+    margin: 0;
+  }
 `
 
 const Pager = ({ onPageChanged, page, perPage, items }) => (


### PR DESCRIPTION
This looks unintentional:
![image](https://user-images.githubusercontent.com/1863771/47495771-a3c0e800-d872-11e8-9fab-4e5475a3ad20.png)


Removing some overrides, let the button contents centre themselves.

The button is now shorter because its' using the height that `<Button size="compressed"/>` gives it like a good compound component (see chromatic)

(Found while trying to fix https://github.com/auth0/cosmos/pull/955)