### PR TITLE
Internal: Replace extend with styled

### DIFF
--- a/core/components/_helpers/component.story.js
+++ b/core/components/_helpers/component.story.js
@@ -20,18 +20,24 @@ const Box = styled.div`
   ${borderStyles};
 `
 
-/* extend works */
-const TallBox = Box.extend`
-  height: 200px;
-`
+/*
+ extend works:
+ commented out because .extend will be deprecated in styled-components v4
+*/
+// const TallBox = Box.extend`
+//   height: 200px;
+// `
 
 /* styled wrapper works */
 const ShortBox = styled(Box)`
   height: 20px;
 `
+const TallBox = styled(Box)`
+  height: 200px;
+`
 
 /* withComponent works */
-const InputBox = Box.withComponent('input').extend`
+const InputBox = styled(Box.withComponent('input'))`
   :hover {
     background: #fff;
   }

--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -275,7 +275,7 @@ Button.Text = styled.span`
   margin-top: 1px;
 `
 
-Button.LinkElement = Button.Element.withComponent('a').extend`
+Button.LinkElement = styled(Button.Element.withComponent('a'))`
   text-decoration: none;
 `
 

--- a/core/components/atoms/heading/heading.js
+++ b/core/components/atoms/heading/heading.js
@@ -17,21 +17,21 @@ const Heading = props => {
 
 Heading.Element = []
 
-Heading.Element[1] = BaseHeading.withComponent('h1').extend`
+Heading.Element[1] = styled(BaseHeading.withComponent('h1'))`
   font-size: 36px;
 `
 
-Heading.Element[2] = BaseHeading.withComponent('h2').extend`
+Heading.Element[2] = styled(BaseHeading.withComponent('h2'))`
   font-size: 24px;
   font-weight: ${fonts.weight.medium};
 `
 
-Heading.Element[3] = BaseHeading.withComponent('h3').extend`
+Heading.Element[3] = styled(BaseHeading.withComponent('h3'))`
   font-size: 18px; /* TO-DO: tokenize */
   font-weight: ${fonts.weight.bold};
 `
 
-Heading.Element[4] = BaseHeading.withComponent('h4').extend`
+Heading.Element[4] = styled(BaseHeading.withComponent('h4'))`
   font-size: 14px;
   font-weight: ${fonts.weight.medium};
 `

--- a/core/components/atoms/select/select.js
+++ b/core/components/atoms/select/select.js
@@ -59,11 +59,11 @@ const Select = ({ options, ...props }) => {
   )
 }
 
-Select.Element = StyledInput.withComponent('select').extend`
+Select.Element = styled(StyledInput.withComponent('select'))`
   appearance: none;
-  
+
   padding-right: ${spacing.large};
-  
+
   height: ${misc.input.default.height};
   opacity: ${props => (props.disabled ? selectOpacity.disabled : selectOpacity.default)};
   background-color: ${props =>

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from '@auth0/cosmos/styled'
 
 import { misc } from '@auth0/cosmos-tokens'
 import { StyledInput } from '../_styled-input'
@@ -30,7 +31,7 @@ const TextInput = ({ defaultValue, type, ...props }) => {
   )
 }
 
-TextInput.Element = StyledInput.extend`
+TextInput.Element = styled(StyledInput)`
   height: ${props => misc.input[props.size].height};
 `
 

--- a/core/components/atoms/textarea/textarea.js
+++ b/core/components/atoms/textarea/textarea.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from '@auth0/cosmos/styled'
 
 import { StyledInput } from '../_styled-input'
 import { deprecate } from '../../_helpers/custom-validations'
@@ -9,7 +10,7 @@ const TextArea = props => (
   <TextArea.Element rows={props.length} {...props} {...Automation('text-area')} />
 )
 
-TextArea.Element = StyledInput.withComponent('textarea').extend`
+TextArea.Element = styled(StyledInput.withComponent('textarea'))`
   resize: ${props => (props.resizable ? 'vertical' : 'none')};
   font-size: ${props => (props.code ? '13px' : 'inherit')};
   display: block;


### PR DESCRIPTION
`styled-components@3.4.10` introduced a soft deprecation warning (like we do) for using `.extend`

Replacing the places we use `Component.extend` with `styled(Component)`