### PR TITLE
Disabled option in select component

### DIFF
--- a/core/components/atoms/select/select.js
+++ b/core/components/atoms/select/select.js
@@ -9,6 +9,8 @@ const StyledSelect = StyledInput.withComponent('select').extend`
   height: ${misc.input.default.height};
 `
 
+const StyledOption = StyledInput.withComponent('option')
+
 const Select = ({ options, ...props }) => {
   /*
     select boxes do not support readonly like input boxes,
@@ -20,14 +22,14 @@ const Select = ({ options, ...props }) => {
   return (
     <StyledSelect {...props} {...Automation('select')}>
       {/* First option will be selected if there is no value passed as a prop */}
-      <option disabled hidden selected={!props.value} value="" {...Automation('select.option')}>
+      <StyledOption disabled hidden selected={!props.value} value="" {...Automation('select.option')}>
         {props.placeholder}
-      </option>
+      </StyledOption>
 
       {options.map((option, index) => (
-        <option key={index} value={option.value} {...Automation('select.option')}>
+        <StyledOption key={index} value={option.value} readOnly={option.readOnly} disabled={option.readOnly} {...Automation('select.option')}>
           {option.text}
-        </option>
+        </StyledOption>
       ))}
     </StyledSelect>
   )
@@ -38,7 +40,8 @@ Select.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string.isRequired,
-      value: PropTypes.any.isRequired
+      value: PropTypes.any.isRequired,
+      readOnly: PropTypes.bool
     })
   ).isRequired,
   /** Make input readOnly if it does not validate constraint */

--- a/core/components/atoms/select/select.md
+++ b/core/components/atoms/select/select.md
@@ -9,7 +9,7 @@
 <Select {props}
   placeholder="Select an option..."
   options={[
-    { text: 'One', value: 1 },
+    { text: 'One', value: 1, readOnly: true },
     { text: 'Two', value: 2 },
     { text: 'Three', value: 3 }
   ]}

--- a/core/components/atoms/select/select.story.js
+++ b/core/components/atoms/select/select.story.js
@@ -5,7 +5,7 @@ import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 import { Select } from '@auth0/cosmos'
 
 storiesOf('Select').add('simple', () => (
-  <Example title="Code">
+  <Example title="Select: simple">
     <Select
       options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
       onChange={event => console.log(event)}
@@ -14,7 +14,7 @@ storiesOf('Select').add('simple', () => (
 ))
 
 storiesOf('Select').add('with placeholder', () => (
-  <Example title="Code">
+  <Example title="Select: with placeholder">
     <Select
       placeholder="Select an option..."
       options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
@@ -24,7 +24,7 @@ storiesOf('Select').add('with placeholder', () => (
 ))
 
 storiesOf('Select').add('default value', () => (
-  <Example title="Code">
+  <Example title="Select: with default value">
     <Select
       value={2}
       options={[{ text: 'One', value: 1 }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
@@ -34,7 +34,7 @@ storiesOf('Select').add('default value', () => (
 ))
 
 storiesOf('Select').add('readonly', () => (
-  <Example title="Code">
+  <Example title="Select: readonly">
     <Select
       value={2}
       readonly
@@ -44,8 +44,19 @@ storiesOf('Select').add('readonly', () => (
   </Example>
 ))
 
+storiesOf('Select').add('readonly option', () => (
+  <Example title="Select: readonly option">
+    <Select
+      placeholder="Selct from the enabled options"
+      readonly
+      options={[{ text: 'One', value: 1, readonly: true }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
+      onChange={event => console.log(event)}
+    />
+  </Example>
+))
+
 storiesOf('Select').add('stressed', () => (
-  <Example title="stressed - 56 characters with 300px width">
+  <Example title="Select: stressed - 56 characters with 300px width">
     <Select
       value={1}
       style={{ width: 300 }}

--- a/core/components/atoms/select/select.story.js
+++ b/core/components/atoms/select/select.story.js
@@ -48,7 +48,6 @@ storiesOf('Select').add('readonly option', () => (
   <Example title="Select: readonly option">
     <Select
       placeholder="Selct from the enabled options"
-      readonly
       options={[{ text: 'One', value: 1, readonly: true }, { text: 'Two', value: 2 }, { text: 'Three', value: 3 }]}
       onChange={event => console.log(event)}
     />


### PR DESCRIPTION
### What's working (Resolves #1062 )
- Added the feature to identify the option if it is readOnly.
### What's not working
- Examples of `select` component fail to work in **readOnly** mode in Stories (reference [here](https://github.com/auth0/cosmos/issues/1062#issuecomment-435575655))