### PR TITLE
Removes pointer events on the overlay component

### DIFF
--- a/core/components/atoms/_overlay/overlay.js
+++ b/core/components/atoms/_overlay/overlay.js
@@ -99,6 +99,7 @@ Overlay.Backdrop = styled.div`
 Overlay.Element = styled.div`
   width: 100%;
   margin: ${spacing.xlarge} ${spacing.small};
+  pointer-events: none;
 
   /* Since the focus trap is adding divs around the dialog box, the max width prop should be here */
   max-width: ${props => Overlay.getSizeForOverlay(props.contentSize)};


### PR DESCRIPTION
This Pr fixes #1224 by removing pointer events from the overlay.