### PR TITLE
Remove prop-types to typescript declarations module

### DIFF
--- a/core/components/package.json
+++ b/core/components/package.json
@@ -8,7 +8,6 @@
   "keywords": [],
   "author": "auth0",
   "license": "MIT",
-  "types": "meta/index.d.ts",
   "dependencies": {
     "md5": "^2.2.1",
     "@auth0/cosmos-tokens": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "nps-utils": "1.6.0",
     "prettier": "1.14.3",
     "prettycli": "1.4.3",
-    "proptypes-to-ts-declarations": "0.8.3",
     "react-chromatic": "0.8.4",
     "react-docgen": "2.21.0",
     "react-docgen-deprecation-handler": "1.0.0",

--- a/tooling/component-metadata.js
+++ b/tooling/component-metadata.js
@@ -8,7 +8,6 @@ const deprecationHandler = require('react-docgen-deprecation-handler')
 const chokidar = require('chokidar')
 const { info, warn } = require('prettycli')
 const camelCase = require('lodash.camelcase')
-const propTypesToTS = require('proptypes-to-ts-declarations')
 const getMetadata = require('./get-metadata')
 const { icons } = require('@auth0/cosmos/atoms/icon/icons.json')
 const colors = require('@auth0/cosmos-tokens/colors')
@@ -162,20 +161,6 @@ const run = () => {
     'core/components/meta/changelog.json',
     JSON.stringify({ changelog }, null, 2),
     'utf8'
-  )
-
-  // Write typescript definitions to index.d.ts.
-  info('DOCS', 'Generating TypeScript definitions')
-  propTypesToTS(
-    '@auth0/cosmos',
-    'core/components/+(atoms|molecules)/**/*.js',
-    './core/components/meta/index.d.ts',
-    {
-      oneOfResolvers: {
-        __ICONNAMES__: Object.keys(icons),
-        __COLORS__: Object.keys(colors.base)
-      }
-    }
   )
 
   if (warning) {


### PR DESCRIPTION
This is a temporal _solution_. 

I want to make a manual typing proof of concept anytime soon, which involves adding a TypeScript compilation pipeline to Cosmos.

Related to #1131 (but does not resolves it)