### PR TITLE
Fix Radio onChange callback firing twice

### DIFF
--- a/core/components/atoms/radio/radio.js
+++ b/core/components/atoms/radio/radio.js
@@ -14,20 +14,19 @@ const justifyContent = {
 
 const Radio = props => (
   <Radio.Element {...props} {...Automation('radio')}>
-    {React.Children.map(props.children, child => {
-      return React.cloneElement(child, {
+    {React.Children.map(props.children, child =>
+      React.cloneElement(child, {
         name: props.name,
         checked: props.selected === child.props.value,
-        readOnly: props.readOnly || child.props.readOnly,
-        onChange: props.onChange
+        readOnly: props.readOnly || child.props.readOnly
       })
-    })}
+    )}
   </Radio.Element>
 )
 
 Radio.Option = ({ readOnly, children, ...props }) => (
   <Radio.Option.Element readOnly={props.readOnly}>
-    <input {...Automation('radio.option')} pepe="test" type="radio" readOnly {...props} />
+    <input {...Automation('radio.option')} type="radio" readOnly {...props} />
     <CheckMark />
     <Label>{children}</Label>
   </Radio.Option.Element>


### PR DESCRIPTION
Resolves #1379 

--

We didn't need to pass the `onChange` function to every radio option.