### PR TITLE
Do not show `children` props table

### DIFF
--- a/internal/docs/spec/props.js
+++ b/internal/docs/spec/props.js
@@ -68,7 +68,7 @@ class Props extends React.Component {
 
     const keys = Object.keys(propData).filter(key => key[0] !== '_')
 
-    return (
+    return keys.length ? (
       <Table>
         <thead>
           <tr>
@@ -104,7 +104,7 @@ class Props extends React.Component {
           ))}
         </tbody>
       </Table>
-    )
+    ) : null
   }
 }
 export default Props

--- a/tooling/component-metadata.js
+++ b/tooling/component-metadata.js
@@ -83,6 +83,8 @@ const run = () => {
               prop.type.raw = prop.type.raw.replace('.isRequired', '')
             }
           })
+          // delete `children` prop - we don't want to show them in props
+          delete data.props.children
         }
 
         /* add filepath to metadata */


### PR DESCRIPTION
Closes #676 

I'm not sure if this is the right way to do. I thought it's better not to have `children` prop in generated metadata than skipping the `children` prop in `Props` component's loop. Let me know if you want to handle this differently. Or feel free to close this if it's not required :)