### PR TITLE
Applied container styles to Sidebar, Codeblock and Playground

### DIFF
--- a/internal/docs/docs-components/code-block.js
+++ b/internal/docs/docs-components/code-block.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import containerStyles from '../../../core/components/_helpers/container-styles'
+import containerStyles from '@auth0/cosmos/_helpers/container-styles'
 
 import Highlight from 'react-highlight'
 import './material-theme.css'

--- a/internal/docs/docs-components/code-block.js
+++ b/internal/docs/docs-components/code-block.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
+import containerStyles from '../../../core/components/_helpers/container-styles'
 
 import Highlight from 'react-highlight'
 import './material-theme.css'
 
 const Wrapper = styled.div`
+  ${containerStyles};
   margin: 16px 0;
   code {
     border-radius: 5px;

--- a/internal/docs/sidebar/index.js
+++ b/internal/docs/sidebar/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import containerStyles from '../../../core/components/_helpers/container-styles'
+import containerStyles from '@auth0/cosmos/_helpers/container-styles'
 
 import { colors } from '@auth0/cosmos/tokens'
 import SearchBox from './search.js'

--- a/internal/docs/sidebar/index.js
+++ b/internal/docs/sidebar/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import containerStyles from '../../../core/components/_helpers/container-styles'
 
 import { colors } from '@auth0/cosmos/tokens'
 import SearchBox from './search.js'
@@ -9,6 +10,7 @@ import List from './list'
 import { metadata as components } from '@auth0/cosmos/meta/metadata.json'
 
 const StyledSidebar = styled.div`
+  ${containerStyles};
   background: ${colors.base.grayLightest};
   padding-bottom: calc(2rem + 80px);
 `

--- a/internal/docs/spec/playground.js
+++ b/internal/docs/spec/playground.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import containerStyles from '../../../core/components/_helpers/container-styles'
+import containerStyles from '@auth0/cosmos/_helpers/container-styles'
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 import * as Components from '@auth0/cosmos'

--- a/internal/docs/spec/playground.js
+++ b/internal/docs/spec/playground.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import containerStyles from '../../../core/components/_helpers/container-styles'
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 import * as Components from '@auth0/cosmos'
@@ -11,6 +12,7 @@ import CopyButton from './copy-button'
 import { getDefaultsFromCode, stripDefaultsFromDocs } from './get-defaults-from-code'
 
 const Container = styled.div`
+  ${containerStyles};
   margin: ${spacing.medium} 0;
 
   & .react-live {


### PR DESCRIPTION
Addresses: https://github.com/auth0/cosmos/issues/1166

I've tried added the container styles to the affected components, but I'm not sure if this is the answer for this situation. Should we just declare the line-height here, without the helper?

@siddharthkp 	can you check it out?