### PR TITLE
Quick aria labels fix for Tabs

### DIFF
--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -100,7 +100,6 @@ class Tabs extends React.Component {
                   role="tab"
                   id={id}
                   tabIndex={tabIsSelected ? '0' : '-1'}
-                  aria-label={tab.props.label}
                   aria-selected={tabIsSelected}
                   aria-controls={id + '-tab'}
                   onClick={() => this.changeTab(index)}

--- a/core/components/molecules/tabs/tabs.js
+++ b/core/components/molecules/tabs/tabs.js
@@ -119,7 +119,7 @@ class Tabs extends React.Component {
           React.cloneElement(this.tabs[selectedIndex], {
             role: 'tabpanel',
             id: `${uniqueTabPrefix}-${selectedIndex}-tab`,
-            'aria-labelledby': `${uniqueTabPrefix}-${selectedIndex}-tab`,
+            'aria-labelledby': `${uniqueTabPrefix}-${selectedIndex}`,
             ...Automation('tabs.item')
           })}
       </Tabs.Element>

--- a/internal/test/unit/__snapshots__/tabs.test.js.snap
+++ b/internal/test/unit/__snapshots__/tabs.test.js.snap
@@ -62,7 +62,7 @@ exports[`Tabs only render one tab title as selected 1`] = `
     </styled.li>
   </styled.ul>
   <styled.div
-    aria-labelledby="tabs-m0ck3d-0-tab"
+    aria-labelledby="tabs-m0ck3d-0"
     data-cosmos-key="tabs.item"
     id="tabs-m0ck3d-0-tab"
     key=".0"
@@ -138,7 +138,7 @@ exports[`Tabs only render one tab title as selected 2`] = `
     </styled.li>
   </styled.ul>
   <styled.div
-    aria-labelledby="tabs-m0ck3d-1-tab"
+    aria-labelledby="tabs-m0ck3d-1"
     data-cosmos-key="tabs.item"
     id="tabs-m0ck3d-1-tab"
     key=".1"
@@ -214,7 +214,7 @@ exports[`Tabs only render one tab title as selected 3`] = `
     </styled.li>
   </styled.ul>
   <styled.div
-    aria-labelledby="tabs-m0ck3d-2-tab"
+    aria-labelledby="tabs-m0ck3d-2"
     data-cosmos-key="tabs.item"
     id="tabs-m0ck3d-2-tab"
     key=".2"


### PR DESCRIPTION
Seems like an honest mistake

```diff
- aria-labelledby="tabs-first-tab"
+ aria-labelledby="tabs-first"
```

Demo: [auth0-cosmos-alt-unique-id/sandbox/tabs](https://auth0-cosmos-alt-unique-id.now.sh/sandbox/?selectedKind=Tabs&selectedStory=default&full=0&addons=1&stories=1&panelRight=0)