### PR TITLE
RFC: Standardise size prop

### DIFF
--- a/core/components/atoms/size.story.js
+++ b/core/components/atoms/size.story.js
@@ -1,0 +1,103 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Example, Stack } from '@auth0/cosmos/_helpers/story-helpers'
+
+import {
+  Well,
+  Avatar,
+  Button,
+  Heading,
+  Icon,
+  Logo,
+  Spinner,
+  TextInput,
+  GalleryLayout,
+  AvatarBlock
+} from '@auth0/cosmos'
+
+const componentConfig = [
+  {
+    name: 'Avatar',
+    sizes: ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge'],
+    fixture: size => (
+      <span>
+        <Avatar size={size} />
+        {size}
+      </span>
+    )
+  },
+  {
+    name: 'Button',
+    sizes: ['small', 'compressed', 'default', 'large'],
+    fixture: size => <Button size={size}>Clicky {size}</Button>
+  },
+  {
+    name: 'Heading',
+    sizes: [4, 3, 2, 1],
+    fixture: size => <Heading size={size}>Hello {size}</Heading>
+  },
+  {
+    name: 'Icon',
+    sizes: [5, 20, 50],
+    fixture: size => (
+      <span>
+        <Icon name="delete" size={size} />
+        {size}
+      </span>
+    )
+  },
+  {
+    name: 'Logo',
+    sizes: ['tiny', 'small', 'default'],
+    fixture: size => (
+      <span>
+        <Logo size={size} />
+        {size}
+      </span>
+    )
+  },
+  {
+    name: 'Spinner',
+    sizes: ['small', 'medium', 'large'],
+    fixture: size => (
+      <span>
+        <Spinner size={size} />
+        {size}
+      </span>
+    )
+  },
+  {
+    name: 'TextInput',
+    sizes: ['small', 'compressed', 'default', 'large'],
+    fixture: size => <TextInput size={size} defaultValue={size} />
+  },
+  {
+    name: 'GalleryLayout',
+    sizes: ['small', 'medium', 'large'],
+    fixture: size => (
+      <GalleryLayout size={size}>
+        <Well>{size}</Well>
+        <Well>{size}</Well>
+      </GalleryLayout>
+    )
+  },
+  {
+    name: 'AvatarBlock',
+    sizes: ['compact', 'default', 'large'],
+    fixture: size => <AvatarBlock title={size} size={size} />
+  }
+]
+
+storiesOf('Size', module).add('sizes', () => (
+  <Example>
+    {componentConfig.map(function(config) {
+      return (
+        <Stack style={{ marginBottom: 50 }}>
+          {config.sizes.map(function(size) {
+            if (config.fixture) return config.fixture(size)
+          })}
+        </Stack>
+      )
+    })}
+  </Example>
+))


### PR DESCRIPTION
The `size` prop is used in multiple components, but it behaves differently in each one.

This is bad for the user because they always have to test it out and see if it looks okay. (both devs and designers)

Example 1: You need to remember that a Button is `compressed` but an AvatarBlock is `compact`

Example 2: Putting a `medium` Button next to a `medium` Avatar might not look right.

&nbsp;

Here's the API reference: [cosmos-api/api#size](https://auth0-cosmos-api.now.sh/docs/#/component/api#size)

and here's a story comparing sizes: [cosmos-consistent-size/sandbox](https://auth0-cosmos-consistent-size.now.sh/sandbox/?selectedKind=Size&selectedStory=sizes&full=0&addons=1&stories=1&panelRight=0)

&nbsp;

Nuances: 

1. It's okay if a component offers more granularity / fine-tuning as long as it's compatible with other components (see example 2 above)

2. The goal of this isn't to make names seem wrong - compressed is a valid size even though it doesn't fit on a xsmall to xxlarge scale.

&nbsp;

Components with the size prop: 

```
{
    name: 'Avatar',
    sizes: ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge']
  },
  {
    name: 'Button',
    sizes: ['small', 'compressed', 'default', 'large']
  },
  {
    name: 'Heading',
    sizes: [4, 3, 2, 1]
  },
  {
    name: 'Icon',
    sizes: any px value
  },
  {
    name: 'Logo',
    sizes: ['tiny', 'small', 'default']
  },
  {
    name: 'Spinner',
    sizes: ['small', 'medium', 'large']
  },
  {
    name: 'TextInput',
    sizes: ['small', 'compressed', 'default', 'large']
  },
  {
    name: 'GalleryLayout',
    sizes: ['small', 'medium', 'large']
  },
  {
    name: 'AvatarBlock',
    sizes: ['compact', 'default', 'large']
  }
```

&nbsp;

Suggestions:

1. Remove default as an option - it doesn't convey anything. Put a size name to it and set it as defaultProp

2. In some atoms like Button, compressed can be replaced with small/xsmall

   The same might not make sense in molecules like AvatarBlock. But we should rename to `compact` to `compressed`

3. Restrict Icon options to xsmall - xxlarge scale, that gives plenty of flexibility as well. (bonus: you don't have to think of a compatible px values to a string value of another component)

4. Match the sizes between components (see example 2 above)



** This PR does not have the implementation **