### PR TITLE
Build scripts should use production mode

### DIFF
--- a/core/engine/configs/webpack.production.config.js
+++ b/core/engine/configs/webpack.production.config.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   entry: './index.js',
   output: {
     filename: 'main.[contenthash].js',


### PR DESCRIPTION
```diff
// core/engine/configs/webpack.production.config.js

- mode: 'development'
+ mode: 'production'
```