### PR TITLE
add a tiny story

### DIFF
--- a/core/components/molecules/form/field/stories/text-field.story.js
+++ b/core/components/molecules/form/field/stories/text-field.story.js
@@ -7,7 +7,9 @@ import { Form } from '@auth0/cosmos'
 storiesOf('Form').add('text field', () => (
   <Example title="text field">
     <Form>
-      <Form.TextInput label="Field label" type="text" placeholder="Enter something" />
+      <Form.Field label="Field label">
+        <TextInput type="text" placeholder="Enter something" />
+      </Form.Field>
     </Form>
   </Example>
 ))


### PR DESCRIPTION
### Problem

`Form` fields have a pretty confusing API


![image](https://user-images.githubusercontent.com/1863771/49011096-4a164b00-f19b-11e8-9376-e82f42afacc9.png)


Playground link for the above code: [here](https://auth0-cosmos.now.sh/docs/#/playground?code=const%20Example%20=%20()%20=%3E%20%7B%250A%20%20return%20(%250A%20%20%20%20%3CForm%3E%250A%20%20%20%20%20%20%3CForm.TextInput%250A%20%20%20%20%20%20%20%20label=%22Allowed%20URLs%22%250A%20%20%20%20%20%20%20%20type=%22text%22%250A%20%20%20%20%20%20%20%20placeholder=%22Enter%20something%22%250A%20%20%20%20%20%20%20%20defaultValue=%22auth0.com%22%250A%20%20%20%20%20%20%20%20error=%22This%20is%20not%20a%20valid%20URL%22%250A%20%20%20%20%20%20%20%20helpText=%22Make%20sure%20to%20specify%20the%20protocol,%20http://%20or%20https://%22%250A%20%20%20%20%20%20%20%20actions=%7B%5B%250A%20%20%20%20%20%20%20%20%20%20%7B%20icon:%20%22copy%22,%20label:%20%22Copy%20URL%22,%20handler:%20e%20=%3E%20console.log(e)%20%7D%250A%20%20%20%20%20%20%20%20%5D%7D%250A%20%20%20%20%20%20/%3E%250A%20%20%20%20%3C/Form%3E%250A%20%20)%250A%7D%250A%250Arender(Example)%250A)


It looks deceptively similar to `TextInput` API, which was intentional in the original API design, but after hearing from our users (developers), I realised this leads to more confusion than simplicity.

Example:

- Which of these props are for the Form Field and which ones are passed to `TextInput`?

	Few take out a few props for `Form.Field` and pass all the others to the field component inside.

    In the above example, `label`, `helpText` are Field props while `type`, `placeholder` and `defaultValue` are TextInput props.


- Do I pass `error` or `hasError`? 

    `TextInput` accepts a `hasError` boolean while `Form.TextInput` accepts `error` as string. This is intentional so that the Field can show the error message and pass `hasError` to the `TextInput` implicitly. 

    But, It's easy to pass `error` to `TextInput` and expect it to add an error message because they API looks similar

- `actions` is a Field prop but only applies to `Form.TextInput` (not `Form.TextArea`, `Form.Switch` etc.)

    This is going to become even more confusing soon when `TextInput` outside Form starts accepting actions (https://github.com/auth0/cosmos/issues/1082)



### Proposal

Make Form field more explicit to differentiate