### PR TITLE
Fix sidebar linkgroup item colored when open but no subitems selected

### DIFF
--- a/core/components/molecules/sidebar/sidebar-link-group.js
+++ b/core/components/molecules/sidebar/sidebar-link-group.js
@@ -8,19 +8,15 @@ import Automation from '../../_helpers/automation-attribute'
 class SidebarLinkGroup extends React.Component {
   constructor(props) {
     super(props)
-    let open = false
+    const open = props.defaultOpen || false
+    let subItemSelected = false
 
-    if (props.defaultOpen) {
-      open = true
-    } else {
-      /* If a child is selected... */
-      React.Children.forEach(props.children, child => {
-        /* group should be open and parent be selected */
-        if (child && child.props && child.props.selected) open = true
-      })
-    }
+    React.Children.forEach(props.children, child => {
+      /* group should be open and parent be selected */
+      if (child && child.props && child.props.selected) subItemSelected = true
+    })
 
-    this.state = { open }
+    this.state = { open, subItemSelected }
   }
 
   handleClick = () => {
@@ -29,12 +25,19 @@ class SidebarLinkGroup extends React.Component {
 
   render() {
     const { icon, label, children } = this.props
-    const { open } = this.state
+    const { open, subItemSelected } = this.state
 
     return (
       <SidebarLinkGroup.Element {...Automation('sidebar.group')} {...this.props}>
-        <SidebarLink icon={icon} label={label} onClick={this.handleClick} selected={open} />
-        <SidebarLinkGroup.Content open={open}>{children}</SidebarLinkGroup.Content>
+        <SidebarLink
+          icon={icon}
+          label={label}
+          onClick={this.handleClick}
+          selected={subItemSelected}
+        />
+        <SidebarLinkGroup.Content open={subItemSelected || open}>
+          {children}
+        </SidebarLinkGroup.Content>
       </SidebarLinkGroup.Element>
     )
   }


### PR DESCRIPTION
Do not paint current sidebar linkgroup item link when the linkgroup is open but no subitem is selected.