### PR TITLE
Reset line height in story wrapper

### DIFF
--- a/core/components/_helpers/story-example.js
+++ b/core/components/_helpers/story-example.js
@@ -7,7 +7,6 @@ const Title = styled.div`
   font-family: 'Roboto Mono';
   font-size: 12px;
   color: rgb(168, 168, 168);
-  top: 1.5em;
   left: 2em;
 `
 

--- a/core/components/_helpers/story-example.js
+++ b/core/components/_helpers/story-example.js
@@ -7,10 +7,12 @@ const Title = styled.div`
   font-family: 'Roboto Mono';
   font-size: 12px;
   color: rgb(168, 168, 168);
+  top: 1.5em;
   left: 2em;
 `
 
 const Wrapper = styled.div`
+  line-height: inherit;
   padding: 4.5rem 3rem 3rem 3rem;
   position: relative;
   border: 1px solid rgb(236, 236, 236);


### PR DESCRIPTION
`[class^="sc-"] { line-height: 1.6; }` also applies to the story wrapper, which means any components inheriting line-height will take the wrapper's line-height. 

This makes our tests less confident as the components might not behave the same way in a different environment

Overriding this to `inherit`