### PR TITLE
Docs: Removed links that can be found in the Top navigation

### DIFF
--- a/internal/docs/sidebar/list.js
+++ b/internal/docs/sidebar/list.js
@@ -35,9 +35,7 @@ const guides = [
   { path: '/contribution-guide', title: 'Contributing to Cosmos' },
   { path: '/faqs', title: 'FAQs' },
   { path: '/changes', title: 'Changelog' },
-  { path: '/overview', title: 'Component overview' },
-  { path: '/automation', title: 'Automation Glossary' },
-  { path: '/playground', title: 'Cosmos playground' }
+  { path: '/automation', title: 'Automation Glossary' }
 ]
 
 const List = props => {


### PR DESCRIPTION
Removed the Overview and Playground links from the Docs sidebar. 