### PR TITLE
Explictly declare element ordering in switch

### DIFF
--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -29,23 +29,15 @@ class Switch extends React.Component {
   render() {
     let [onLabel, offLabel] = this.props.accessibleLabels
     const checkbox = (
-      <Checkbox
-        type="checkbox"
-        checked={this.state.on}
-        readOnly
-        id={this.props.id}
-        key="switch-checkbox"
-      />
+      <Checkbox type="checkbox" checked={this.state.on} readOnly id={this.props.id} />
     )
 
     let elements = <>{checkbox}</>
 
     const label = (
-      <Label labelPosition={this.props.labelPosition} key="switch-label">
-        {this.state.on ? onLabel : offLabel}
-      </Label>
+      <Label labelPosition={this.props.labelPosition}>{this.state.on ? onLabel : offLabel}</Label>
     )
-    const toggle = <Toggle on={this.state.on} readOnly={this.props.readOnly} key="switch-toggle" />
+    const toggle = <Toggle on={this.state.on} readOnly={this.props.readOnly} />
 
     if (this.props.labelPosition == 'left') {
       elements = (

--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -32,7 +32,7 @@ class Switch extends React.Component {
       <Checkbox type="checkbox" checked={this.state.on} readOnly id={this.props.id} />
     )
 
-    let elements = <>{checkbox}</>
+    let elements = <React.Fragment>{checkbox}</React.Fragment>
 
     const label = (
       <Label labelPosition={this.props.labelPosition}>{this.state.on ? onLabel : offLabel}</Label>
@@ -41,19 +41,19 @@ class Switch extends React.Component {
 
     if (this.props.labelPosition == 'left') {
       elements = (
-        <>
+        <React.Fragment>
           {checkbox}
           {this.props.hideAccessibleLabels ? null : label}
           {toggle}
-        </>
+        </React.Fragment>
       )
     } else if (this.props.labelPosition == 'right') {
       elements = (
-        <>
+        <React.Fragment>
           {checkbox}
           {toggle}
           {this.props.hideAccessibleLabels ? null : label}
-        </>
+        </React.Fragment>
       )
     }
 

--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -28,7 +28,7 @@ class Switch extends React.Component {
   }
   render() {
     let [onLabel, offLabel] = this.props.accessibleLabels
-    let elements = [
+    const checkbox = (
       <Checkbox
         type="checkbox"
         checked={this.state.on}
@@ -36,7 +36,10 @@ class Switch extends React.Component {
         id={this.props.id}
         key="switch-checkbox"
       />
-    ]
+    )
+
+    let elements = <>{checkbox}</>
+
     const label = (
       <Label labelPosition={this.props.labelPosition} key="switch-label">
         {this.state.on ? onLabel : offLabel}
@@ -47,9 +50,22 @@ class Switch extends React.Component {
     if (this.props.labelPosition == 'left') {
       if (!this.props.hideAccessibleLabels) elements.push(label)
       elements.push(toggle)
+
+      elements = (
+        <>
+          {checkbox}
+          {this.props.hideAccessibleLabels ? null : label}
+          {toggle}
+        </>
+      )
     } else if (this.props.labelPosition == 'right') {
-      elements.push(toggle)
-      if (!this.props.hideAccessibleLabels) elements.push(label)
+      elements = (
+        <>
+          {checkbox}
+          {toggle}
+          {this.props.hideAccessibleLabels ? null : label}
+        </>
+      )
     }
 
     /*

--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -29,12 +29,20 @@ class Switch extends React.Component {
   render() {
     let [onLabel, offLabel] = this.props.accessibleLabels
     let elements = [
-      <Checkbox type="checkbox" checked={this.state.on} readOnly id={this.props.id} />
+      <Checkbox
+        type="checkbox"
+        checked={this.state.on}
+        readOnly
+        id={this.props.id}
+        key="switch-checkbox"
+      />
     ]
     const label = (
-      <Label labelPosition={this.props.labelPosition}>{this.state.on ? onLabel : offLabel}</Label>
+      <Label labelPosition={this.props.labelPosition} key="switch-label">
+        {this.state.on ? onLabel : offLabel}
+      </Label>
     )
-    const toggle = <Toggle on={this.state.on} readOnly={this.props.readOnly} />
+    const toggle = <Toggle on={this.state.on} readOnly={this.props.readOnly} key="switch-toggle" />
 
     if (this.props.labelPosition == 'left') {
       if (!this.props.hideAccessibleLabels) elements.push(label)

--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -48,9 +48,6 @@ class Switch extends React.Component {
     const toggle = <Toggle on={this.state.on} readOnly={this.props.readOnly} key="switch-toggle" />
 
     if (this.props.labelPosition == 'left') {
-      if (!this.props.hideAccessibleLabels) elements.push(label)
-      elements.push(toggle)
-
       elements = (
         <>
           {checkbox}


### PR DESCRIPTION
I have reworked over #1273. Instead of using an array to order elements I explicitly order the elements surrounding them by fragments assigning them to the elements variable.