### PR TITLE
Internal: Clean up code for masked TextInput

### DIFF
--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -24,7 +24,6 @@ const TextInput = props => {
   return (
     <TextInput.Element
       {...Automation('text-input')}
-      defaultValue={defaultValue}
       placeholder={placeholder}
       readOnly={readOnly}
       {...restOfTheProps}

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -6,26 +6,28 @@ import { StyledInput } from '../_styled-input'
 import { deprecate } from '../../_helpers/custom-validations'
 import Automation from '../../_helpers/automation-attribute'
 
-const TextInput = ({ defaultValue, type, ...props }) => {
+const TextInput = props => {
+  let { placeholder, readOnly, ...restOfTheProps } = props
+
+  /*
+    override placeholder and readOnly for masked
+
+    masked is like a readOnly field but with the values replaced with *
+    (like password, but without the value underneath)
+  */
   if (props.masked) {
-    const length = defaultValue ? defaultValue.length : 8
-    const maskedValue = new Array(length).join('•')
-    return (
-      <TextInput.Element
-        type={type}
-        {...props}
-        placeholder={maskedValue}
-        readOnly
-        {...Automation('text-input')}
-      />
-    )
+    const length = props.defaultValue ? props.defaultValue.length : 8
+    placeholder = new Array(length).join('•')
+    readOnly = true
   }
+
   return (
     <TextInput.Element
       {...Automation('text-input')}
-      type={type}
       defaultValue={defaultValue}
-      {...props}
+      placeholder={placeholder}
+      readOnly={readOnly}
+      {...restOfTheProps}
     />
   )
 }

--- a/core/components/atoms/text-input/text-input.js
+++ b/core/components/atoms/text-input/text-input.js
@@ -7,7 +7,7 @@ import { deprecate } from '../../_helpers/custom-validations'
 import Automation from '../../_helpers/automation-attribute'
 
 const TextInput = props => {
-  let { placeholder, readOnly, ...restOfTheProps } = props
+  let { defaultValue, placeholder, readOnly, ...restOfTheProps } = props
 
   /*
     override placeholder and readOnly for masked
@@ -19,11 +19,13 @@ const TextInput = props => {
     const length = props.defaultValue ? props.defaultValue.length : 8
     placeholder = new Array(length).join('•')
     readOnly = true
+    defaultValue = null
   }
 
   return (
     <TextInput.Element
       {...Automation('text-input')}
+      defaultValue={defaultValue}
       placeholder={placeholder}
       readOnly={readOnly}
       {...restOfTheProps}


### PR DESCRIPTION
The code had some confusing duplication. Hope this doesn't break it.

There should be zero chromatic changes

Dependency for https://github.com/auth0/cosmos/pull/1281