### PR TITLE
Breadcrumb: Fix automation attribute?

### DIFF
--- a/core/components/atoms/link/link.js
+++ b/core/components/atoms/link/link.js
@@ -6,7 +6,7 @@ import Automation from '../../_helpers/automation-attribute'
 import { colors } from '@auth0/cosmos-tokens'
 
 const Link = props => (
-  <Link.Element {...props} {...Automation('link')}>
+  <Link.Element {...Automation('link')} {...props}>
     {props.children}
   </Link.Element>
 )

--- a/internal/docs/pages/automation-glossary.js
+++ b/internal/docs/pages/automation-glossary.js
@@ -34,7 +34,7 @@ class AutomationGlossary extends React.Component {
                 component: 'Breadcrumb',
                 selectors: [
                   '$(\'div[data-cosmos-key="breadcrumb"]\')',
-                  '$(\'div[data-cosmos-key="breadcrumb"] a[data-cosmos-key="link"]\')'
+                  '$(\'div[data-cosmos-key="breadcrumb"] a[data-cosmos-key="breadcrumb.link"]\')'
                 ]
               },
               {

--- a/internal/docs/pages/contribution-guide.js
+++ b/internal/docs/pages/contribution-guide.js
@@ -10,6 +10,7 @@ import Architecture from './contribution-guide/architecture'
 import ComponentFiles from './contribution-guide/component-files'
 import Testing from './contribution-guide/testing'
 import LineHeight from './contribution-guide/line-height'
+import OrderOfProps from './contribution-guide/order-of-props'
 
 class ContributionGuide extends React.Component {
   render() {
@@ -25,6 +26,7 @@ class ContributionGuide extends React.Component {
         <ComponentFiles />
         <Testing />
         <LineHeight />
+        <OrderOfProps />
       </div>
     )
   }

--- a/internal/docs/pages/contribution-guide/order-of-props.js
+++ b/internal/docs/pages/contribution-guide/order-of-props.js
@@ -1,0 +1,96 @@
+import React from 'react'
+
+import FoldingSection from '../../docs-components/folding-section'
+import { Heading3, Heading4, Text, Link, List, ListItem } from '../../docs-components/typography'
+import CodeBlock from '../../docs-components/code-block'
+import { Code } from '@auth0/cosmos'
+
+const OrderOfProps = () => (
+  <FoldingSection page="contribution-guide" name="Order of props">
+    <List>
+      <ListItem>
+        <Heading3>
+          Components should respect the props passed to them and set them on the underlying element
+        </Heading3>
+        <CodeBlock language="jsx">
+          {`
+const Link = (props) => (
+  <a {...props}>clicky</a>
+)
+
+render(<Link id="custom-id">)
+        `}
+        </CodeBlock>
+        renders
+        <CodeBlock language="html">{`<a id="custom-id">`}</CodeBlock>
+      </ListItem>
+
+      <ListItem>
+        <Heading3>Props should override local attributes.</Heading3>
+        <Text>This will make sure the parent gets preference over what is rendered. </Text>
+        <Text>
+          Example: When you add an automation attribute in <Code>Breadcrumb.Link</Code>, you are
+          overriding the automation attribute of the underlying Link
+        </Text>
+        <CodeBlock language="jsx">
+          {`
+const Breadcrumb.Link = (props) => (
+  <Link {...Automation('breadcrumb.link')}>{props.children}</Link>
+)
+
+const Link = (props) => (
+  <a {...Automation('link')} {...props}>clicky</a>
+)
+        `}
+        </CodeBlock>
+        renders
+        <CodeBlock language="html">{`<a data-cosmos-key="breadcrumb.link"/>`}</CodeBlock>
+        <Text>
+          This principle extends to cosmos users as well, they can give their own attributes to
+          cosmos components.
+        </Text>
+        <CodeBlock language="jsx">
+          {`
+<Link rel="nofollow" />
+
+// or even
+<Link data-cosmos-key="custom-component.link" />
+        `}
+        </CodeBlock>
+        <Text>
+          {' '}
+          This is usually the behaviour you want from any atomic component. So it's useful to make
+          this into a rule.
+        </Text>
+        <Heading4>
+          <Code>...props</Code>
+          should be the last thing inside a <Code>Component.Element</Code>
+        </Heading4>
+      </ListItem>
+      <ListItem>
+        <Heading3>When needed, cosmos can override the user's intent</Heading3>
+        <Text>
+          This is a tricky one, you usually want the user to be able to have the final say.
+        </Text>
+        <Text>
+          But, in some cases, you can override them to save them from making a mistake (usually a
+          design mistake)
+        </Text>
+        <Text>
+          Example:
+          <CodeBlock language="jsx">{`
+const InputAction = (props) => (
+  <Button {...props} appearance="link" />
+)
+          `}</CodeBlock>
+        </Text>
+        <Text>
+          Here we are locking <Code>appearance</Code> to link even if the user passed{' '}
+          <Code>appearance="destructive"</Code>
+        </Text>
+      </ListItem>
+    </List>
+  </FoldingSection>
+)
+
+export default OrderOfProps


### PR DESCRIPTION
Sorry I wrote an essay

tl;dr: found a bug, fix means breaking change, we might be able to squeeze this in in without breaking anything

&nbsp;

---

&nbsp;

### Automation attribute bug

&nbsp;

When you render

```jsx
<Breadcrumb>
  <Breadcrumb.Link>Home</Breadcrumb.Link>
  <Breadcrumb.Link>Parent</Breadcrumb.Link>
</Breadcrumb>
```

These are the cosmos-key it renders:

```html
<div data-cosmos-key="breadcrumb">
  <a data-cosmos-key="link">Home</a>
  <a data-cosmos-key="link">Parent</a>
</div>
```

There are 2 problems with the `data-cosmos-key` of the child being `link`:

1. It seems to rely on an implementation detail - the breadcrumb uses a `Link` component today, this might change (maybe to `<Button appearance="link">` 🤷‍♀️)

2. This is not what the code says! The code says `breadcrumb.link`

```jsx
const Breadcrumb.Link = props =>  <Link {...props} {...Automation('breadcrumb.link')} />
//                                                                          ⬆️
```

Then how does this happen 🤔 

---

&nbsp;

### A tale why order of props is important

&nbsp;

When you render 

```jsx
const Link = (props) => <a href="a.com" href="b.com">clicky</a>

render(<Link/>)
```

it results in:

```html
<a href="b.com">clicky</a>
```

**The second prop wins.**

&nbsp;

Using objects makes this more difficult to see:

```jsx
// breadcrumb.link wants to attach it's own cosmos-key
const Breadcrumb.Link = (props) => <Link data-cosmos-key="breadcrumb.link">{props.children}</Link>

// we've got ...props and link's own cosmos-key
const Link = (props) =>  <a {...props} data-cosmos-key="link">{props.children}</a>

render(<Breadcrumb.Link>clicky</Breadcrumb.Link>)
```

this will render

```html
<a data-cosmos-key="link">clicky</a>
```


Whoops, you'd want the key to be `breadcrumb.link` but the **second prop won.**


```jsx
const Link = (props) =>  <a {...props} data-cosmos-key="link">{props.children}</a>
//                               1️⃣                 2️⃣
```

&nbsp;

The fix is pretty straightforward:

```diff
- const Link = (props) =>  <a {...props} data-cosmos-key="link">clicky</a>
+ const Link = (props) =>  <a data-cosmos-key="link" {...props}>clicky</a>
//                               1️⃣                      2️⃣
```

now it renders

```html
<a data-cosmos-key="breadcrumb.link">clicky</a>
// 👍 
```

&nbsp;

This is a useful feature of React but also easy to screw up. Double edged swords? ⚔️ 

----

&nbsp;

### Guidelines for prop

(added this to contribution guide)

&nbsp;

1. **Components should respect the props passed to them and set them on the underlying element**

    ```jsx
    const Link = (props) => <a {...props}>clicky</a>

    render(<Link id="custom-id">)
    ```

    renders 

    ```html
    <a id="custom-id">
    ```

    This is how the new `margin` prop works as well 😉 

&nbsp;

2. **Props should override local attributes.**

    This will make sure the parent gets preference over what is rendered.

    When you add an automation attribute in `Breadcrumb.Link`, you are overriding the automation attribute of the underlying `Link`

	 ```jsx
    const Breadcrumb.Link = (props) => (
  	    <Link {...Automation('breadcrumb.link')}>{props.children}</Link>
    )

    const Link = (props) => <a {...Automation('link')} {...props}>clicky</a>
	```

    This way, the user of the component (Breadcrumb here) gets the final say in what is rendered.

    ```html
    <a data-cosmos-key="breadcrumb.link"/>
    ```

	This principle extends to cosmos users as well, they can give their own attributes to cosmos components.

    ```jsx
    <Link rel="nofollow" />
    ```

    or even

    ```jsx
    <Link data-cosmos-key="custom-component.link" />
	```

	&nbsp;

    This is usually the behaviour you want from any atomic component. So it's useful to make this into a rule.

    **`{...props}` should be the last thing inside a Component.Element**

&nbsp;

3. **When needed, cosmos can override the user's intent**

	This is a tricky one, you usually want the user to be able to have the final say.

    But, in some cases, you can override them to save them from making a mistake (usually a design mistake)

	Example:

    ```jsx
    const InputAction = (props) => <Button {...props} appearance="link" />
    ```

    Here we are locking `appearance` to `link` even if the user passed `appearance="destructive"`

&nbsp;
   
----

&nbsp;

Cool story bro, let's merge this?

&nbsp;

### Breaking change 🙈

&nbsp;

Fun fact, [our docs](https://auth0-cosmos.now.sh/docs/#/automation) documents the bug 😄 

Funner fact, the automation tests did not fail when I made this breaking change 🙈 

```
Breadcrumb Link: $('div[data-cosmos-key="breadcrumb"] a[data-cosmos-key="link"]')
//                                                                        ⬆️🙃 
```

Even though the fix is pretty simple, it is breaking in nature. It will change snapshots and fail automation tests.

Change in snapshots is acceptable as it is part of the implementation detail that is expected to change.

Automation tests failing with a minor upgrade is however not expected.

**The question here is: can we get away by making this change and hope nobody notices?**

&nbsp;

----

&nbsp;

### This must be happening everywhere!

&nbsp;

Yeeep. Any component that doesn't follow those guidelines ⬆️ will have such subtle bugs.

But that's okay, we'll end up fixing all of them as part of https://github.com/auth0/cosmos/pull/1308 and https://github.com/auth0/cosmos/issues/1270 as they keep surfacing.

I'm glad we took up the tasking task in time. kudos to @francocorreasosa for championing this 👏 

&nbsp;