### PR TITLE
Convert GitHub handles in changelog to link to GitHub profiles

### DIFF
--- a/internal/docs/changes.js
+++ b/internal/docs/changes.js
@@ -17,10 +17,19 @@ import { Code } from '@auth0/cosmos'
 
 const Container = styled.div``
 
-const content = changelog.replace(
-  /\[#(\d+)\]/g,
-  '<a href="https://github.com/auth0/cosmos/pull/$1" target="_blank">[#$1]</a>'
-)
+function convertPRToLink(match, p1) {
+  return `<a href="https://github.com/auth0/cosmos/pull/${p1}" target="_blank">${match}</a>`
+}
+
+function convertHandleToLink(match) {
+  const githubUsername = match.substr(1)
+  return `<a href="https://github.com/${githubUsername}" target="_blank">${match}</a>\xa0`
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter
+let content = changelog.replace(/\[#(\d+)\]/g, convertPRToLink)
+
+content = content.replace(/(\B\@\w+\s)/g, convertHandleToLink)
 
 const options = {
   overrides: {


### PR DESCRIPTION
Closes #1124 

Here's how it looks now:

![cosmos-changelog-link-gh-handles](https://user-images.githubusercontent.com/450559/49241791-ed32c300-f42e-11e8-9071-b2805becfb3b.png)


