### PR TITLE
Fixes anchor buttons

### DIFF
--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -276,18 +276,7 @@ Button.Text = styled.span`
 `
 
 Button.LinkElement = Button.Element.withComponent('a').extend`
-  display: table;
   text-decoration: none;
-
-  ${Button.Text} {
-    display: table-cell;
-  }
-
-  ${Icon.Element} {
-    display: table-cell;
-    vertical-align: middle;
-    padding-right: ${props => (props.text ? spacing.xsmall : 0)};
-  }
 `
 
 Button.propTypes = {


### PR DESCRIPTION
This PR fixes #1164 by removing the unnecesary `display: table` on anchor btns.

@siddharthkp I tested it as far as I could, and I think it's ok, can you take another look at it on the usecases described on the issue please?