### PR TITLE
Fix applications details warning to be thrown by a missing prop

### DIFF
--- a/examples/manage/pages/application-detail/settings.js
+++ b/examples/manage/pages/application-detail/settings.js
@@ -77,7 +77,7 @@ class Settings extends React.Component {
             ]}
             helpText="The type of application will determine which settings you can configure from the dashboard."
           />
-            
+
           <Form.Select
             onChange={ev => this.setState({ tokenEndpointAuthentication: ev.target.value })}
             value={this.state.tokenEndpointAuthentication}

--- a/examples/manage/pages/application-detail/settings.js
+++ b/examples/manage/pages/application-detail/settings.js
@@ -10,7 +10,9 @@ class Settings extends React.Component {
       name: 'API Explorer Application',
       domain: 'storezero.auth0.com',
       applicationID: props.applicationId,
-      secret: 'asoidvsubdwfqeagwbviuyeaobvi'
+      secret: 'asoidvsubdwfqeagwbviuyeaobvi',
+      applicationType: '',
+      tokenEndpointAuthentication: ''
     }
   }
   save() {}
@@ -64,6 +66,8 @@ class Settings extends React.Component {
             helpText="The URL of the logo to display for the application, if none is set the default badge for this type of application will be shown. Recommended size is 150x150 pixels."
           />
           <Form.Select
+            onChange={ev => this.setState({ applicationType: ev.target.value })}
+            value={this.state.applicationType}
             label="Application Type"
             options={[
               { text: 'Native', value: 'native', defaultSelected: true },
@@ -72,9 +76,11 @@ class Settings extends React.Component {
               { text: 'Single Page Application', value: 'spa' }
             ]}
             helpText="The type of application will determine which settings you can configure from the dashboard."
-          />
-
+            />
+            
           <Form.Select
+            onChange={ev => this.setState({ tokenEndpointAuthentication: ev.target.value })}
+            value={this.state.tokenEndpointAuthentication}
             label="Token Endpoint Authentication handler"
             options={[
               { text: 'None', value: 'none' },

--- a/examples/manage/pages/application-detail/settings.js
+++ b/examples/manage/pages/application-detail/settings.js
@@ -76,7 +76,7 @@ class Settings extends React.Component {
               { text: 'Single Page Application', value: 'spa' }
             ]}
             helpText="The type of application will determine which settings you can configure from the dashboard."
-            />
+          />
             
           <Form.Select
             onChange={ev => this.setState({ tokenEndpointAuthentication: ev.target.value })}


### PR DESCRIPTION
When i went to application detail, it was showing me an error screen

it was because the `Form.Select` was missing a prop, so i added and now the example view works fine