### PR TITLE
Fix FormGroup warning when only one child is passed

### DIFF
--- a/core/components/molecules/form-group/form-group.js
+++ b/core/components/molecules/form-group/form-group.js
@@ -24,7 +24,7 @@ FormGroup.FormWrapper = styled(Well)`
 `
 FormGroup.propTypes = {
   /** children should be Form components */
-  children: PropTypes.arrayOf(PropTypes.element)
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)])
 }
 
 FormGroup.defaultProps = {}


### PR DESCRIPTION
Resolves #1147 