### PR TITLE
Select: Removes pointer events on the icon

### DIFF
--- a/core/components/atoms/select/select.js
+++ b/core/components/atoms/select/select.js
@@ -79,6 +79,7 @@ Select.Wrapper = styled.div`
 Select.ArrowIcon = styled(Icon)`
   position: absolute;
   right: 12px;
+  pointer-events: none;
 
   svg {
     display: block;


### PR DESCRIPTION
If a user clicks on the icon on the select, the select doesn't open.

This PR removes pointer events on the icon to fix the problem