### PR TITLE
Fix SSR (#971)

### DIFF
--- a/core/components/_helpers/dom.js
+++ b/core/components/_helpers/dom.js
@@ -1,0 +1,18 @@
+const insertAtHeadStart = styles => {
+  let tag = document.getElementById('cosmos-globals')
+
+  if (tag) {
+    tag.innerHTML = styles
+  } else {
+    tag = document.createElement('style')
+    tag.type = 'text/css'
+    tag.id = 'cosmos-globals'
+    tag.innerHTML = styles
+
+    // Register the resets before anything else
+    const head = document.getElementsByTagName('head')[0]
+    head.insertBefore(tag, head.firstChild)
+  }
+}
+
+export { insertAtHeadStart }

--- a/core/components/_helpers/globals.js
+++ b/core/components/_helpers/globals.js
@@ -1,30 +1,7 @@
 import { fonts, misc } from '@auth0/cosmos-tokens'
+import { insertAtHeadStart } from './dom'
 
-let includeGlobals = true
-
-if (process && process.env && process.env.COSMOS_DISABLE_RESETS) {
-  includeGlobals = false
-}
-
-const insertAtTheStart = styles => {
-  let tag = document.getElementById('cosmos-globals')
-
-  if (tag) {
-    tag.innerHTML = styles
-  } else {
-    tag = document.createElement('style')
-    tag.type = 'text/css'
-    tag.id = 'cosmos-globals'
-    tag.innerHTML = styles
-
-    // Register the resets before anything else
-    const head = document.getElementsByTagName('head')[0]
-    head.insertBefore(tag, head.firstChild)
-  }
-}
-
-if (includeGlobals) {
-  insertAtTheStart(`
+const recommendedResets = `
   html, body, div, span, applet, object, iframe,
   h1, h2, h3, h4, h5, h6, p, blockquote, pre,
   a, abbr, acronym, address, big, cite, code,
@@ -89,12 +66,9 @@ if (includeGlobals) {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+`
 
-  
-`)
-} else {
-  /* We still insert some styles to add missing fonts and keep other things sane 😅 */
-  insertAtTheStart(`
+const minimumResets = `
     * {
       box-sizing: border-box;
     }
@@ -113,5 +87,15 @@ if (includeGlobals) {
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
     }
-  `)
-}
+`
+
+const includeGlobals = process && process.env && process.env.COSMOS_DISABLE_RESETS
+
+const resets = includeGlobals
+  ? recommendedResets
+  : /* We still insert some styles to add missing fonts and keep other things sane 😅 */
+    minimumResets
+
+const apply = ({ applyFn = insertAtHeadStart }) => applyFn(resets)
+
+export { resets, apply }

--- a/core/components/components.js
+++ b/core/components/components.js
@@ -7,9 +7,6 @@
 
 /* eslint-disable import/first */
 
-/* resets for font */
-import './_helpers/globals'
-
 /* internal */
 import Box from './atoms/_box'
 import Well from './atoms/_well'

--- a/core/components/index.js
+++ b/core/components/index.js
@@ -1,3 +1,6 @@
+/* resets for font */
+import { resets, apply } from './_helpers/globals'
+
 import {
   Alert,
   AppLayout,
@@ -49,6 +52,10 @@ import {
   StackLayout
 } from './components'
 
+if (process && process.env && process.env.COSMOS_MANUAL_RESETS) {
+  apply()
+}
+
 export {
   Alert,
   AppLayout,
@@ -97,5 +104,6 @@ export {
   GalleryLayout,
   RowLayout,
   PageLayout,
-  StackLayout
+  StackLayout,
+  resets
 }


### PR DESCRIPTION
#### Description
SSR is currently broken because we're making use of `document` to include the style resets that cosmos requires.

To solve that problem my approach was to add a flag to avoid the automatic inclusion of styles in the Document and to export the minimum and recommended resets so they can be applied differently according to the platform.

Example:
```js
// with COSMOS_MANUAL_RESETS=true

import { resets } from '@auth0/cosmos'

insertDifferentlyAtHead(resets);

// or for Next.js

export default () => (
  <div>
    <style jsx global>{resets}</style>
  </div>
)
```

Let me know if you think the approach makes sense! 🙂 
(I know some naming, export/import decisions are debatable, please comment if you disagree with them)

#### Related Issue
#971 

#### Motivation and Context
To have SSR

#### How has this been tested?
⚠️ Not tested yet