### PR TITLE
use insertBefore instead of prepend

### DIFF
--- a/core/components/_helpers/globals.js
+++ b/core/components/_helpers/globals.js
@@ -19,7 +19,7 @@ const insertAtTheStart = styles => {
 
     // Register the resets before anything else
     const head = document.getElementsByTagName('head')[0]
-    head.prepend(tag)
+    head.insertBefore(tag, head.firstChild)
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/1402

Browser compatibility for:

- [x] [insertBefore](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore#Browser_compatibility)
- [x] [firstChild](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild#Browser_compatibility)

Tested for IE11, Edge 18, Firefox latest, Chrome latest, Safari latest on browserstack

## Related PR: https://github.com/auth0/cosmos-fonts/pull/3