### PR TITLE
Add replacement to deprecation warning

### DIFF
--- a/core/components/atoms/button/button.js
+++ b/core/components/atoms/button/button.js
@@ -311,7 +311,7 @@ Button.propTypes = {
   success: PropTypes.bool,
 
   /** Type of button */
-  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  type: PropTypes.oneOf(['submit', 'button', 'reset']),
 
   /** Handler to be called when the button is clicked */
   onClick: PropTypes.func

--- a/core/components/molecules/resource-list/item/item.js
+++ b/core/components/molecules/resource-list/item/item.js
@@ -10,6 +10,7 @@ import { colors, spacing } from '@auth0/cosmos-tokens'
 import Automation from '../../../_helpers/automation-attribute'
 import { actionToButtonProps, buttonBuilder } from '../action-builder'
 import widthString from '../../../_helpers/width-string-prop-validator'
+import { deprecate } from '../../../_helpers/custom-validations'
 
 const itemFocusOutline = '2px'
 
@@ -210,10 +211,12 @@ ListItem.propTypes = {
     if (!React.isValidElement(firstAction)) {
       // See: https://github.com/auth0/cosmos/issues/1133
       // See: https://github.com/auth0/cosmos/issues/1222
-      console.warn(
-        'Passing objects in actions is deprecated and will be removed in Cosmos 1.0.' +
-          ' See https://github.com/auth0/cosmos/pull/1133 for more information.'
-      )
+      return deprecate(props, {
+        name: 'actions',
+        oldAPI: 'Objects in actions',
+        replacement:
+          '<Button /> in actions. See https://github.com/auth0/cosmos/pull/1133 for an example.'
+      })
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/auth0/cosmos/issues/1388

There was just one place where we didn't have a replacement: `ResourceList.Item`

Found a rogue file that isn't imported anywhere: https://github.com/auth0/cosmos/blob/master/core/components/_helpers/icon-prop.js, @francocorreasosa can we delete this?

Unrelated change: Changed the first item in `Button` prop `type` to `submit` so that it shows up first (that's the html default)
