### PR TITLE
Test Tabs linked accessibility identifiers are present and correctly named

### DIFF
--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -78,7 +78,6 @@ class Tabs extends React.Component {
   }
 
   changeFocusedTab(tabsId, index) {
-    console.log({ tabsId, index })
     const tab = document.querySelector(`#${tabsId}-${index}`)
     tab.focus()
   }

--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -119,7 +119,7 @@ class Tabs extends React.Component {
           React.cloneElement(this.tabs[selectedIndex], {
             role: 'tabpanel',
             id: `${uniqueTabPrefix}-${selectedIndex}-tab`,
-            'aria-labelledby': this.tabs[selectedIndex].props.id,
+            'aria-labelledby': `${uniqueTabPrefix}-${selectedIndex}-tab`,
             ...Automation('tabs.item')
           })}
       </Tabs.Element>

--- a/internal/test/unit/__snapshots__/tabs.test.js.snap
+++ b/internal/test/unit/__snapshots__/tabs.test.js.snap
@@ -61,6 +61,7 @@ exports[`Tabs only render one tab title as selected 1`] = `
     </styled.li>
   </styled.ul>
   <styled.div
+    aria-labelledby="tabs-m0ck3d-0-tab"
     data-cosmos-key="tabs.item"
     id="tabs-m0ck3d-0-tab"
     key=".0"
@@ -135,6 +136,7 @@ exports[`Tabs only render one tab title as selected 2`] = `
     </styled.li>
   </styled.ul>
   <styled.div
+    aria-labelledby="tabs-m0ck3d-1-tab"
     data-cosmos-key="tabs.item"
     id="tabs-m0ck3d-1-tab"
     key=".1"
@@ -209,6 +211,7 @@ exports[`Tabs only render one tab title as selected 3`] = `
     </styled.li>
   </styled.ul>
   <styled.div
+    aria-labelledby="tabs-m0ck3d-2-tab"
     data-cosmos-key="tabs.item"
     id="tabs-m0ck3d-2-tab"
     key=".2"

--- a/internal/test/unit/tabs.test.js
+++ b/internal/test/unit/tabs.test.js
@@ -61,4 +61,24 @@ describe('Tabs', () => {
 
     expect(selectedHandler).toHaveBeenCalled()
   })
+
+  it('renders linked accessibility identifiers', () => {
+    const { generator } = tabsFactory()
+    const testableIndexes = [0, 1, 2]
+
+    testableIndexes.forEach(index => {
+      const tabs = generator(index)
+
+      const [tabList, activeTabPanel] = tabs.children()
+
+      const tabLinkIds = tabList.props.children.map(i => i.props.children.props.id)
+      const tabLinkAriaControls = tabList.props.children.map(
+        i => i.props.children.props['aria-controls']
+      )
+
+      expect(tabLinkIds[index]).toEqual(activeTabPanel.props.id.replace('-tab', ''))
+      expect(tabLinkAriaControls[index]).toEqual(activeTabPanel.props.id)
+      expect(tabLinkIds[index]).toEqual(activeTabPanel.props['aria-labelledby'].replace('-tab', ''))
+    })
+  })
 })


### PR DESCRIPTION
It tests the Tabs component internal identifiers are present and correctly linked according to the W3C spec: https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html