### PR TITLE
Implement attrs to styled API

### DIFF
--- a/core/components/_helpers/component.story.js
+++ b/core/components/_helpers/component.story.js
@@ -37,15 +37,8 @@ const InputBox = Box.withComponent('input').extend`
   }
 `
 
-/* attrs doesn't work properly
-  completely breaks:
-  const PasswordBox = styled.input.attrs({ type: 'password' })``
-  works without helpers
-  const PasswordBox = styled('input').attrs({ type: 'password' })``
-*/
-
-// weird workaround that works:
-const PasswordBox = styled(InputBox).attrs({ type: 'password' })``
+const PasswordBox = styled('input').attrs({ type: 'password' })``
+const ExtendedPasswordBox = styled(InputBox).attrs({ type: 'password' })``
 
 storiesOf('Component', module).add('default', () => (
   <Stack>
@@ -55,5 +48,6 @@ storiesOf('Component', module).add('default', () => (
     <ShortBox bg="blue" />
     <InputBox bg="blue" defaultValue="okay" />
     <PasswordBox bg="blue" defaultValue="okay" />
+    <ExtendedPasswordBox bg="blue" defaultValue="okay" />
   </Stack>
 ))

--- a/core/components/styled.js
+++ b/core/components/styled.js
@@ -11,7 +11,10 @@ import domElements from './_helpers/dom-elements'
 /* import cosmos specific helpers */
 import margin from './_helpers/styled-margin'
 
-/* create a thin replacement for styled */
+/*
+  create a thin replacement for styled
+  styledWithHelpers(c) = styled(c)
+*/
 let styledWithHelpers = styledComponent => {
   return styled(styledComponent)
 }
@@ -32,6 +35,10 @@ domElements.forEach(domElement => {
 
     return styled(domElement)(styles, ...interpolations)
   }
+
+  /* attach inbuilt styled-components helpers back */
+  styledWithHelpers[domElement].withConfig = styled[domElement].withConfig
+  styledWithHelpers[domElement].attrs = styled[domElement].attrs
 })
 
 export default styledWithHelpers


### PR DESCRIPTION
This brings back `styled.div.attrs` and `styled.div.withConfig` that were deprecated in 0.10.0

Found an easy way to implement them 😄 