### PR TITLE
Examples: react + react-dom should have same version

### DIFF
--- a/examples/manage/package.json
+++ b/examples/manage/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@auth0/cosmos": "0.10.1",
     "@auth0/cosmos-fonts": "0.0.1",
-    "react": "16.3.0",
-    "react-dom": "16.3.0",
+    "react": "16.6.3",
+    "react-dom": "16.6.3",
     "react-router-dom": "4.2.2"
   },
   "devDependencies": {

--- a/examples/manage/package.json
+++ b/examples/manage/package.json
@@ -12,7 +12,7 @@
     "@auth0/cosmos": "0.10.1",
     "@auth0/cosmos-fonts": "0.0.1",
     "react": "16.3.0",
-    "react-dom": "16.3.3",
+    "react-dom": "16.3.0",
     "react-router-dom": "4.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Was getting some fiber errors on manage example, turns out the versions were out of sync