### PR TITLE
adds z-index to tooltips

### DIFF
--- a/core/components/atoms/tooltip/tooltip.js
+++ b/core/components/atoms/tooltip/tooltip.js
@@ -78,6 +78,7 @@ const Tooltip = ({ content, ...props }) => (
 
 Tooltip.Element = styled.div`
   position: absolute;
+  z-index: 10;
   background: ${colors.tooltip.background};
   color: ${colors.tooltip.text};
   border-radius: ${misc.radius};


### PR DESCRIPTION
This PR solved part of the issues we have on tooltips appearing behind other elements.

Fixes #1307