### PR TITLE
Allow using empty string as a Select value

### DIFF
--- a/core/components/atoms/select/select.js
+++ b/core/components/atoms/select/select.js
@@ -46,7 +46,7 @@ const Select = ({ options, ...props }) => {
     and functionality of select disabled
   */
 
-  const shouldUsePlaceholder = valueIsUndefined(props.value) && !props.defaultValue
+  const shouldUsePlaceholder = valueIsUndefined(props.value) && valueIsUndefined(props.defaultValue)
   if (shouldUsePlaceholder) props.value = PLACEHOLDER_VALUE
 
   return (

--- a/core/components/atoms/select/select.js
+++ b/core/components/atoms/select/select.js
@@ -11,7 +11,10 @@ const selectOpacity = {
   default: 1,
   disabled: 0.5
 }
+
 const PLACEHOLDER_VALUE = '__select_placeholder'
+
+const valueIsUndefined = value => value === undefined || value === null
 
 const isGroup = option => option.groupName && option.items
 const renderOption = (option, idx) => {
@@ -42,7 +45,9 @@ const Select = ({ options, ...props }) => {
     but they do have disabled. we need the style of readOnly input
     and functionality of select disabled
   */
-  if (!(props.value || props.defaultValue)) props.value = PLACEHOLDER_VALUE
+
+  const shouldUsePlaceholder = valueIsUndefined(props.value) && !props.defaultValue
+  if (shouldUsePlaceholder) props.value = PLACEHOLDER_VALUE
 
   return (
     <Select.Wrapper>

--- a/core/components/atoms/select/select.story.js
+++ b/core/components/atoms/select/select.story.js
@@ -13,6 +13,40 @@ storiesOf('Select', module).add('simple', () => (
   </Example>
 ))
 
+class SelectWithEmptyString extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = { value: 'custom' }
+
+    this.handleValue = this.handleValue.bind(this)
+  }
+
+  handleValue(event) {
+    this.setState({ value: event.target.value })
+  }
+
+  render() {
+    return (
+      <Select
+        options={[
+          { text: 'All apps', value: '' },
+          { text: 'Custom apps', value: 'custom' },
+          { text: 'Private apps', value: 'private' }
+        ]}
+        value={this.state.value}
+        onChange={this.handleValue}
+      />
+    )
+  }
+}
+
+storiesOf('Select', module).add('simple with empty string', () => (
+  <Example title="Select: simple">
+    <SelectWithEmptyString />
+  </Example>
+))
+
 storiesOf('Select', module).add('with placeholder', () => (
   <Example title="Select: with placeholder">
     <Select


### PR DESCRIPTION
Fixes #1444 

This is now possible:
```jsx
class SelectWithEmptyString extends React.Component {
  constructor(props) {
    super(props)

    this.state = { value: 'custom' }

    this.handleValue = this.handleValue.bind(this)
  }

  handleValue(event) {
    this.setState({ value: event.target.value })
  }

  render() {
    return (
      <Select
        options={[
          { text: 'All apps', value: '' },
          { text: 'Custom apps', value: 'custom' },
          { text: 'Private apps', value: 'private' }
        ]}
        value={this.state.value}
        onChange={this.handleValue}
      />
    )
  }
}
```