### PR TITLE
Changes the Page Header from grid to flex

### DIFF
--- a/core/components/molecules/page-header/description.js
+++ b/core/components/molecules/page-header/description.js
@@ -40,7 +40,7 @@ export const StyledParagraph = styled(Paragraph)`
   }
 
   @media (min-width: 768px) {
-    margin-top: ${spacing.small};
+    margin-top: ${spacing.medium};
   }
 `
 

--- a/core/components/molecules/page-header/description.js
+++ b/core/components/molecules/page-header/description.js
@@ -25,7 +25,11 @@ export const StyledParagraph = styled(Paragraph)`
   We'll remove this margin reset when we remove margins from the paragraph
   */
   margin: 0;
-  grid-area: subtitle;
+  flex: 1 0 100%;
+  order: 1;
+  &:empty {
+    display: none;
+  }
 
   &:hover ${ArrowMore} {
     border-color: transparent transparent transparent ${colors.link.defaultHover};
@@ -33,6 +37,10 @@ export const StyledParagraph = styled(Paragraph)`
 
   &:hover ${StyledLink} {
     color: ${colors.link.defaultHover};
+  }
+
+  @media (min-width: 768px) {
+    margin-top: ${spacing.small};
   }
 `
 

--- a/core/components/molecules/page-header/description.js
+++ b/core/components/molecules/page-header/description.js
@@ -27,9 +27,6 @@ export const StyledParagraph = styled(Paragraph)`
   margin: 0;
   flex: 1 0 100%;
   order: 1;
-  &:empty {
-    display: none;
-  }
 
   &:hover ${ArrowMore} {
     border-color: transparent transparent transparent ${colors.link.defaultHover};
@@ -38,9 +35,9 @@ export const StyledParagraph = styled(Paragraph)`
   &:hover ${StyledLink} {
     color: ${colors.link.defaultHover};
   }
-
+  margin-top: ${spacing.medium};
   @media (min-width: 768px) {
-    margin-top: ${spacing.medium};
+    margin-bottom: 0;
   }
 `
 

--- a/core/components/molecules/page-header/page-header.js
+++ b/core/components/molecules/page-header/page-header.js
@@ -19,37 +19,37 @@ const PageHeader = props => {
     <PageHeader.Element {...Automation('page-header')}>
       <Heading size={1}>{props.title}</Heading>
       <PageHeader.Description {...props} />
-      <ButtonGroup>
-        {props.secondaryAction && (
-          <Button
-            size="large"
-            appearance="secondary"
-            icon={props.secondaryAction.icon}
-            onClick={props.secondaryAction.handler}
-          >
-            {props.secondaryAction.label}
-          </Button>
-        )}
-        {props.primaryAction && (
-          <Button
-            size="large"
-            appearance="cta"
-            icon={props.primaryAction.icon}
-            onClick={props.primaryAction.handler}
-          >
-            {props.primaryAction.label}
-          </Button>
-        )}
-      </ButtonGroup>
+
+      {(props.secondaryAction || props.primaryAction) && (
+        <ButtonGroup>
+          {props.secondaryAction && (
+            <Button
+              size="large"
+              appearance="secondary"
+              icon={props.secondaryAction.icon}
+              onClick={props.secondaryAction.handler}
+            >
+              {props.secondaryAction.label}
+            </Button>
+          )}
+          {props.primaryAction && (
+            <Button
+              size="large"
+              appearance="cta"
+              icon={props.primaryAction.icon}
+              onClick={props.primaryAction.handler}
+            >
+              {props.primaryAction.label}
+            </Button>
+          )}
+        </ButtonGroup>
+      )}
     </PageHeader.Element>
   )
 }
 
 PageHeader.Element = styled.div`
   ${containerStyles};
-  > *:not(:last-child) {
-    margin-bottom: ${spacing.small};
-  }
 
   @media (min-width: 768px) {
     display: flex;
@@ -64,11 +64,10 @@ PageHeader.Element = styled.div`
   margin-bottom: ${spacing.large};
 
   ${ButtonGroup.Element} {
+    margin-top: ${spacing.medium};
     @media (min-width: 768px) {
+      margin-top: 0;
       margin-left: ${spacing.small};
-    }
-    &:empty {
-      display: none;
     }
   }
 
@@ -78,10 +77,7 @@ PageHeader.Element = styled.div`
     Components should not have margin by default.
     We'll remove this margin reset when we remove margins from headers
     */
-    margin-top: 0;
-    @media (min-width: 768px) {
-      margin-bottom: 0;
-    }
+    margin: 0;
   }
 `
 

--- a/core/components/molecules/page-header/page-header.js
+++ b/core/components/molecules/page-header/page-header.js
@@ -47,24 +47,15 @@ const PageHeader = props => {
 
 PageHeader.Element = styled.div`
   ${containerStyles};
-  display: grid;
-  /* Placeholder width media feature until we have global variables for breakpoints */
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto auto;
-  grid-template-areas:
-    'title'
-    'subtitle'
-    'actions';
-  grid-row-gap: ${spacing.small};
+  > *:not(:last-child) {
+    margin-bottom: ${spacing.small};
+  }
 
   @media (min-width: 768px) {
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-      'title actions'
-      'subtitle subtitle';
-    grid-column-gap: ${spacing.xsmall};
-    grid-row-gap: ${spacing.medium};
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    align-items: center;
   }
   /* 
   Components should not have margin by default.
@@ -73,16 +64,24 @@ PageHeader.Element = styled.div`
   margin-bottom: ${spacing.large};
 
   ${ButtonGroup.Element} {
-    grid-area: actions;
+    @media (min-width: 768px) {
+      margin-left: ${spacing.small};
+    }
+    &:empty {
+      display: none;
+    }
   }
 
   ${Heading.Element[1]} {
-    grid-area: title;
+    flex: 1;
     /* 
     Components should not have margin by default.
     We'll remove this margin reset when we remove margins from headers
     */
-    margin: 0;
+    margin-top: 0;
+    @media (min-width: 768px) {
+      margin-bottom: 0;
+    }
   }
 `
 


### PR DESCRIPTION
This PR fixes #1226 

It move the component from grid to flex so it doesn't render the grid gap and removes the node when it has no content.