### PR TITLE
Docs: Make it easier to add a guide

### DIFF
--- a/internal/docs/app.js
+++ b/internal/docs/app.js
@@ -84,7 +84,8 @@ class App extends React.Component {
       const hashParts = window.location.hash.split('#')
       if (hashParts.length > 2) {
         const hash = hashParts.slice(-1)[0]
-        document.querySelector(`#${hash}`).scrollIntoView()
+        const link = document.querySelector(`#${hash}`)
+        if (link) link.scrollIntoView()
       } else {
         document.querySelector('nav').scrollIntoView()
       }

--- a/internal/docs/app.js
+++ b/internal/docs/app.js
@@ -10,13 +10,7 @@ import Home from './home'
 import Overview from './overview'
 import Playground from './playground'
 import Navigation from './docs-components/navigation'
-
-import GuidingPrinciples from './pages/guiding-principles'
-import Usage from './pages/usage'
-import ContributionGuide from './pages/contribution-guide'
-import FAQS from './pages/faqs'
-import Changes from './pages/changes'
-import AutomationGlossary from './pages/automation-glossary'
+import guides from './guides'
 
 const SideContent = styled.div`
   width: 19rem;
@@ -111,12 +105,10 @@ class App extends React.Component {
           </SideContent>
           <MainContent id="main">
             <Body>
-              <Route exact path="/guiding-principles" component={GuidingPrinciples} />
-              <Route path="/usage" component={Usage} />
-              <Route exact path="/contribution-guide" component={ContributionGuide} />
-              <Route exact path="/faqs" component={FAQS} />
-              <Route exact path="/changes" component={Changes} />
-              <Route exact path="/automation" component={AutomationGlossary} />
+              {guides.map(guide => (
+                <Route exact path={guide.path} component={guide.component} />
+              ))}
+
               <Route exact path="/playground" component={Playground} />
               <Route exact path="/component/:componentName" component={Spec} />
               <Route exact path="/" component={Home} />

--- a/internal/docs/docs-components/folding-section.js
+++ b/internal/docs/docs-components/folding-section.js
@@ -18,7 +18,7 @@ class FoldingSection extends React.Component {
     this.state = { id, expanded }
   }
   toggle = () => {
-    location.href = `/#/contribution-guide#${this.state.id}`
+    location.href = `/#/${this.props.page}#${this.state.id}`
     this.setState({ expanded: !this.state.expanded })
   }
 

--- a/internal/docs/guides.js
+++ b/internal/docs/guides.js
@@ -1,0 +1,18 @@
+import GuidingPrinciples from './pages/guiding-principles'
+import Usage from './pages/usage'
+import ContributionGuide from './pages/contribution-guide'
+import FAQS from './pages/faqs'
+import Changes from './pages/changes'
+import AutomationGlossary from './pages/automation-glossary'
+
+const guides = [
+  { path: '/', title: 'Getting started' },
+  { path: '/usage', title: 'How to use Cosmos?', component: Usage },
+  { path: '/guiding-principles', title: 'Guiding Principles', component: GuidingPrinciples },
+  { path: '/faqs', title: 'FAQs', component: FAQS },
+  { path: '/changes', title: 'Changelog', component: Changes },
+  { path: '/automation', title: 'Automation Glossary', component: AutomationGlossary },
+  { path: '/contribution-guide', title: 'Contributing to Cosmos', component: ContributionGuide }
+]
+
+export default guides

--- a/internal/docs/pages/contribution-guide.js
+++ b/internal/docs/pages/contribution-guide.js
@@ -2,18 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Helmet from 'react-helmet'
 
-import {
-  Heading1,
-  Heading2,
-  Heading3,
-  Heading4,
-  Text,
-  Link,
-  List,
-  ListItem
-} from '../docs-components/typography'
-import CodeBlock from '../docs-components/code-block'
-import { Code } from '@auth0/cosmos'
+import { Heading1 } from '../docs-components/typography'
 
 import Setup from './contribution-guide/setup'
 import SystemGuidelines from './contribution-guide/system-guidelines'
@@ -22,23 +11,20 @@ import ComponentFiles from './contribution-guide/component-files'
 import Testing from './contribution-guide/testing'
 import LineHeight from './contribution-guide/line-height'
 
-const Container = styled.div``
-
 class ContributionGuide extends React.Component {
   render() {
     return (
       <div>
         <Helmet title="Documentation &mdash; Cosmos" />
-        <Container>
-          <Heading1>Contributing to Cosmos</Heading1>
 
-          <Setup />
-          <SystemGuidelines />
-          <Architecture />
-          <ComponentFiles />
-          <Testing />
-          <LineHeight />
-        </Container>
+        <Heading1>Contributing to Cosmos</Heading1>
+
+        <Setup />
+        <SystemGuidelines />
+        <Architecture />
+        <ComponentFiles />
+        <Testing />
+        <LineHeight />
       </div>
     )
   }

--- a/internal/docs/pages/overriding-components.js
+++ b/internal/docs/pages/overriding-components.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { Heading1, Heading2, Text, Link, Subheader } from './docs-components/typography'
+import CodeBlock from './docs-components/code-block'
+import Tag from './docs-components/tag'
+
+class Overriding extends React.Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Documentation &mdash; Cosmos" />
+        <Heading1>Getting Started</Heading1>
+        <Subheader>Cosmos is a Design System to build Auth0 products.</Subheader>
+
+        <Heading2>Installation</Heading2>
+      </div>
+    )
+  }
+}
+
+export default Overriding

--- a/internal/docs/pages/usage.js
+++ b/internal/docs/pages/usage.js
@@ -6,6 +6,11 @@ import Pre from '../docs-components/pre'
 import { Code } from '@auth0/cosmos'
 import CodeBlock from '../docs-components/code-block'
 
+import Installation from './usage/installation'
+import UsingComponents from './usage/using-components'
+import CustomComponents from './usage/custom-components'
+import WithStyleguide from './usage/with-styleguide'
+
 class Usage extends React.Component {
   render() {
     return (
@@ -13,101 +18,10 @@ class Usage extends React.Component {
         <Helmet title="How to use Cosmos?" />
         <Heading1>How to use Cosmos?</Heading1>
 
-        <Heading2>Installation</Heading2>
-        <Text>
-          To add <Code>cosmos</Code> to your react application, run
-          <CodeBlock language="shell">$ yarn add @auth0/cosmos</CodeBlock>
-          If you prefer npm, run this command instead:
-          <CodeBlock language="shell">$ npm install --save @auth0/cosmos</CodeBlock>
-          That is all you need to do, you are now ready to use it in your app, no build step needed.
-        </Text>
-
-        <Text>
-          Cosmos assumes you have licensed fonts available on your app: Fakt-web and Roboto Mono.
-          Auth0 employees can grab these from the{' '}
-          <Link href="https://github.com/auth0/cosmos-fonts">cosmos-fonts repo</Link>
-        </Text>
-
-        <Heading2>Components</Heading2>
-        <Text>
-          Import components that you want from the library
-          <Pre code="import { Button } from '@auth0/cosmos'" />
-          and use them along with you React components:
-          <Pre
-            code={`
-  const Actions = () => (
-    <div>
-      <Button appearance="primary" onClick={this.save}>Save changes</Button>
-      <Button onClick={this.clear}>Clear</Button>
-    </div>
-  )
-            `}
-          />
-        </Text>
-
-        <Text>
-          To learn more about the components and the <Code>props</Code> they offer, pick a component
-          from the sidebar on the left.
-        </Text>
-        <Text>
-          You can also look at example code from our Manage Clients{' '}
-          <Link href="https://github.com/auth0/cosmos/tree/master/src/manage">
-            proof of concept repo.
-          </Link>
-        </Text>
-
-        <Heading2>Building your own components</Heading2>
-        <Text>
-          Cosmos uses{' '}
-          <Link target="_blank" href="https://www.styled-components.com">
-            styled-components
-          </Link>{' '}
-          under the hood. We recommend using it to create presentational components.
-        </Text>
-        <Text>
-          You can import it from cosmos to make sure you use the same version:
-          <Pre code="import styled from '@auth0/cosmos/styled'" />
-          and use them to create new components:
-          <Pre
-            code={`
-  import styled from '@auth0/cosmos/styled'
-
-  const Wrapper = styled.div\`
-    background-color: grey;
-  \`
-
-  const Actions = () => (
-    <Wrapper>
-      <Button appearance="primary" onClick={this.save}>Save changes</Button>
-      <Button onClick={this.clear}>Clear</Button>
-    </Wrapper>
-  )
-            `}
-          />
-          <Code>styled-components</Code> has very good{' '}
-          <Link target="_blank" href="https://www.styled-components.com">
-            documentation
-          </Link>{' '}
-          where you can learn how to use it.
-        </Text>
-
-        <Heading2>Disable global resets</Heading2>
-        <Text>
-          Cosmos adds a set of resets the same resets to your application, if you already have some
-          resets in place, you can disable the resets from Cosmos by setting an environment variable
-          with webpack
-          <CodeBlock language="javascript">
-            {`
-{
-   plugins: [
-      new webpack.EnvironmentPlugin({
-         COSMOS_DISABLE_RESETS: true
-      })
-   ]
-}
-`}
-          </CodeBlock>
-        </Text>
+        <Installation />
+        <UsingComponents />
+        <CustomComponents />
+        <WithStyleguide />
       </div>
     )
   }

--- a/internal/docs/pages/usage/custom-components.js
+++ b/internal/docs/pages/usage/custom-components.js
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import { Text, Link } from '../../docs-components/typography'
+import CodeBlock from '../../docs-components/code-block'
+import FoldingSection from '../../docs-components/folding-section'
+import { Code } from '@auth0/cosmos'
+
+const CustomComponents = () => (
+  <FoldingSection page="usage" name="Building your own components">
+    <Text>
+      Cosmos uses{' '}
+      <Link target="_blank" href="https://www.styled-components.com">
+        styled-components
+      </Link>{' '}
+      under the hood. We recommend using it to create presentational components.
+    </Text>
+    <Text>You can import it from cosmos to make sure you use the same version:</Text>
+    <CodeBlock language="javascript">{`import styled from '@auth0/cosmos/styled'`}</CodeBlock>
+    <Text>and use them to create new components:</Text>
+    <CodeBlock language="javascript">
+      {`
+import styled from '@auth0/cosmos/styled'
+
+const Wrapper = styled.div\`
+  background-color: grey;
+\`
+
+const Actions = () => (
+  <Wrapper>
+    <Button appearance="primary" onClick={this.save}>Save changes</Button>
+    <Button onClick={this.clear}>Clear</Button>
+  </Wrapper>
+)
+      `}
+    </CodeBlock>
+    <Text>
+      <Code>styled-components</Code> has very good{' '}
+      <Link target="_blank" href="https://www.styled-components.com">
+        documentation
+      </Link>{' '}
+      where you can learn how to use it.
+    </Text>
+  </FoldingSection>
+)
+
+export default CustomComponents

--- a/internal/docs/pages/usage/installation.js
+++ b/internal/docs/pages/usage/installation.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { Text, Link } from '../../docs-components/typography'
+import CodeBlock from '../../docs-components/code-block'
+import FoldingSection from '../../docs-components/folding-section'
+import { Code } from '@auth0/cosmos'
+
+const Installation = () => (
+  <FoldingSection page="usage" name="Installation">
+    <Text>
+      To add <Code>cosmos</Code> to your react application, run
+      <CodeBlock language="shell">$ yarn add @auth0/cosmos</CodeBlock>
+      If you prefer npm, run this command instead:
+      <CodeBlock language="shell">$ npm install --save @auth0/cosmos</CodeBlock>
+      That is all you need to do, you are now ready to use it in your app, no build step needed.
+    </Text>
+
+    <Text>
+      Cosmos assumes you have licensed fonts available on your app: Fakt-web and Roboto Mono. Auth0
+      employees can grab these from the{' '}
+      <Link href="https://github.com/auth0/cosmos-fonts">cosmos-fonts repo</Link>
+    </Text>
+  </FoldingSection>
+)
+
+export default Installation

--- a/internal/docs/pages/usage/using-components.js
+++ b/internal/docs/pages/usage/using-components.js
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import { Text, Link, Pre } from '../../docs-components/typography'
+import CodeBlock from '../../docs-components/code-block'
+import FoldingSection from '../../docs-components/folding-section'
+import { Code } from '@auth0/cosmos'
+
+const UsingComponents = () => (
+  <FoldingSection page="usage" name="Using components">
+    <Text>Import components that you want from the library</Text>
+    <CodeBlock language="javascript">{`import {Button} from '@auth0/cosmos'`}</CodeBlock>
+    <Text>and use them along with you React components:</Text>
+    <CodeBlock>
+      {`
+const Actions = () => (
+  <div>
+    <Button appearance="primary" onClick={this.save}>Save changes</Button>
+    <Button onClick={this.clear}>Clear</Button>
+  </div>
+)
+    `}
+    </CodeBlock>
+
+    <Text>
+      To learn more about the components and the <Code>props</Code> they offer, pick a component
+      from the sidebar on the left.
+    </Text>
+    <Text>
+      You can also look at example code from our Manage Clients{' '}
+      <Link href="https://github.com/auth0/cosmos/tree/master/src/manage">
+        proof of concept repo.
+      </Link>
+    </Text>
+  </FoldingSection>
+)
+
+export default UsingComponents

--- a/internal/docs/pages/usage/with-styleguide.js
+++ b/internal/docs/pages/usage/with-styleguide.js
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { Text, Link, Pre } from '../../docs-components/typography'
+import CodeBlock from '../../docs-components/code-block'
+import FoldingSection from '../../docs-components/folding-section'
+import { Code } from '@auth0/cosmos'
+
+const WithStyleguide = () => (
+  <FoldingSection page="usage" name="Usage with styleguide">
+    <Text>
+      Cosmos adds a set of resets the same resets to your application, if you are already using the
+      legacy styleguide, you can disable the resets from Cosmos by setting an environment variable
+      in your <Code>webpack.config.js</Code>
+    </Text>
+    <CodeBlock language="javascript">
+      {`
+{
+  plugins: [
+    new webpack.EnvironmentPlugin({
+      COSMOS_DISABLE_RESETS: true
+    })
+  ]
+}
+      `}
+    </CodeBlock>
+  </FoldingSection>
+)
+
+export default WithStyleguide

--- a/internal/docs/sidebar/list.js
+++ b/internal/docs/sidebar/list.js
@@ -7,6 +7,7 @@ import { colors, spacing } from '@auth0/cosmos/tokens'
 import Link from './link'
 import Group, { getGroups } from './group'
 import attachChildren from './children'
+import guides from '../guides'
 
 const StyledLink = styled.div`
   a {
@@ -26,16 +27,6 @@ const StyledLink = styled.div`
     }
   }
 `
-
-const guides = [
-  { path: '/', title: 'Getting started' },
-  { path: '/usage', title: 'How to use Cosmos?' },
-  { path: '/guiding-principles', title: 'Guiding Principles' },
-  { path: '/faqs', title: 'FAQs' },
-  { path: '/changes', title: 'Changelog' },
-  { path: '/automation', title: 'Automation Glossary' },
-  { path: '/contribution-guide', title: 'Contributing to Cosmos' }
-]
 
 const List = props => {
   /* Filter out internal components */


### PR DESCRIPTION
1. Now you have to add a page only to this file: https://github.com/auth0/cosmos/blob/e7325d4ee5cd7e3ae3985c95528a6c1c3be9ed65/internal/docs/guides.js

2. Split usage into sections