### PR TITLE
remove line height in example

### DIFF
--- a/core/components/_helpers/story-example.js
+++ b/core/components/_helpers/story-example.js
@@ -9,6 +9,7 @@ const Title = styled.div`
   color: rgb(168, 168, 168);
   top: 1.5em;
   left: 2em;
+  line-height: 1.6;
 `
 
 const Wrapper = styled.div`
@@ -17,6 +18,7 @@ const Wrapper = styled.div`
   border: 1px solid rgb(236, 236, 236);
   margin-bottom: 1rem;
   border-radius: 3px;
+  line-height: inherit;
 
   &.align-center {
     display: flex;


### PR DESCRIPTION
While working on https://github.com/auth0/cosmos/pull/955, I found that our tests setup also get the sc^ hack because it is built with styled-components

Any components inheriting line-height will take the wrapper's line-height. This makes our tests less reliable as the components might not behave the same way in a different environment (like styleguide)

This is how our components look outside of cosmos right now

I'm resetting the line-height in the story wrapper to inherit to establish a new source of truth for tests in #955 (where I'm fixing them)

For other PRs, you might want to back merge for best results