### PR TITLE
Button - `action` appearance

### DIFF
--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -87,6 +87,19 @@ const appearances = {
     focusBackground: 'transparent',
     focusBorder: 'transparent',
     loadingInverse: false
+  },
+  action: {
+    text: colors.button.action.text,
+    icon: colors.button.action.icon,
+    background: 'transparent',
+    border: 'transparent',
+    hoverText: colors.button.action.hover,
+    hoverBackground: 'transparent',
+    hoverBorder: 'transparent',
+    focusText: colors.button.action.focus,
+    focusBackground: 'transparent',
+    focusBorder: 'transparent',
+    loadingInverse: false
   }
 }
 
@@ -284,7 +297,15 @@ Button.propTypes = {
   size: PropTypes.oneOf(['default', 'large', 'small', 'compressed']),
 
   /** The visual style used to convey the button's purpose */
-  appearance: PropTypes.oneOf(['default', 'primary', 'secondary', 'cta', 'link', 'destructive']),
+  appearance: PropTypes.oneOf([
+    'default',
+    'primary',
+    'secondary',
+    'cta',
+    'link',
+    'destructive',
+    'action'
+  ]),
 
   /** Name of icon */
   icon: PropTypes.oneOf(__ICONNAMES__),

--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -172,7 +172,7 @@ const getAttributes = props => {
   if (props.icon && !props.text) {
     styles.padding = spacing.xsmall
     styles.minWidth = '36px'
-    styles.icon = colors.button.link.icon
+    styles.icon = appearanceStyles.icon || colors.button.link.icon
   }
 
   return styles

--- a/core/components/atoms/button/button.md
+++ b/core/components/atoms/button/button.md
@@ -40,6 +40,7 @@ their attention to it.
     <Button>default</Button>
     <Button appearance="destructive">destructive</Button>
     <Button appearance="link" icon="copy" label="I'm a button, but look like a link." />
+    <Button appearance="action" icon="close" label="Close" />
   </Stack>
 </div>
 ```

--- a/core/tokens/colors.js
+++ b/core/tokens/colors.js
@@ -143,6 +143,12 @@ const colors = {
       icon: 'blue',
       hover: '#0a84ae',
       focus: '#0a84ae'
+    },
+    action: {
+      text: '#333',
+      icon: 'black',
+      hover: '#333',
+      focus: '#333'
     }
   },
   icon: {


### PR DESCRIPTION
This is for #1196.
 
This PR adds a new appearance called `action` to `Button` component.

This also fixes a bug(?) where `Button` component was always passing `link` appearance's color to `Icon` component (may be it's intentional!).