### PR TITLE
Tooling: Auto accept chromatic builds on master

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,6 @@
 import { configure } from '@storybook/react'
 import { getStorybook } from '@storybook/react'
-import 'react-chromatic/storybook-addon'
+import 'storybook-chromatic'
 
 /* This line loads all the .story files from the components */
 const components = require.context('../core/components/', true, /story\.js$/)

--- a/internal/cosmos-scripts/task.js
+++ b/internal/cosmos-scripts/task.js
@@ -2,7 +2,7 @@ const execa = require('execa')
 const ora = require('ora')
 const argv = require('yargs').argv
 
-const task = async ({ label, command, params, watch }) => {
+const task = async ({ label, command, params, watch, failOnError }) => {
   /* initiate spinner for feedback */
   const spinner = ora({ text: label, spinner: 'moon' })
 
@@ -28,7 +28,8 @@ const task = async ({ label, command, params, watch }) => {
   } catch (error) {
     console.log(error)
     spinner.fail()
-    console.log(error.stderr || error.stdout)
+    if (failOnError) console.error(error)
+    else console.log(error.stderr || error.stdout)
   }
 
   /* newline after everything */

--- a/internal/cosmos-scripts/task.js
+++ b/internal/cosmos-scripts/task.js
@@ -24,6 +24,7 @@ const task = async ({ label, command, params, watch, failOnError }) => {
       const { stdout } = await execa(command, params)
       spinner.succeed()
       if (argv.verbose) console.log(stdout)
+      process.exit(0)
     }
   } catch (error) {
     console.log(error)

--- a/internal/cosmos-scripts/task.js
+++ b/internal/cosmos-scripts/task.js
@@ -28,8 +28,9 @@ const task = async ({ label, command, params, watch, failOnError }) => {
   } catch (error) {
     console.log(error)
     spinner.fail()
-    if (failOnError) console.error(error)
-    else console.log(error.stderr || error.stdout)
+
+    console.log(error.stderr || error.stdout)
+    if (failOnError) process.exit(1)
   }
 
   /* newline after everything */

--- a/internal/cosmos-scripts/task.js
+++ b/internal/cosmos-scripts/task.js
@@ -2,7 +2,7 @@ const execa = require('execa')
 const ora = require('ora')
 const argv = require('yargs').argv
 
-const task = async ({ label, command, params, watch, failOnError }) => {
+const task = async ({ label, command, params, watch, verbose, failOnError }) => {
   /* initiate spinner for feedback */
   const spinner = ora({ text: label, spinner: 'moon' })
 
@@ -16,14 +16,14 @@ const task = async ({ label, command, params, watch, failOnError }) => {
       const response = execa(command, params)
 
       /* pipe all output to the console */
-      if (argv.verbose) {
+      if (argv.verbose || verbose) {
         response.stdout.pipe(process.stdout)
         response.stderr.pipe(process.stderr)
       }
     } else {
       const { stdout } = await execa(command, params)
       spinner.succeed()
-      if (argv.verbose) console.log(stdout)
+      if (argv.verbose || verbose) console.log(stdout)
       process.exit(0)
     }
   } catch (error) {

--- a/internal/test/chromatic.js
+++ b/internal/test/chromatic.js
@@ -27,5 +27,6 @@ task({
   label: 'Running chromatic',
   command: 'chromatic',
   params,
+  verbose: true,
   failOnError: true
 })

--- a/internal/test/chromatic.js
+++ b/internal/test/chromatic.js
@@ -6,7 +6,7 @@ if (!ci) {
   process.exit(1)
 }
 
-if (event === 'pull_request') {
+if (event !== 'push') {
   console.log('This script only runs on the "push" event, check the other build')
   process.exit(0)
 }
@@ -27,6 +27,7 @@ task({
   label: 'Running chromatic',
   command: 'chromatic',
   params,
+  watch: true,
   verbose: true,
   failOnError: true
 })

--- a/internal/test/chromatic.js
+++ b/internal/test/chromatic.js
@@ -26,5 +26,6 @@ if (repo === 'auth0/cosmos' && branch === 'master') {
 task({
   label: 'Running chromatic',
   command: 'chromatic',
-  params
+  params,
+  failOnError: true
 })

--- a/internal/test/chromatic.js
+++ b/internal/test/chromatic.js
@@ -1,0 +1,30 @@
+const { event, repo, branch, ci } = require('ci-env')
+const task = require('../cosmos-scripts/task')
+
+if (!ci) {
+  console.error('This script should only run on CI')
+  process.exit(1)
+}
+
+if (event === 'pull_request') {
+  console.log('This script only runs on the "push" event, check the other build')
+  process.exit(0)
+}
+
+const params = [
+  'test',
+  '--app-code=wuz4h54syum',
+  '--storybook-addon',
+  '--script-name=sandbox',
+  '--exit-zero-on-changes'
+]
+
+if (repo === 'auth0/cosmos' && branch === 'master') {
+  params.push('--auto-accept-changes')
+}
+
+task({
+  label: 'Running chromatic',
+  command: 'chromatic',
+  params
+})

--- a/internal/test/package.json
+++ b/internal/test/package.json
@@ -10,8 +10,6 @@
     "test-watch": "jest --watch --no-cache",
     "test-unit": "jest unit --no-cache",
     "test-unit-watch": "jest unit --no-cache --watch",
-    "test-visual": "node chromatic.js",
-    "sandbox": "../../node_modules/.bin/start-storybook -p 9001 -s build",
     "coverage": "jest --coverage"
   },
   "jest": {

--- a/internal/test/package.json
+++ b/internal/test/package.json
@@ -11,6 +11,7 @@
     "test-unit": "jest unit --no-cache",
     "test-unit-watch": "jest unit --no-cache --watch",
     "test-visual": "node chromatic.js",
+    "sandbox": "../../node_modules/.bin/start-storybook -p 9001 -s build",
     "coverage": "jest --coverage"
   },
   "jest": {

--- a/internal/test/package.json
+++ b/internal/test/package.json
@@ -10,6 +10,7 @@
     "test-watch": "jest --watch --no-cache",
     "test-unit": "jest unit --no-cache",
     "test-unit-watch": "jest unit --no-cache --watch",
+    "test-visual": "node chromatic.js",
     "coverage": "jest --coverage"
   },
   "jest": {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -51,7 +51,7 @@ module.exports = {
         description: 'Check if applications build + Run visual tests + Run unit tests'
       },
       visual: {
-        script: 'cd internal/test && yarn test-visual',
+        script: 'node internal/test/chromatic.js',
         description: 'Run chromatic visual tests'
       },
       unit: {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -47,13 +47,12 @@ module.exports = {
     },
     test: {
       default: {
-        script: series('production.build', 'test.chromaticci', 'test.unit'),
+        script: series('production.build', 'test.visual', 'test.unit'),
         description: 'Check if applications build + Run visual tests + Run unit tests'
       },
-      chromaticci: {
-        script:
-          'if [ $TRAVIS_EVENT_TYPE != "pull_request" -o "$TRAVIS_PULL_REQUEST_SLUG" != "$TRAVIS_REPO_SLUG" ]; then chromatic test --app-code=wuz4h54syum --storybook-addon --script-name=sandbox --exit-zero-on-changes; fi;',
-        description: 'Check if CI event is push and then run chromatic'
+      visual: {
+        script: 'cd internal/test && yarn test-visual',
+        description: 'Run chromatic visual tests'
       },
       unit: {
         default: {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -51,7 +51,7 @@ module.exports = {
         description: 'Check if applications build + Run visual tests + Run unit tests'
       },
       visual: {
-        script: 'CI=true node tooling/chromatic.js',
+        script: 'node tooling/chromatic.js',
         description: 'Run chromatic visual tests'
       },
       unit: {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -51,7 +51,7 @@ module.exports = {
         description: 'Check if applications build + Run visual tests + Run unit tests'
       },
       visual: {
-        script: 'node tooling/chromatic.js',
+        script: 'CI=true node tooling/chromatic.js',
         description: 'Run chromatic visual tests'
       },
       unit: {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -51,7 +51,7 @@ module.exports = {
         description: 'Check if applications build + Run visual tests + Run unit tests'
       },
       visual: {
-        script: 'CI=true node internal/test/chromatic.js',
+        script: 'node tooling/chromatic.js',
         description: 'Run chromatic visual tests'
       },
       unit: {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -51,7 +51,7 @@ module.exports = {
         description: 'Check if applications build + Run visual tests + Run unit tests'
       },
       visual: {
-        script: 'node internal/test/chromatic.js',
+        script: 'CI=true node internal/test/chromatic.js',
         description: 'Run chromatic visual tests'
       },
       unit: {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "nps -s test",
     "sandbox": "start-storybook -p 9001 -s build",
     "precommit": "nps icons.build && lint-staged",
-    "chromatic": "chromatic test --storybook-addon --script-name sandbox --exit-zero-on-changes"
+    "chromatic": "echo 'defined inside package-scripts.js'"
   },
   "lint-staged": {
     "*.{js,json,md}": [
@@ -44,10 +44,11 @@
     "@storybook/addon-links": "4.0.8",
     "@storybook/addons": "4.0.8",
     "@storybook/react": "4.0.8",
-    "babel-loader": "7.1.4",
     "babel-cli": "6.26.0",
     "babel-jest": "^23.4.2",
+    "babel-loader": "7.1.4",
     "chokidar": "2.0.4",
+    "ci-env": "1.7.0",
     "enzyme": "^3.5.0",
     "enzyme-adapter-react-16": "^1.3.0",
     "enzyme-to-json": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "start": "nps -s production.start",
     "test": "nps -s test",
     "precommit": "nps icons.build && lint-staged",
+    "sandbox": "start-storybook -p 9001 -s build",
     "chromatic": "echo 'defined inside package-scripts.js'"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "build": "nps -s production.build",
     "start": "nps -s production.start",
     "test": "nps -s test",
-    "sandbox": "start-storybook -p 9001 -s build",
     "precommit": "nps icons.build && lint-staged",
     "chromatic": "echo 'defined inside package-scripts.js'"
   },

--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
     "nps-utils": "1.6.0",
     "prettier": "1.14.3",
     "prettycli": "1.4.3",
-    "react-chromatic": "0.8.4",
     "react-docgen": "2.21.0",
     "react-docgen-deprecation-handler": "1.0.0",
     "react-docgen-displayname-handler": "2.1.0",
     "read-pkg": "4.0.1",
+    "storybook-chromatic": "1.2.1",
     "svgo": "1.0.5"
   }
 }

--- a/tooling/chromatic.js
+++ b/tooling/chromatic.js
@@ -16,7 +16,8 @@ const params = [
   '--app-code=wuz4h54syum',
   '--storybook-addon',
   '--script-name=sandbox',
-  '--exit-zero-on-changes'
+  '--exit-zero-on-changes',
+  '--no-interactive'
 ]
 
 if (repo === 'auth0/cosmos' && branch === 'master') {

--- a/tooling/chromatic.js
+++ b/tooling/chromatic.js
@@ -1,5 +1,5 @@
 const { event, repo, branch, ci } = require('ci-env')
-const task = require('../cosmos-scripts/task')
+const task = require('@auth0/cosmos-scripts/task')
 
 if (!ci) {
   console.error('This script should only run on CI')

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,15 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@chromaui/localtunnel@1.9.1-chromatic.3":
+  version "1.9.1-chromatic.3"
+  resolved "https://registry.npmjs.org/@chromaui/localtunnel/-/localtunnel-1.9.1-chromatic.3.tgz#0875a1e1a51e6f42a3c7ce540ca434ed0d8b8ae3"
+  dependencies:
+    axios "0.17.1"
+    debug "^3.0.1"
+    openurl "1.1.1"
+    yargs "6.6.0"
+
 "@emotion/cache@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-0.8.8.tgz#2c3bd1aa5fdb88f1cc2325176a3f3201739e726c"
@@ -3959,15 +3968,15 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
-
 debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
@@ -4320,12 +4329,6 @@ ejs@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
-ejson@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/ejson/-/ejson-2.1.2.tgz#0eed4055bc7e0e7561fe59e8c320edc3ff8ce7df"
-  dependencies:
-    underscore "1.8.x"
-
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47:
   version "1.3.83"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz#74584eb0972bb6777811c5d68d988c722f5e6666"
@@ -4382,11 +4385,11 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-env-ci@^1.5.0:
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/env-ci/-/env-ci-1.7.2.tgz#bf50ed2ad4f7364f85a2b038b819921dabdbd2ba"
+env-ci@^2.1.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/env-ci/-/env-ci-2.6.0.tgz#3fc46537c972b4d3ab5f0b82d07dfc1491297662"
   dependencies:
-    execa "^0.10.0"
+    execa "^1.0.0"
     java-properties "^0.2.9"
 
 enzyme-adapter-react-16@^1.3.0:
@@ -4487,10 +4490,6 @@ es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
 es5-shim@^4.5.10:
   version "4.5.10"
   resolved "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.10.tgz#b7e17ef4df2a145b821f1497b50c25cf94026205"
-
-es6-error@^4.0.2:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
 
 es6-iterator@~2.0.3:
   version "2.0.3"
@@ -4617,7 +4616,7 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.2.0"
 
-execa@0.10.0, execa@^0.10.0:
+execa@0.10.0:
   version "0.10.0"
   resolved "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
   dependencies:
@@ -4659,6 +4658,18 @@ execa@^0.9.0:
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -5031,11 +5042,17 @@ focus-lock@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.4.2.tgz#3e91141ac911352d4831215fba300d02b9faa6b4"
 
-follow-redirects@^1.0.0, follow-redirects@^1.2.5:
+follow-redirects@^1.0.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
   dependencies:
     debug "^3.1.0"
+
+follow-redirects@^1.2.5:
+  version "1.5.10"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -5192,6 +5209,12 @@ get-stdin@^5.0.1:
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -6816,7 +6839,7 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.x, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -7063,15 +7086,6 @@ loader-utils@^0.2.16:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
-
-localtunnel@^1.8.3:
-  version "1.9.0"
-  resolved "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz#8ffecdcf8c8a14f62df1056cf9d54acbb0bb9a8f"
-  dependencies:
-    axios "0.17.1"
-    debug "2.6.8"
-    openurl "1.1.1"
-    yargs "6.6.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -7567,6 +7581,10 @@ mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.18.1:
+  version "2.22.2"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
@@ -7739,6 +7757,14 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
+
+node-loggly-bulk@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.npmjs.org/node-loggly-bulk/-/node-loggly-bulk-2.2.4.tgz#bdd8638d97c43ecf1e1831ca98b250968fa6dee9"
+  dependencies:
+    json-stringify-safe "5.0.x"
+    moment "^2.18.1"
+    request ">=2.76.0 <3.0.0"
 
 node-notifier@^5.2.1:
   version "5.2.1"
@@ -8140,7 +8166,7 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
 
 os-locale@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  resolved "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
 
@@ -9023,25 +9049,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-chromatic@0.8.4:
-  version "0.8.4"
-  resolved "https://registry.npmjs.org/react-chromatic/-/react-chromatic-0.8.4.tgz#0aed07fb89ccdb6c3e77d3362d3a2c4520e493d9"
-  dependencies:
-    apollo-fetch "^0.6.0"
-    babel-runtime "^6.26.0"
-    commander "^2.9.0"
-    debug "^3.0.1"
-    denodeify "^1.2.1"
-    ejson "^2.1.2"
-    env-ci "^1.5.0"
-    es6-error "^4.0.2"
-    isomorphic-fetch "^2.2.1"
-    jsdom "^11.5.1"
-    jsonfile "^4.0.0"
-    localtunnel "^1.8.3"
-    node-ask "^1.0.1"
-    tree-kill "^1.1.0"
-
 react-clientside-effect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.0.0.tgz#81c4f91bd4ec0f8792ba76fe29c1d09e37fff062"
@@ -9657,7 +9664,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.83.0:
+"request@>=2.76.0 <3.0.0", request@^2.83.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
@@ -10325,6 +10332,26 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+storybook-chromatic@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/storybook-chromatic/-/storybook-chromatic-1.2.1.tgz#6a32ef2619ecfe64b7d1fa78bafbbba802515561"
+  dependencies:
+    "@chromaui/localtunnel" "1.9.1-chromatic.3"
+    apollo-fetch "^0.6.0"
+    babel-runtime "^6.26.0"
+    commander "^2.9.0"
+    debug "^3.0.1"
+    denodeify "^1.2.1"
+    env-ci "^2.1.0"
+    isomorphic-fetch "^2.2.1"
+    jsdom "^11.5.1"
+    jsonfile "^4.0.0"
+    node-ask "^1.0.1"
+    node-loggly-bulk "^2.2.4"
+    strip-color "^0.1.0"
+    tree-kill "^1.1.0"
+    uuid "^3.3.2"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -10458,6 +10485,10 @@ strip-bom@^2.0.0:
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-color@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz#106f65d3d3e6a2d9401cac0eb0ce8b8a702b4f7b"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -10857,10 +10888,6 @@ uglifyjs-webpack-plugin@^1.2.4:
     uglify-es "^3.3.4"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
-
-underscore@1.8.x:
-  version "1.8.3"
-  resolved "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 underscore@~1.4.4:
   version "1.4.4"
@@ -11497,7 +11524,7 @@ yamljs@0.3.0:
 
 yargs-parser@^4.2.0:
   version "4.2.1"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
+  resolved "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
   dependencies:
     camelcase "^3.0.0"
 
@@ -11532,7 +11559,7 @@ yargs@11.0.0:
 
 yargs@6.6.0:
   version "6.6.0"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
+  resolved "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
   dependencies:
     camelcase "^3.0.0"
     cliui "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3227,6 +3227,10 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
+ci-env@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/ci-env/-/ci-env-1.7.0.tgz#55cc9f8ff7bb4380de298cbed3ae27c35dcdfd8e"
+
 ci-info@^1.3.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"


### PR DESCRIPTION
1. This PR adds `--auto-accept-changes` to the chromatic call for master builds.


2. Moves all the logic around chromatic to a script inside `internal/test`

The logic around when the run chromatic was getting a bit complex for a single line. This should make it more reliable and easier to change (check out the script)

```diff
- if [ $TRAVIS_EVENT_TYPE != "pull_request" -o "$TRAVIS_PULL_REQUEST_SLUG" != "$TRAVIS_REPO_SLUG" ]; then chromatic test --app-code=wuz4h54syum --storybook-addon --script-name=sandbox --exit-zero-on-changes; fi;
+ cd internal/test && yarn test-visual
```
