### PR TITLE
Alternative implementation for testing event handlers [Atoms]

### DIFF
--- a/internal/test/integration/atoms/alert.fixture.js
+++ b/internal/test/integration/atoms/alert.fixture.js
@@ -1,14 +1,19 @@
 import React from 'react'
 import { Alert } from '@auth0/cosmos'
 
+const mockFn = jest.fn()
+
 class Fixture extends React.Component {
   render() {
     return (
-      <Alert id="custom-id" icon="notes" type="default" title="FYI!">
+      <Alert id="custom-id" icon="notes" type="default" title="FYI!" onDismiss={mockFn}>
         Just a regular message
       </Alert>
     )
   }
 }
+
+/* Convention: Attach mock function to fixture */
+Fixture.mockFn = mockFn
 
 export default Fixture

--- a/internal/test/integration/atoms/alert.fixture.js
+++ b/internal/test/integration/atoms/alert.fixture.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Alert } from '@auth0/cosmos'
-
 import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {

--- a/internal/test/integration/atoms/alert.fixture.js
+++ b/internal/test/integration/atoms/alert.fixture.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Alert } from '@auth0/cosmos'
 
-const mockFn = jest.fn()
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
@@ -12,8 +12,5 @@ class Fixture extends React.Component {
     )
   }
 }
-
-/* Convention: Attach mock function to fixture */
-Fixture.mockFn = mockFn
 
 export default Fixture

--- a/internal/test/integration/atoms/alert.test.js
+++ b/internal/test/integration/atoms/alert.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './alert.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'alert')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'alert.dismiss')
 })

--- a/internal/test/integration/atoms/alert.test.js
+++ b/internal/test/integration/atoms/alert.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'alert')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'alert.dismiss')
 })

--- a/internal/test/integration/atoms/avatar.fixture.js
+++ b/internal/test/integration/atoms/avatar.fixture.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Avatar } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
@@ -10,6 +11,7 @@ class Fixture extends React.Component {
         image="https://images.unsplash.com/photo-1493666438817-866a91353ca9?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&h=200&fit=crop&crop=faces&s=a72ca28288878f8404a795f39642a46f"
         size="medium"
         type="user"
+        onClick={mockFn}
       />
     )
   }

--- a/internal/test/integration/atoms/avatar.test.js
+++ b/internal/test/integration/atoms/avatar.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'avatar')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'avatar')
 })

--- a/internal/test/integration/atoms/avatar.test.js
+++ b/internal/test/integration/atoms/avatar.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './avatar.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'avatar')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'avatar')
 })

--- a/internal/test/integration/atoms/badge.fixture.js
+++ b/internal/test/integration/atoms/badge.fixture.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Badge } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
     return (
-      <Badge appearance="default" id="custom-id">
+      <Badge appearance="default" id="custom-id" onClick={mockFn}>
         99
       </Badge>
     )

--- a/internal/test/integration/atoms/badge.test.js
+++ b/internal/test/integration/atoms/badge.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './badge.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'badge')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'badge')
 })

--- a/internal/test/integration/atoms/badge.test.js
+++ b/internal/test/integration/atoms/badge.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'badge')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'badge')
 })

--- a/internal/test/integration/atoms/breadcrumb.fixture.js
+++ b/internal/test/integration/atoms/breadcrumb.fixture.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { Breadcrumb } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
     return (
       <Breadcrumb id="custom-id">
-        <Breadcrumb.Link id="custom-id" href="/home">
+        <Breadcrumb.Link id="custom-id" href="/home" onClick={mockFn}>
           Home
         </Breadcrumb.Link>
         <Breadcrumb.Link href="/parent">Parent</Breadcrumb.Link>

--- a/internal/test/integration/atoms/breadcrumb.test.js
+++ b/internal/test/integration/atoms/breadcrumb.test.js
@@ -3,8 +3,13 @@ import { render } from 'react-testing-library'
 
 import Fixture from './breadcrumb.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'breadcrumb')
   customIdTest(Fixture, 'breadcrumb.link')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'breadcrumb.link')
 })

--- a/internal/test/integration/atoms/breadcrumb.test.js
+++ b/internal/test/integration/atoms/breadcrumb.test.js
@@ -10,6 +10,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'breadcrumb.link')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'breadcrumb.link')
 })

--- a/internal/test/integration/atoms/button.fixture.js
+++ b/internal/test/integration/atoms/button.fixture.js
@@ -1,10 +1,19 @@
 import React from 'react'
 import { Button } from '@auth0/cosmos'
 
+const mockFn = jest.fn()
+
 class Fixture extends React.Component {
   render() {
-    return <Button id="custom-id">Button</Button>
+    return (
+      <Button id="custom-id" onClick={event => mockFn(event)}>
+        Button
+      </Button>
+    )
   }
 }
+
+/* Convention: Attach mock function to fixture */
+Fixture.mockFn = mockFn
 
 export default Fixture

--- a/internal/test/integration/atoms/button.fixture.js
+++ b/internal/test/integration/atoms/button.fixture.js
@@ -6,7 +6,7 @@ import { mockFn } from '../helpers/event-handler'
 class Fixture extends React.Component {
   render() {
     return (
-      <Button id="custom-id" onClick={event => mockFn(event)}>
+      <Button id="custom-id" onClick={mockFn}>
         Button
       </Button>
     )

--- a/internal/test/integration/atoms/button.fixture.js
+++ b/internal/test/integration/atoms/button.fixture.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button } from '@auth0/cosmos'
 
-const mockFn = jest.fn()
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
@@ -12,8 +12,5 @@ class Fixture extends React.Component {
     )
   }
 }
-
-/* Convention: Attach mock function to fixture */
-Fixture.mockFn = mockFn
 
 export default Fixture

--- a/internal/test/integration/atoms/button.test.js
+++ b/internal/test/integration/atoms/button.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'button')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'button')
 })

--- a/internal/test/integration/atoms/button.test.js
+++ b/internal/test/integration/atoms/button.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './button.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'button')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'button')
 })

--- a/internal/test/integration/atoms/checkbox.fixture.js
+++ b/internal/test/integration/atoms/checkbox.fixture.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Checkbox } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
     return (
-      <Checkbox name="example" value="one" id="custom-id">
+      <Checkbox name="example" value="one" id="custom-id" onClick={mockFn}>
         You can check me
       </Checkbox>
     )

--- a/internal/test/integration/atoms/checkbox.test.js
+++ b/internal/test/integration/atoms/checkbox.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'checkbox')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'checkbox')
 })

--- a/internal/test/integration/atoms/checkbox.test.js
+++ b/internal/test/integration/atoms/checkbox.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './checkbox.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'checkbox')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'checkbox')
 })

--- a/internal/test/integration/atoms/code.fixture.js
+++ b/internal/test/integration/atoms/code.fixture.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import { Code } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <Code id="custom-id">let me = 'be'</Code>
+    return (
+      <Code id="custom-id" onClick={mockFn}>
+        let me = 'be'
+      </Code>
+    )
   }
 }
 

--- a/internal/test/integration/atoms/code.test.js
+++ b/internal/test/integration/atoms/code.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'code')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'code')
 })

--- a/internal/test/integration/atoms/code.test.js
+++ b/internal/test/integration/atoms/code.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './code.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'code')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'code')
 })

--- a/internal/test/integration/atoms/heading.fixture.js
+++ b/internal/test/integration/atoms/heading.fixture.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Heading } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
     return (
-      <Heading size={1} id="custom-id">
+      <Heading size={1} id="custom-id" onClick={mockFn}>
         Big whoop
       </Heading>
     )

--- a/internal/test/integration/atoms/heading.test.js
+++ b/internal/test/integration/atoms/heading.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './heading.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'heading')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'heading')
 })

--- a/internal/test/integration/atoms/heading.test.js
+++ b/internal/test/integration/atoms/heading.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'heading')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'heading')
 })

--- a/internal/test/integration/atoms/icon.fixture.js
+++ b/internal/test/integration/atoms/icon.fixture.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Icon } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <Icon name="delete" id="custom-id" />
+    return <Icon name="delete" id="custom-id" onClick={mockFn} />
   }
 }
 

--- a/internal/test/integration/atoms/icon.test.js
+++ b/internal/test/integration/atoms/icon.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './icon.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'icon')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'icon')
 })

--- a/internal/test/integration/atoms/icon.test.js
+++ b/internal/test/integration/atoms/icon.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'icon')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'icon')
 })

--- a/internal/test/integration/atoms/image.fixture.js
+++ b/internal/test/integration/atoms/image.fixture.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Image } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
@@ -7,6 +8,7 @@ class Fixture extends React.Component {
       <Image
         source="https://images.unsplash.com/photo-1493666438817-866a91353ca9?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&h=200&fit=crop&crop=faces&s=a72ca28288878f8404a795f39642a46f"
         id="custom-id"
+        onClick={mockFn}
       />
     )
   }

--- a/internal/test/integration/atoms/image.test.js
+++ b/internal/test/integration/atoms/image.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './image.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'image')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'image')
 })

--- a/internal/test/integration/atoms/image.test.js
+++ b/internal/test/integration/atoms/image.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'image')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'image')
 })

--- a/internal/test/integration/atoms/label.fixture.js
+++ b/internal/test/integration/atoms/label.fixture.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import { Label } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <Label id="custom-id">Label Text</Label>
+    return (
+      <Label id="custom-id" onClick={mockFn}>
+        Label Text
+      </Label>
+    )
   }
 }
 

--- a/internal/test/integration/atoms/label.test.js
+++ b/internal/test/integration/atoms/label.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'label')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'label')
 })

--- a/internal/test/integration/atoms/label.test.js
+++ b/internal/test/integration/atoms/label.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './label.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'label')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'label')
 })

--- a/internal/test/integration/atoms/link.fixture.js
+++ b/internal/test/integration/atoms/link.fixture.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Link } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
     return (
-      <Link id="custom-id" href="https://auth0.com">
+      <Link id="custom-id" href="https://auth0.com" onClick={mockFn}>
         Click me!
       </Link>
     )

--- a/internal/test/integration/atoms/link.test.js
+++ b/internal/test/integration/atoms/link.test.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import { render } from 'react-testing-library'
+import eventHandlerTest from '../helpers/event-handler'
 
 import Fixture from './link.fixture'
 import customIdTest from '../helpers/custom-id'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'link')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'link')
 })

--- a/internal/test/integration/atoms/link.test.js
+++ b/internal/test/integration/atoms/link.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'link')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'link')
 })

--- a/internal/test/integration/atoms/logo.fixture.js
+++ b/internal/test/integration/atoms/logo.fixture.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Logo } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <Logo id="custom-id" />
+    return <Logo id="custom-id" onClick={mockFn} />
   }
 }
 

--- a/internal/test/integration/atoms/logo.test.js
+++ b/internal/test/integration/atoms/logo.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './logo.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'logo')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'logo')
 })

--- a/internal/test/integration/atoms/logo.test.js
+++ b/internal/test/integration/atoms/logo.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'logo')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'logo')
 })

--- a/internal/test/integration/atoms/paragraph.fixture.js
+++ b/internal/test/integration/atoms/paragraph.fixture.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import { Paragraph } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <Paragraph id="custom-id">Long text here</Paragraph>
+    return (
+      <Paragraph id="custom-id" onClick={mockFn}>
+        Long text here
+      </Paragraph>
+    )
   }
 }
 

--- a/internal/test/integration/atoms/paragraph.test.js
+++ b/internal/test/integration/atoms/paragraph.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './paragraph.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'paragraph')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'paragraph')
 })

--- a/internal/test/integration/atoms/paragraph.test.js
+++ b/internal/test/integration/atoms/paragraph.test.js
@@ -9,6 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'paragraph')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'paragraph')
 })

--- a/internal/test/integration/atoms/radio.fixture.js
+++ b/internal/test/integration/atoms/radio.fixture.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Radio } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   constructor(props) {
@@ -16,6 +17,7 @@ class Fixture extends React.Component {
         selected={this.state.selected}
         onChange={evt => this.handleChange(evt)}
         id="custom-id"
+        onClick={mockFn}
       >
         <Radio.Option value="one" id="custom-id">
           Option 1

--- a/internal/test/integration/atoms/radio.test.js
+++ b/internal/test/integration/atoms/radio.test.js
@@ -10,6 +10,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'radio.option')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'radio')
 })

--- a/internal/test/integration/atoms/radio.test.js
+++ b/internal/test/integration/atoms/radio.test.js
@@ -3,8 +3,13 @@ import { render } from 'react-testing-library'
 
 import Fixture from './radio.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'radio')
   customIdTest(Fixture, 'radio.option')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'radio')
 })

--- a/internal/test/integration/atoms/select.fixture.js
+++ b/internal/test/integration/atoms/select.fixture.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { Select } from '@auth0/cosmos'
 import { mockFn } from '../helpers/event-handler'
 
+const onChange = jest.fn()
+
 class Fixture extends React.Component {
   render() {
     return (
@@ -13,11 +15,13 @@ class Fixture extends React.Component {
           { text: 'Two', value: 2 },
           { text: 'Three', value: 3 }
         ]}
-        onChange={event => console.log(event)}
+        onChange={onChange}
         onClick={mockFn}
       />
     )
   }
 }
+
+Fixture.onChange = onChange
 
 export default Fixture

--- a/internal/test/integration/atoms/select.fixture.js
+++ b/internal/test/integration/atoms/select.fixture.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Select } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
@@ -13,6 +14,7 @@ class Fixture extends React.Component {
           { text: 'Three', value: 3 }
         ]}
         onChange={event => console.log(event)}
+        onClick={mockFn}
       />
     )
   }

--- a/internal/test/integration/atoms/select.test.js
+++ b/internal/test/integration/atoms/select.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './select.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'select')
+})
+
+test('Calls event handler', () => {
+  eventHandlerTest(Fixture, 'select')
 })

--- a/internal/test/integration/atoms/select.test.js
+++ b/internal/test/integration/atoms/select.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render, fireEvent } from 'react-testing-library'
 
 import Fixture from './select.fixture'
 import customIdTest from '../helpers/custom-id'
@@ -9,6 +9,16 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'select')
 })
 
-test('Calls event handler', () => {
+test('Calls custom event handler', () => {
   eventHandlerTest(Fixture, 'select')
+})
+
+test('Calls onChange', () => {
+  const body = render(<Fixture />)
+
+  const select = body.getByTestId('select')
+
+  fireEvent.change(select, { value: 2 })
+
+  expect(Fixture.onChange).toHaveBeenCalledTimes(1)
 })

--- a/internal/test/integration/atoms/spinner.fixture.js
+++ b/internal/test/integration/atoms/spinner.fixture.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Spinner } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <Spinner id="custom-id" />
+    return <Spinner id="custom-id" onClick={mockFn} />
   }
 }
 

--- a/internal/test/integration/atoms/spinner.test.js
+++ b/internal/test/integration/atoms/spinner.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './spinner.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'spinner')
+})
+
+test('Calls custom event handler', () => {
+  eventHandlerTest(Fixture, 'spinner')
 })

--- a/internal/test/integration/atoms/switch.fixture.js
+++ b/internal/test/integration/atoms/switch.fixture.js
@@ -1,10 +1,15 @@
 import React from 'react'
 import { Switch } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
+
+const onToggle = jest.fn()
 
 class Fixture extends React.Component {
   render() {
-    return <Switch id="custom-id" onToggle={value => console.log(value)} />
+    return <Switch id="custom-id" onToggle={onToggle} />
   }
 }
+
+Fixture.onToggle = onToggle
 
 export default Fixture

--- a/internal/test/integration/atoms/switch.fixture.js
+++ b/internal/test/integration/atoms/switch.fixture.js
@@ -6,7 +6,7 @@ const onToggle = jest.fn()
 
 class Fixture extends React.Component {
   render() {
-    return <Switch id="custom-id" onToggle={onToggle} />
+    return <Switch id="custom-id" onToggle={onToggle} onClick={mockFn} />
   }
 }
 

--- a/internal/test/integration/atoms/switch.fixture.js
+++ b/internal/test/integration/atoms/switch.fixture.js
@@ -1,15 +1,14 @@
 import React from 'react'
 import { Switch } from '@auth0/cosmos'
-import { mockFn } from '../helpers/event-handler'
 
-const onToggle = jest.fn()
+const customToggle = jest.fn()
 
 class Fixture extends React.Component {
   render() {
-    return <Switch id="custom-id" onToggle={onToggle} onClick={mockFn} />
+    return <Switch id="custom-id" onToggle={customToggle} />
   }
 }
 
-Fixture.onToggle = onToggle
+Fixture.customToggle = customToggle
 
 export default Fixture

--- a/internal/test/integration/atoms/switch.test.js
+++ b/internal/test/integration/atoms/switch.test.js
@@ -9,13 +9,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'switch')
 })
 
-/*
-There's a bug here. onClick overwrites the onClick on Switch.Element
-*/
-test('Calls custom event handler', () => {
-  eventHandlerTest(Fixture, 'switch')
-})
-
 test('Calls onToggle', () => {
   const body = render(<Fixture />)
 

--- a/internal/test/integration/atoms/switch.test.js
+++ b/internal/test/integration/atoms/switch.test.js
@@ -1,9 +1,27 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render, fireEvent } from 'react-testing-library'
 
 import Fixture from './switch.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'switch')
+})
+
+/*
+There's a bug here. onClick overwrites the onClick on Switch.Element
+*/
+test('Calls custom event handler', () => {
+  eventHandlerTest(Fixture, 'switch')
+})
+
+test('Calls onToggle', () => {
+  const body = render(<Fixture />)
+
+  const element = body.getByTestId('switch')
+
+  fireEvent.click(element)
+
+  expect(Fixture.customToggle).toHaveBeenCalledTimes(1)
 })

--- a/internal/test/integration/atoms/tag.fixture.js
+++ b/internal/test/integration/atoms/tag.fixture.js
@@ -1,18 +1,22 @@
 import React from 'react'
 import { Tag } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
+
+const onRemove = jest.fn()
 
 class Fixture extends React.Component {
   render() {
     return (
-      <Tag.Group id="custom-id">
-        <Tag id="custom-id" onRemove={evt => alert('First tag was removed!')}>
+      <Tag.Group id="custom-id" onClick={mockFn}>
+        <Tag id="custom-id" onRemove={onRemove}>
           First
         </Tag>
-        <Tag onRemove={evt => alert('Second tag was removed!')}>Second</Tag>{' '}
-        <Tag onRemove={evt => alert('Third tag was removed!')}>Third</Tag>
+        <Tag>Second</Tag> <Tag>Third</Tag>
       </Tag.Group>
     )
   }
 }
+
+Fixture.onRemove = onRemove
 
 export default Fixture

--- a/internal/test/integration/atoms/tag.test.js
+++ b/internal/test/integration/atoms/tag.test.js
@@ -1,10 +1,24 @@
 import React from 'react'
-import { render } from 'react-testing-library'
+import { render, fireEvent } from 'react-testing-library'
 
 import Fixture from './tag.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'tag')
   customIdTest(Fixture, 'tag.group')
+})
+
+test('Calls custom event handler', () => {
+  eventHandlerTest(Fixture, 'tag')
+})
+
+test('Calls onRemove', () => {
+  const body = render(<Fixture />)
+
+  const removeElement = body.getByTestId('tag.remove')
+  fireEvent.click(removeElement)
+
+  expect(Fixture.onRemove).toHaveBeenCalledTimes(1)
 })

--- a/internal/test/integration/atoms/text-input.fixture.js
+++ b/internal/test/integration/atoms/text-input.fixture.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { TextInput } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <TextInput id="custom-id" placeholder="Placeholder text" type="text" />
+    return <TextInput id="custom-id" placeholder="Placeholder text" type="text" onClick={mockFn} />
   }
 }
 

--- a/internal/test/integration/atoms/text-input.test.js
+++ b/internal/test/integration/atoms/text-input.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './text-input.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'text-input')
+})
+
+test('Calls custom event handler', () => {
+  eventHandlerTest(Fixture, 'text-input')
 })

--- a/internal/test/integration/atoms/text.fixture.js
+++ b/internal/test/integration/atoms/text.fixture.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Text } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
     return (
-      <Text id="custom-id" type="allcaps">
+      <Text id="custom-id" type="allcaps" onClick={mockFn}>
         hey
       </Text>
     )

--- a/internal/test/integration/atoms/text.test.js
+++ b/internal/test/integration/atoms/text.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './text.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'text')
+})
+
+test('Calls custom event handler', () => {
+  eventHandlerTest(Fixture, 'text')
 })

--- a/internal/test/integration/atoms/textarea.fixture.js
+++ b/internal/test/integration/atoms/textarea.fixture.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { TextArea } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <TextArea id="custom-id" placeholder="Placeholder text" />
+    return <TextArea id="custom-id" placeholder="Placeholder text" onClick={mockFn} />
   }
 }
 

--- a/internal/test/integration/atoms/textarea.test.js
+++ b/internal/test/integration/atoms/textarea.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './textarea.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'text-area')
+})
+
+test('Calls custom event handler', () => {
+  eventHandlerTest(Fixture, 'text-area')
 })

--- a/internal/test/integration/atoms/tooltip.fixture.js
+++ b/internal/test/integration/atoms/tooltip.fixture.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Tooltip } from '@auth0/cosmos'
+import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
     return (
-      <Tooltip id="custom-id" content="Here is some text" position="top">
+      <Tooltip id="custom-id" content="Here is some text" position="top" onClick={mockFn}>
         Hover me
       </Tooltip>
     )

--- a/internal/test/integration/atoms/tooltip.test.js
+++ b/internal/test/integration/atoms/tooltip.test.js
@@ -3,7 +3,12 @@ import { render } from 'react-testing-library'
 
 import Fixture from './tooltip.fixture'
 import customIdTest from '../helpers/custom-id'
+import eventHandlerTest from '../helpers/event-handler'
 
 test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'tooltip')
+})
+
+test('Calls custom event handler', () => {
+  eventHandlerTest(Fixture, 'tooltip')
 })

--- a/internal/test/integration/helpers/event-handler.js
+++ b/internal/test/integration/helpers/event-handler.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { render, fireEvent } from 'react-testing-library'
+
+const eventHandlerTest = (Fixture, button) => {
+  const body = render(<Fixture />)
+
+  const clickElement = body.getByTestId(button)
+  fireEvent.click(clickElement)
+
+  expect(Fixture.mockFn).toHaveBeenCalledWith()
+}
+
+export default eventHandlerTest

--- a/internal/test/integration/helpers/event-handler.js
+++ b/internal/test/integration/helpers/event-handler.js
@@ -7,7 +7,7 @@ const eventHandlerTest = (Fixture, button) => {
   const clickElement = body.getByTestId(button)
   fireEvent.click(clickElement)
 
-  expect(Fixture.mockFn).toHaveBeenCalledWith()
+  expect(Fixture.mockFn).toHaveBeenCalledTimes(1)
 }
 
 export default eventHandlerTest

--- a/internal/test/integration/helpers/event-handler.js
+++ b/internal/test/integration/helpers/event-handler.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import { render, fireEvent } from 'react-testing-library'
 
+const mockFn = jest.fn()
+
 const eventHandlerTest = (Fixture, button) => {
   const body = render(<Fixture />)
 
   const clickElement = body.getByTestId(button)
   fireEvent.click(clickElement)
 
-  expect(Fixture.mockFn).toHaveBeenCalledTimes(1)
+  expect(mockFn).toHaveBeenCalledTimes(1)
 }
 
 export default eventHandlerTest
+export { mockFn }

--- a/internal/test/integration/helpers/event-handler.js
+++ b/internal/test/integration/helpers/event-handler.js
@@ -3,10 +3,10 @@ import { render, fireEvent } from 'react-testing-library'
 
 const mockFn = jest.fn()
 
-const eventHandlerTest = (Fixture, button) => {
+const eventHandlerTest = (Fixture, elementToClick) => {
   const body = render(<Fixture />)
 
-  const clickElement = body.getByTestId(button)
+  const clickElement = body.getByTestId(elementToClick)
   fireEvent.click(clickElement)
 
   expect(mockFn).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
In the theme of https://github.com/auth0/cosmos/issues/1270

Alternative implementation of https://github.com/auth0/cosmos/pull/1311 with react-testing-library. Explained why this is better here: https://github.com/auth0/cosmos/pull/1311#issuecomment-452250751

Found bugs in `Switch`, `Checkbox`
