### PR TITLE
[API Consistency] Alert: Icon component as prop

### DIFF
--- a/core/components/_helpers/icon-prop.js
+++ b/core/components/_helpers/icon-prop.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import Icon from '../atoms/icon'
+
+export default prop => {
+  if (typeof prop === 'string') {
+    console.warn('Passing icons as string has been deprecated and will be removed in Cosmos 1.0.')
+    console.log(`Please replace 'icon="${prop}"' with 'icon={<Icon name="${prop}"/>}'`)
+    return <Icon name={prop} />
+  }
+
+  return prop
+}

--- a/core/components/atoms/alert/alert.js
+++ b/core/components/atoms/alert/alert.js
@@ -9,6 +9,7 @@ import FreeText from '../../_helpers/free-text'
 import { deprecate } from '../../_helpers/custom-validations'
 import Automation from '../../_helpers/automation-attribute'
 import Icon, { __ICONNAMES__ } from '../icon'
+import iconProp from '../../_helpers/icon-prop'
 
 const ReadMoreLink = styled(Link)`
   color: ${props => colors.alert[props.type].text};
@@ -56,7 +57,7 @@ class Alert extends React.Component {
           dismissible={this.props.dismissible}
           {...Automation('alert')}
         >
-          {this.props.icon && <Icon name={this.props.icon} color={iconColorMap[this.props.type]} />}
+          {this.props.icon && iconProp(this.props.icon)}
           <Paragraph>
             <Text type="strong">{this.props.title}</Text> <FreeText {...this.props} />
             {this.props.link && (
@@ -145,7 +146,7 @@ Alert.propTypes = {
   type: PropTypes.oneOf(['default', 'information', 'success', 'warning', 'danger']).isRequired,
 
   /** Name of icon */
-  icon: PropTypes.oneOf(__ICONNAMES__),
+  icon: PropTypes.oneOfType([PropTypes.oneOf(__ICONNAMES__), PropTypes.element]),
 
   /** Title text (in bold) */
   title: PropTypes.string,

--- a/core/components/atoms/alert/alert.md
+++ b/core/components/atoms/alert/alert.md
@@ -9,7 +9,7 @@
 The `Alert` component should be used to draw the user's attention to a message.
 
 ```jsx
-<Alert {props} defaults={{type: "warning", icon:"warning", title: "Notice!"}}>This is an important message!</Alert>
+<Alert {props} defaults={{type: "warning", title: "Notice!"}}>This is an important message!</Alert>
 ```
 
 ## Examples
@@ -20,23 +20,23 @@ There are multiple alert types for different situations
 
 ```js
 <div>
-  <Alert icon="notes" type="default" title="FYI!">
+  <Alert icon={<Icon name="notes" />} type="default" title="FYI!">
     Just a regular message
   </Alert>
   <br />
-  <Alert icon="megaphone" type="information" title="Hi!">
+  <Alert icon={<Icon name="megaphone" />} type="information" title="Hi!">
     You should probably know this
   </Alert>
   <br />
-  <Alert icon="check-circle" type="success" title="Good job!">
+  <Alert icon={<Icon name="check-circle" />} type="success" title="Good job!">
     You did the thing!
   </Alert>
   <br />
-  <Alert icon="danger" type="danger" title="Oh no!">
+  <Alert icon={<Icon name="danger" />} type="danger" title="Oh no!">
     We've got bad news
   </Alert>
   <br />
-  <Alert icon="warning" type="warning" title="Notice!">
+  <Alert icon={<Icon name="warning" />} type="warning" title="Notice!">
     You should pay attention
   </Alert>
 </div>

--- a/core/components/atoms/alert/alert.story.js
+++ b/core/components/atoms/alert/alert.story.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { storiesOf } from '@storybook/react'
 import { Example as ExampleHelper } from '@auth0/cosmos/_helpers/story-helpers'
-import { Alert, Link, Text } from '@auth0/cosmos'
+import { Alert, Link, Text, Icon } from '@auth0/cosmos'
 
 const Example = styled(ExampleHelper)`
   ${Alert.Element} {
@@ -65,7 +65,7 @@ storiesOf('Alert').add('with title and link', () => (
 storiesOf('Alert').add('with icon', () => (
   <Example>
     {types.map(type => (
-      <Alert type={type} title="A title" link="/test" icon="hourglass" key={type}>
+      <Alert type={type} title="A title" link="/test" icon={<Icon name="hourglass" />} key={type}>
         This is the <Text type="strong">alert</Text>
       </Alert>
     ))}


### PR DESCRIPTION
Deprecates:
```js
<Alert icon="warning" ... />
```

in favor of:
```js
<Alert icon={<Icon name="warning" />} ... />
```