### PR TITLE
Improved examples in Pagination toolbar docs

### DIFF
--- a/core/components/molecules/pagination-toolbar/pagination-toolbar.md
+++ b/core/components/molecules/pagination-toolbar/pagination-toolbar.md
@@ -165,8 +165,8 @@ class PaginatedResourceList extends React.Component {
         <ResourceList
           items={this.getCurrentItems()}
           actions={[
-            { icon: 'settings', handler: function() {}, label: 'Settings' },
-            { icon: 'delete', handler: function() {}, label: 'Delete' }
+            <Button icon="settings" onClick={() => {}} label="Settings" />,
+            <Button icon="delete" onClick={() => {}} label="Delete" />
           ]}
         />
         <PaginationToolbar
@@ -331,12 +331,14 @@ class PaginatedTable extends React.Component {
     return (
       <React.Fragment>
         <Table items={this.getCurrentItems()}>
-          <Table.Column field="image" width="50px">
-            {item => <Avatar type="user" image={item.avatar} />}
+          <Table.Column field="image" title="User" width="50%">
+            {item => (
+              <AvatarBlock size="compact" type="user" image={item.avatar} title={item.email} />
+            )}
           </Table.Column>
-          <Table.Column field="email" title="Email" width="30%" />
-          <Table.Column field="latestLogin" title="Latest Login" />
-          <Table.Column field="logins" title="Logins" sortable />
+
+          <Table.Column field="latestLogin" title="Latest Login" width="25%" />
+          <Table.Column field="logins" title="Logins" sortable width="25%" />
         </Table>
         <PaginationToolbar
           items={this.state.items.length}


### PR DESCRIPTION
Table example had suboptimal column widths:

**Before**
<img width="821" alt="screen shot 2018-12-03 at 23 58 53" src="https://user-images.githubusercontent.com/239215/49416107-9f33fd00-f757-11e8-89dd-291dba47771a.png">

**After**
<img width="814" alt="screen shot 2018-12-03 at 23 57 55" src="https://user-images.githubusercontent.com/239215/49416111-a3f8b100-f757-11e8-8d17-62e3ac4f2ece.png">

---

Resource List example was giving a deprecation warning. Changed example to use recommended syntax.

<img width="1068" alt="screen shot 2018-12-03 at 23 58 50" src="https://user-images.githubusercontent.com/239215/49416138-bbd03500-f757-11e8-8881-714ab1784505.png">



