### PR TITLE
Make default prop change warning to appear if there is not a value set for the prop

### DIFF
--- a/core/components/_helpers/default-prop-change.js
+++ b/core/components/_helpers/default-prop-change.js
@@ -7,7 +7,8 @@ export default function defaultPropChangeWarning(
 ) {
   const componentName = Component.constructor.name
   const currentDefault = Component.defaultProps[propName]
-  if (currentDefault === futureDefault) return
+  const currentValueIsSet = typeof currentValue !== 'undefined'
+  if (currentDefault === futureDefault || currentValueIsSet) return
 
   const warning = `
 	The prop '${propName}' of the ${componentName} component will change from '${currentDefault}' to '${futureDefault}' on version ${version} of Cosmos.


### PR DESCRIPTION
Fixes #1092 