### PR TITLE
feat: Added subtitle to page-header component

### DIFF
--- a/core/components/molecules/page-header/page-header.js
+++ b/core/components/molecules/page-header/page-header.js
@@ -26,6 +26,13 @@ const StyledPageHeader = styled.div`
   }
 `
 
+const StyledSubtitle = styled.div`
+  color: gray;
+  margin-top: 0;
+  margin-bottom: -12px;
+  padding-left: ${spacing.xxsmall};
+`
+
 const SoftDescription = ({ description, learnMore }) => {
   if (!description) return null
 
@@ -39,6 +46,38 @@ const SoftDescription = ({ description, learnMore }) => {
 }
 
 const PageHeader = props => {
+  if (props.subtitle) {
+    return (
+      <StyledPageHeader {...Automation('page-header')}>
+        <ButtonGroup align="right">
+          {props.secondaryAction && (
+            <Button
+              size="large"
+              appearance="secondary"
+              icon={props.secondaryAction.icon}
+              onClick={props.secondaryAction.handler}
+            >
+              {props.secondaryAction.label}
+            </Button>
+          )}
+          {props.primaryAction && (
+            <Button
+              size="large"
+              appearance="cta"
+              icon={props.primaryAction.icon}
+              onClick={props.primaryAction.handler}
+            >
+              {props.primaryAction.label}
+            </Button>
+          )}
+        </ButtonGroup>
+  
+        <Heading size={1} style={{marginBottom:-10 +"px"}}>{props.title}</Heading>
+        <StyledSubtitle>{props.subtitle}</StyledSubtitle>
+        <SoftDescription {...props} />
+      </StyledPageHeader>
+    )
+  }
   return (
     <StyledPageHeader {...Automation('page-header')}>
       <ButtonGroup align="right">

--- a/core/components/molecules/page-header/page-header.story.js
+++ b/core/components/molecules/page-header/page-header.story.js
@@ -29,6 +29,32 @@ storiesOf('Page Header').add('default', () => (
   </Example>
 ))
 
+storiesOf('Page Header').add('with subtitle', () => (
+  <Example title="default">
+    <PageHeader
+      title="Clients"
+      subtitle="The API consumers"
+      description={
+        <span>
+          Setup a mobile, web or IoT application to{' '}
+          <Text type="strong">use Auth0 for Authentication</Text>.
+        </span>
+      }
+      learnMore="/link"
+      primaryAction={{
+        label: 'Create Client',
+        icon: 'plus',
+        handler: () => {}
+      }}
+      secondaryAction={{
+        label: 'Tutorial',
+        icon: 'play-circle',
+        handler: () => {}
+      }}
+    />
+  </Example>
+))
+
 storiesOf('Page Header').add('only primary action', () => (
   <Example title="default">
     <PageHeader


### PR DESCRIPTION
Now the component from page header has an optional subtitle option which
creates a gray text next to the component name. As expected in the
contribution guideline the story to this new feature is now on.

Resolves: #1004