### PR TITLE
Removes line height declaration on tables

### DIFF
--- a/core/components/molecules/table/table-header.js
+++ b/core/components/molecules/table/table-header.js
@@ -68,7 +68,6 @@ TableHeader.Cell = styled.th`
   border-bottom: 2px solid ${colors.base.grayLight};
   text-align: left;
   vertical-align: bottom;
-  line-height: 2;
   ${props => (props.width ? `width: ${props.width};` : '')}
   cursor: ${props => (props.sortable ? 'pointer' : 'auto')};
   &:hover {

--- a/core/components/molecules/table/table.js
+++ b/core/components/molecules/table/table.js
@@ -190,7 +190,7 @@ Table.Body = styled.tbody``
 Table.Row = styled.tr`
   cursor: ${props => (props.onClick ? 'pointer' : 'inherit')};
   &:hover {
-    background: ${colors.list.backgroundHover};
+    background-color: ${colors.list.backgroundHover};
   }
 `
 
@@ -199,7 +199,6 @@ Table.Cell = styled.td`
   border-top: 1px solid ${colors.base.grayLight};
   text-align: left;
   vertical-align: middle;
-  line-height: 2;
   overflow-wrap: break-word;
   width: ${props => props.column.width || 'auto'};
   ${props =>


### PR DESCRIPTION
This PR fixes #1231 by removing the line-height declaration from `th` and `td`s

It also cleans the CSS by avoiding the use of shorthands on `background`.