### PR TITLE
Incomplete RFC: Form.Field with as prop

### DIFF
--- a/core/components/_helpers/custom-validations.js
+++ b/core/components/_helpers/custom-validations.js
@@ -20,10 +20,19 @@ const numberOfValues = (elements, expectedCount) => {
   }
 }
 
-const deprecate = (props, { name, replacement }) => {
+const getDeprecationMessage = (name, replacement) => {
   let message = `'Hi 👋, ${name}' prop will be deprecated in 1.0.0`
   if (replacement) message += ` You might want to use '${replacement}' instead.`
+  return message
+}
+
+const deprecate = (props, { name, replacement }) => {
+  const message = getDeprecationMessage(name, replacement)
   if (props[name]) return new Error(message)
 }
 
-export { onlyOneOf, sumOfElements, numberOfValues, deprecate }
+const throwWarning = message => {
+  console.error(message)
+}
+
+export { onlyOneOf, sumOfElements, numberOfValues, deprecate, getDeprecationMessage, throwWarning }

--- a/core/components/molecules/dialog/dialog.story.js
+++ b/core/components/molecules/dialog/dialog.story.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
-import { Dialog, Form, Link, Paragraph, Text } from '@auth0/cosmos'
+import { Dialog, Form, TextInput, Link, Paragraph, Text } from '@auth0/cosmos'
 
 const StyledExample = styled(Example)`
   min-height: 800px;
@@ -63,9 +63,14 @@ storiesOf('Dialog').add('with form', () => (
       width={600}
     >
       <Form layout="label-on-top">
-        <Form.TextInput label="First Name" type="text" placeholder="John" />
-        <Form.TextInput label="Last Name" type="text" placeholder="Doe" />
-        <Form.TextInput label="Email Address" type="text" placeholder="john.doe@auth0.com" />
+        <Form.Field as={TextInput} label="First Name" type="text" placeholder="John" />
+        <Form.Field as={TextInput} label="Last Name" type="text" placeholder="Doe" />
+        <Form.Field
+          as={TextInput}
+          label="Email Address"
+          type="text"
+          placeholder="john.doe@auth0.com"
+        />
       </Form>
     </Dialog>
   </StyledExample>
@@ -89,9 +94,14 @@ storiesOf('Dialog').add('with introduction + form', () => (
         <Text type="strong">bold</Text> text.
       </Paragraph>
       <Form layout="label-on-top">
-        <Form.TextInput label="First Name" type="text" placeholder="John" />
-        <Form.TextInput label="Last Name" type="text" placeholder="Doe" />
-        <Form.TextInput label="Email Address" type="text" placeholder="john.doe@auth0.com" />
+        <Form.Field as={TextInput} label="First Name" type="text" placeholder="John" />
+        <Form.Field as={TextInput} label="Last Name" type="text" placeholder="Doe" />
+        <Form.Field
+          as={TextInput}
+          label="Email Address"
+          type="text"
+          placeholder="john.doe@auth0.com"
+        />
       </Form>
     </Dialog>
   </StyledExample>

--- a/core/components/molecules/form-group/form-group.story.js
+++ b/core/components/molecules/form-group/form-group.story.js
@@ -2,20 +2,30 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { FormGroup, Form } from '@auth0/cosmos'
+import { FormGroup, Form, TextInput } from '@auth0/cosmos'
 
 storiesOf('Form Group').add('default', () => (
   <Example title="default">
     <FormGroup>
       <Form>
         <Form.FieldSet label="iOS Settings">
-          <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+          <Form.Field
+            as={TextInput}
+            label="Field label"
+            type="text"
+            placeholder="Enter something"
+          />
           <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
         </Form.FieldSet>
       </Form>
       <Form layout="label-on-top">
         <Form.FieldSet label="Android Settings">
-          <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+          <Form.Field
+            as={TextInput}
+            label="Field label"
+            type="text"
+            placeholder="Enter something"
+          />
           <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
         </Form.FieldSet>
       </Form>

--- a/core/components/molecules/form/field/field.js
+++ b/core/components/molecules/form/field/field.js
@@ -5,6 +5,11 @@ import styled from 'styled-components'
 import { spacing, misc } from '@auth0/cosmos-tokens'
 import getLayoutValues from '../layout'
 import uniqueId from '../../../_helpers/uniqueId'
+import {
+  getDeprecationMessage,
+  deprecate,
+  throwWarning
+} from '../../../_helpers/custom-validations'
 import FormContext from '../form-context'
 import Automation from '../../../_helpers/automation-attribute'
 
@@ -51,7 +56,18 @@ const ContentLayout = styled.div`
 const Field = props => {
   /* Get unique id for label */
   let id = props.id || uniqueId(props.label)
-  const { error, ...fieldProps } = props
+  const FieldComponent = props.as || props.fieldComponent
+
+  /** deprecate Form.TextInput, etc. API */
+  if (props.componentName) {
+    const message = getDeprecationMessage(
+      `Form.${props.componentName}`, // old API
+      `Form.Field as={${props.componentName}}` // replacement
+    )
+    throwWarning(message)
+  }
+
+  const { error, as, fieldComponent, ...fieldProps } = props
 
   return (
     <FormContext.Consumer>
@@ -61,8 +77,8 @@ const Field = props => {
             <StyledLabel htmlFor={id}>{props.label}</StyledLabel>
           </LabelLayout>
           <ContentLayout layout={context.layout}>
-            {props.fieldComponent ? (
-              <props.fieldComponent id={id} hasError={error ? true : false} {...fieldProps} />
+            {FieldComponent ? (
+              <FieldComponent id={id} hasError={error ? true : false} {...fieldProps} />
             ) : (
               props.children
             )}
@@ -85,7 +101,9 @@ Field.propTypes = {
   /** Error message to show in case of failed validation */
   error: PropTypes.string,
   /** Actions to be attached to input */
-  actions: PropTypes.arrayOf(actionShapeWithRequiredIcon)
+  actions: PropTypes.arrayOf(actionShapeWithRequiredIcon),
+  /** Component to use as field component */
+  as: PropTypes.any
 }
 
 Field.defaultProps = {

--- a/core/components/molecules/form/field/stories/custom-field.story.js
+++ b/core/components/molecules/form/field/stories/custom-field.story.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
+
+import { Form, TextInput, Button, Switch } from '@auth0/cosmos'
+
+const CustomField = props => {
+  console.log('receives props?', props)
+  const { id, hasError } = props
+  return (
+    <Stack>
+      <TextInput placeholder="Value" id={id} hasError={hasError} />
+      <TextInput placeholder="Unit" hasError={hasError} />
+    </Stack>
+  )
+}
+
+storiesOf('Form').add('custom field - depreacted API', () => (
+  <Example title="switch field">
+    <Form>
+      <Form.Field label="What's your height?">
+        <CustomField />
+      </Form.Field>
+    </Form>
+  </Example>
+))
+
+storiesOf('Form').add('custom field', () => (
+  <Example title="switch field">
+    <Form>
+      <Form.Field label="What's your height?" as={CustomField} />
+    </Form>
+  </Example>
+))
+
+storiesOf('Form').add('custom field with error', () => (
+  <Example title="switch field">
+    <Form>
+      <Form.Field label="What's your height?" as={CustomField} error="Value not found" />
+    </Form>
+  </Example>
+))

--- a/core/components/molecules/form/field/stories/select-field.story.js
+++ b/core/components/molecules/form/field/stories/select-field.story.js
@@ -2,12 +2,13 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { Form } from '@auth0/cosmos'
+import { Form, Select } from '@auth0/cosmos'
 
 storiesOf('Form').add('select field', () => (
   <Example title="select field">
     <Form>
-      <Form.Select
+      <Form.Field
+        as={Select}
         label="Options list"
         options={[
           { text: 'First option', value: '1', defaultSelected: true },
@@ -23,7 +24,8 @@ storiesOf('Form').add('select field', () => (
 storiesOf('Form').add('select field + error', () => (
   <Example title="select field + error">
     <Form>
-      <Form.Select
+      <Form.Field
+        as={Select}
         label="Options list"
         error="Everything is broken"
         options={[

--- a/core/components/molecules/form/field/stories/switch-field.story.js
+++ b/core/components/molecules/form/field/stories/switch-field.story.js
@@ -2,12 +2,12 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { Form } from '@auth0/cosmos'
+import { Form, Switch } from '@auth0/cosmos'
 
 storiesOf('Form').add('switch field', () => (
   <Example title="switch field">
     <Form>
-      <Form.Switch label="Subscribe" on />
+      <Form.Field as={Switch} label="Subscribe" on />
     </Form>
   </Example>
 ))
@@ -15,7 +15,7 @@ storiesOf('Form').add('switch field', () => (
 storiesOf('Form').add('switch field + error', () => (
   <Example title="switch field + error">
     <Form>
-      <Form.Switch label="Subscribe" on error="Everything is broken" />
+      <Form.Field as={Switch} label="Subscribe" on error="Everything is broken" />
     </Form>
   </Example>
 ))

--- a/core/components/molecules/form/field/stories/text-field.story.js
+++ b/core/components/molecules/form/field/stories/text-field.story.js
@@ -2,12 +2,12 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { Form } from '@auth0/cosmos'
+import { Form, TextInput, TextArea } from '@auth0/cosmos'
 
 storiesOf('Form').add('text field', () => (
   <Example title="text field">
     <Form>
-      <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+      <Form.Field as={TextInput} label="Field label" type="text" placeholder="Enter something" />
     </Form>
   </Example>
 ))
@@ -15,7 +15,8 @@ storiesOf('Form').add('text field', () => (
 storiesOf('Form').add('text field + error', () => (
   <Example title="text field + error">
     <Form>
-      <Form.TextInput
+      <Form.Field
+        as={TextInput}
         label="Field label"
         error="Everything is broken"
         type="text"
@@ -26,7 +27,8 @@ storiesOf('Form').add('text field + error', () => (
 ))
 
 const textInputForSize = size => (
-  <Form.TextInput
+  <Form.Field
+    as={TextInput}
     label="Field label"
     type="text"
     size={size}

--- a/core/components/molecules/form/field/stories/textarea-field.story.js
+++ b/core/components/molecules/form/field/stories/textarea-field.story.js
@@ -2,12 +2,12 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { Form } from '@auth0/cosmos'
+import { Form, TextArea } from '@auth0/cosmos'
 
 storiesOf('Form').add('textarea field', () => (
   <Example title="textarea field">
     <Form>
-      <Form.TextArea label="Field label" type="text" placeholder="Enter something" />
+      <Form.Field as={TextArea} label="Field label" type="text" placeholder="Enter something" />
     </Form>
   </Example>
 ))
@@ -15,7 +15,8 @@ storiesOf('Form').add('textarea field', () => (
 storiesOf('Form').add('textarea field + error', () => (
   <Example title="textarea field + error">
     <Form>
-      <Form.TextArea
+      <Form.Field
+        as={TextArea}
         label="Field label"
         error="Everything is broken"
         type="text"

--- a/core/components/molecules/form/fieldset/fieldset.story.js
+++ b/core/components/molecules/form/fieldset/fieldset.story.js
@@ -2,19 +2,19 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { Form } from '@auth0/cosmos'
+import { Form, TextInput, TextArea } from '@auth0/cosmos'
 
 storiesOf('Form').add('fieldset', () => (
   <Example title="fieldset">
     <Form>
       <Form.FieldSet label="Group 1">
-        <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
-        <Form.TextArea label="Long input" placeholder="Add a lot of text here" />
+        <Form.Field as={TextInput} label="Field label" type="text" placeholder="Enter something" />
+        <Form.Field as={TextArea} label="Long input" placeholder="Add a lot of text here" />
       </Form.FieldSet>
 
       <Form.FieldSet label="Group 2">
-        <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
-        <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+        <Form.Field as={TextInput} label="Field label" type="text" placeholder="Enter something" />
+        <Form.Field as={TextInput} label="Field label" type="text" placeholder="Enter something" />
       </Form.FieldSet>
     </Form>
   </Example>

--- a/core/components/molecules/form/form.js
+++ b/core/components/molecules/form/form.js
@@ -21,14 +21,18 @@ const Form = props => (
 )
 
 Form.Field = props => <Field {...props} />
-Form.TextInput = props => <Field {...props} fieldComponent={ActionInput} />
-Form.TextArea = props => <Field {...props} fieldComponent={TextArea} />
-Form.Select = props => <Field {...props} fieldComponent={Select} />
-Form.Switch = props => <Field {...props} fieldComponent={Switch} />
-Form.Radio = props => <Field {...props} fieldComponent={Radio} />
-Form.Radio.Option = Radio.Option
-Form.Actions = Actions
 Form.FieldSet = FieldSet
+Form.Actions = Actions
+
+/* deprecate the following: */
+Form.TextInput = props => (
+  <Field {...props} fieldComponent={ActionInput} componentName="TextInput" />
+)
+Form.TextArea = props => <Field {...props} fieldComponent={TextArea} componentName="TextArea" />
+Form.Select = props => <Field {...props} fieldComponent={Select} componentName="Select" />
+Form.Switch = props => <Field {...props} fieldComponent={Switch} componentName="Switch" />
+Form.Radio = props => <Field {...props} fieldComponent={Radio} componentName="Radio" />
+Form.Radio.Option = Radio.Option
 
 Form.propTypes = {
   /** Two options for controlling form layout */

--- a/core/components/molecules/form/form.story.js
+++ b/core/components/molecules/form/form.story.js
@@ -2,19 +2,19 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
 
-import { Form } from '@auth0/cosmos'
+import { Form, TextInput } from '@auth0/cosmos'
 
 storiesOf('Form').add('layouts', () => (
   <div>
     <Example title="label-on-left">
       <Form>
-        <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+        <Form.Field as={TextInput} label="Field label" type="text" placeholder="Enter something" />
         <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
       </Form>
     </Example>
     <Example title="label-on-top">
       <Form layout="label-on-top">
-        <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+        <Form.Field as={TextInput} label="Field label" type="text" placeholder="Enter something" />
         <Form.Actions primaryAction={{ label: 'Save Changes', handler: () => {} }} />
       </Form>
     </Example>


### PR DESCRIPTION
### Problem

`Form` fields have a pretty confusing API


![image](https://user-images.githubusercontent.com/1863771/49011096-4a164b00-f19b-11e8-9376-e82f42afacc9.png)


Playground link for the above code: [here](https://auth0-cosmos.now.sh/docs/#/playground?code=const%20Example%20=%20()%20=%3E%20%7B%250A%20%20return%20(%250A%20%20%20%20%3CForm%3E%250A%20%20%20%20%20%20%3CForm.TextInput%250A%20%20%20%20%20%20%20%20label=%22Allowed%20URLs%22%250A%20%20%20%20%20%20%20%20type=%22text%22%250A%20%20%20%20%20%20%20%20placeholder=%22Enter%20something%22%250A%20%20%20%20%20%20%20%20defaultValue=%22auth0.com%22%250A%20%20%20%20%20%20%20%20error=%22This%20is%20not%20a%20valid%20URL%22%250A%20%20%20%20%20%20%20%20helpText=%22Make%20sure%20to%20specify%20the%20protocol,%20http://%20or%20https://%22%250A%20%20%20%20%20%20%20%20actions=%7B%5B%250A%20%20%20%20%20%20%20%20%20%20%7B%20icon:%20%22copy%22,%20label:%20%22Copy%20URL%22,%20handler:%20e%20=%3E%20console.log(e)%20%7D%250A%20%20%20%20%20%20%20%20%5D%7D%250A%20%20%20%20%20%20/%3E%250A%20%20%20%20%3C/Form%3E%250A%20%20)%250A%7D%250A%250Arender(Example)%250A)


It looks deceptively similar to `TextInput` API, which was intentional in the original API design, but after hearing from our users (developers), I realised this leads to more confusion than simplicity.

Example:

- Which of these props are for the Form Field and which ones are passed to `TextInput`?

	Few take out a few props for `Form.Field` and pass all the others to the field component inside.

    In the above example, `label`, `helpText` are Field props while `type`, `placeholder` and `defaultValue` are TextInput props.


- Do I pass `error` or `hasError`? 

    `TextInput` accepts a `hasError` boolean while `Form.TextInput` accepts `error` as string. This is intentional so that the Field can show the error message and pass `hasError` to the `TextInput` implicitly. 

    But, It's easy to pass `error` to `TextInput` and expect it to add an error message because they API looks similar

- `actions` is a Field prop but only applies to `Form.TextInput` (not `Form.TextArea`, `Form.Switch` etc.)

    This is going to become even more confusing soon when `TextInput` outside Form starts accepting actions (https://github.com/auth0/cosmos/issues/1082)



### Proposal

Make Form field more explicit to differentiate