### PR TITLE
Tabs focus styles

### DIFF
--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -1,10 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { styled, css } from 'styled-components'
+import styled, { css } from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 
 import Automation from '../../_helpers/automation-attribute'
-
 const Wrapper = styled.div``
 
 export const TabLink = styled.a`

--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import { styled, css } from 'styled-components'
 import { colors, spacing } from '@auth0/cosmos-tokens'
 
 import Automation from '../../_helpers/automation-attribute'
@@ -11,14 +11,24 @@ export const TabLink = styled.a`
   display: inline-block;
   padding: ${spacing.small} 0;
   margin-right: ${spacing.large};
-  color: ${props => (props.selected ? colors.text.default : colors.link.default)};
-  cursor: ${props => (props.selected ? 'default' : 'pointer')};
-  border-bottom: 1px solid ${props => (props.selected ? colors.base.text : 'transparent')};
+  color: ${colors.link.default};
+  border-bottom: 1px solid transparent';
   margin-bottom: -1px;
-
+  &:focus {
+    outline: none;
+    border-bottom-color: ${colors.link.default};
+    color: ${colors.link.default};
+  }
   &:hover {
     color: ${props => (!props.selected ? colors.link.defaultHover : colors.text.default)};
   }
+  ${props =>
+    props.selected &&
+    css`
+      cursor: pointer;
+      color: ${colors.text.default};
+      border-bottom-color: ${colors.base.text};
+    `};
 `
 
 export const TabLinkGroup = styled.div`

--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -11,22 +11,28 @@ export const TabLink = styled.a`
   padding: ${spacing.small} 0;
   margin-right: ${spacing.large};
   color: ${colors.link.default};
-  border-bottom: 1px solid transparent';
+  cursor: pointer;
+  border-bottom: 1px solid transparent;
   margin-bottom: -1px;
-  &:focus {
-    outline: none;
-    border-bottom-color: ${colors.link.default};
-    color: ${colors.link.default};
-  }
   &:hover {
     color: ${props => (!props.selected ? colors.link.defaultHover : colors.text.default)};
+  }
+  &:focus {
+    outline: none;
+    border-bottom: 1px solid ${colors.link.default};
+  }
+  &:active {
+    border-bottom: 1px solid ${colors.base.text};
   }
   ${props =>
     props.selected &&
     css`
-      cursor: pointer;
+      border-bottom: 1px solid ${colors.base.text};
+      cursor: default;
       color: ${colors.text.default};
-      border-bottom-color: ${colors.base.text};
+      &:focus {
+        border-bottom: 1px solid ${colors.base.text};
+      }
     `};
 `
 


### PR DESCRIPTION
Added some custom and subtle focus styles for the tab element. Would like to do a 2nd iteration with some less subtlety. More than nothing, this was an excuse to see if the following notation for conditional CSS is more clear or not. the new one is longer cause it has more styles (for focus and active).

**Old:**
```js
export const TabLink = styled.a`
  display: inline-block;
  padding: ${spacing.small} 0;
  margin-right: ${spacing.large};
  color: ${props => (props.selected ? colors.text.default : colors.link.default)};
  cursor: ${props => (props.selected ? 'default' : 'pointer')};
  border-bottom: 1px solid ${props => (props.selected ? colors.base.text : 'transparent')};
  margin-bottom: -1px;

  &:hover {
    color: ${props => (!props.selected ? colors.link.defaultHover : colors.text.default)};
  }
`
```

**New:**
```js
export const TabLink = styled.a`
  display: inline-block;
  padding: ${spacing.small} 0;
  margin-right: ${spacing.large};
  color: ${colors.link.default};
  cursor: pointer;
  border-bottom: 1px solid transparent;
  margin-bottom: -1px;
  &:hover {
    color: ${props => (!props.selected ? colors.link.defaultHover : colors.text.default)};
  }
  &:focus {
    outline: none;
    border-bottom: 1px solid ${colors.link.default};
  }
  &:active {
    border-bottom: 1px solid ${colors.base.text};
  }
  ${props =>
    props.selected &&
    css`
      border-bottom: 1px solid ${colors.base.text};
      cursor: default;
      color: ${colors.text.default};
      &:focus {
        border-bottom: 1px solid ${colors.base.text};
      }
    `};
`
```