### PR TITLE
Add as prop to Heading

### DIFF
--- a/core/components/atoms/heading/heading.js
+++ b/core/components/atoms/heading/heading.js
@@ -4,17 +4,10 @@ import styled from '@auth0/cosmos/styled'
 import { colors, fonts } from '@auth0/cosmos-tokens'
 import Automation from '../../_helpers/automation-attribute'
 
-const BaseHeading = styled.h1`
-  margin: 1em 0;
-  color: ${colors.text.default};
-  font-weight: ${fonts.weight.normal};
-  line-height: 1.3;
-`
-
 const Heading = props => {
   const element = props.as || 'h' + props.size
 
-  const Component = Heading.Element[props.size].withComponent(element)
+  const Component = Heading.Element.withComponent(element)
 
   return (
     <Component {...Automation('heading')} {...props}>
@@ -23,7 +16,25 @@ const Heading = props => {
   )
 }
 
-Heading.Element = []
+const styles = {
+  1: { size: '36px', weight: fonts.weight.normal },
+  2: { size: '24px', weight: fonts.weight.medium },
+  3: { size: '18px', weight: fonts.weight.medium },
+  4: { size: '14px', weight: fonts.weight.medium }
+}
+
+Heading.Element = styled.h1`
+  margin: 1em 0;
+  color: ${colors.text.default};
+  font-size: ${props => styles[props.size].size};
+  font-weight: ${props => styles[props.size].weight};
+  line-height: 1.3;
+`
+
+/* Backward compatibility layer */
+
+const BaseHeading = Heading.Element
+const StyledHeading = Heading.Element
 
 Heading.Element[1] = styled(BaseHeading)`
   font-size: 36px;
@@ -43,8 +54,6 @@ Heading.Element[4] = styled(BaseHeading)`
   font-size: 14px;
   font-weight: ${fonts.weight.medium};
 `
-
-const StyledHeading = Heading.Element
 
 Heading.propTypes = {
   /** Size of the heading */

--- a/core/components/atoms/heading/heading.js
+++ b/core/components/atoms/heading/heading.js
@@ -19,7 +19,7 @@ const Heading = props => {
 const styles = {
   1: { size: '36px', weight: fonts.weight.normal },
   2: { size: '24px', weight: fonts.weight.medium },
-  3: { size: '18px', weight: fonts.weight.medium },
+  3: { size: '18px', weight: fonts.weight.bold },
   4: { size: '14px', weight: fonts.weight.medium }
 }
 

--- a/core/components/atoms/heading/heading.js
+++ b/core/components/atoms/heading/heading.js
@@ -50,7 +50,7 @@ Heading.propTypes = {
   /** Size of the heading */
   size: PropTypes.oneOf([1, 2, 3, 4]),
   /** h element to use instead of default one */
-  as: PropTypes.string,
+  as: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
   /** Successful state when action is completed successfuly */
   children: PropTypes.string
 }

--- a/core/components/atoms/heading/heading.js
+++ b/core/components/atoms/heading/heading.js
@@ -12,7 +12,10 @@ const BaseHeading = styled.h1`
 `
 
 const Heading = props => {
-  const Component = Heading.Element[props.size]
+  const element = props.as || 'h' + props.size
+
+  const Component = Heading.Element[props.size].withComponent(element)
+
   return (
     <Component {...Automation('heading')} {...props}>
       {props.children}
@@ -22,21 +25,21 @@ const Heading = props => {
 
 Heading.Element = []
 
-Heading.Element[1] = styled(BaseHeading.withComponent('h1'))`
+Heading.Element[1] = styled(BaseHeading)`
   font-size: 36px;
 `
 
-Heading.Element[2] = styled(BaseHeading.withComponent('h2'))`
+Heading.Element[2] = styled(BaseHeading)`
   font-size: 24px;
   font-weight: ${fonts.weight.medium};
 `
 
-Heading.Element[3] = styled(BaseHeading.withComponent('h3'))`
+Heading.Element[3] = styled(BaseHeading)`
   font-size: 18px; /* TO-DO: tokenize */
   font-weight: ${fonts.weight.bold};
 `
 
-Heading.Element[4] = styled(BaseHeading.withComponent('h4'))`
+Heading.Element[4] = styled(BaseHeading)`
   font-size: 14px;
   font-weight: ${fonts.weight.medium};
 `
@@ -44,7 +47,11 @@ Heading.Element[4] = styled(BaseHeading.withComponent('h4'))`
 const StyledHeading = Heading.Element
 
 Heading.propTypes = {
+  /** Size of the heading */
   size: PropTypes.oneOf([1, 2, 3, 4]),
+  /** h element to use instead of default one */
+  as: PropTypes.string,
+  /** Successful state when action is completed successfuly */
   children: PropTypes.string
 }
 

--- a/core/components/atoms/heading/heading.md
+++ b/core/components/atoms/heading/heading.md
@@ -8,7 +8,7 @@
 <Heading {props}>Heading</Heading>
 ```
 
-## Examples
+## Sizes
 
 ```js
 <div>
@@ -16,5 +16,23 @@
   <Heading size={2}>Heading 2</Heading>
   <Heading size={3}>Heading 3</Heading>
   <Heading size={4}>Heading 4</Heading>
+</div>
+```
+
+## Accessibility
+
+The Heading, by default, takes the corresponding `h` element for `size`. Make sure to adjust the heading level according to what makes sense on your document tree.
+
+```js
+<div>
+  <Heading size={1} as="h2">
+    Heading 1
+  </Heading>
+  <Heading size={2} as="h2">
+    Heading 1
+  </Heading>
+  <Heading size={3} as="h2">
+    Heading 1
+  </Heading>
 </div>
 ```

--- a/core/components/atoms/heading/heading.story.js
+++ b/core/components/atoms/heading/heading.story.js
@@ -12,3 +12,20 @@ storiesOf('Heading', module).add('sizes', () => (
     <Heading size={4}>Good design is good business</Heading>
   </Example>
 ))
+
+storiesOf('Heading', module).add('element', () => (
+  <Example title="Sizes">
+    <Heading size={1} as="h2">
+      Good design is good business
+    </Heading>
+    <Heading size={2} as="h2">
+      Good design is good business
+    </Heading>
+    <Heading size={3} as="h2">
+      Good design is good business
+    </Heading>
+    <Heading size={4} as="h2">
+      Good design is good business
+    </Heading>
+  </Example>
+))

--- a/core/components/molecules/danger-zone/danger-zone.js
+++ b/core/components/molecules/danger-zone/danger-zone.js
@@ -44,7 +44,7 @@ const ItemsContainer = styled.ul`
   }
 `
 
-const Title = styled(Heading)`
+const Title = styled(Heading.Element)`
   font-size: 1.0714285714em;
   color: ${colors.text.error};
   margin: 0;

--- a/core/components/molecules/dialog/dialog.js
+++ b/core/components/molecules/dialog/dialog.js
@@ -179,7 +179,14 @@ const DialogHeader = styled.header`
 `
 
 const DialogTitle = props => {
-  return <Heading margin={{ top: 0 }} size={4} as={props.element} {...props} />
+  return (
+    <Heading
+      margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+      size={4}
+      as={props.element}
+      {...props}
+    />
+  )
 }
 
 const DialogBody = styled.div`

--- a/core/components/molecules/dialog/dialog.js
+++ b/core/components/molecules/dialog/dialog.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import styled from '@auth0/cosmos/styled'
 import Button from '../../atoms/button'
-import { BaseHeading } from '../../atoms/heading'
+import Heading from '../../atoms/heading'
 import ButtonGroup from '../../molecules/button-group'
 import Tabs from '../../molecules/tabs'
 import Overlay, { overlayContentSizes } from '../../atoms/_overlay'
@@ -179,13 +179,7 @@ const DialogHeader = styled.header`
 `
 
 const DialogTitle = props => {
-  const InternalTitle = styled(BaseHeading.withComponent(props.element))`
-    font-weight: ${fonts.weight.medium};
-    font-size: ${fonts.size.default};
-    margin: 0;
-  `
-
-  return <InternalTitle {...props} />
+  return <Heading margin={{ top: 0 }} size={4} as={props.element} {...props} />
 }
 
 const DialogBody = styled.div`

--- a/core/components/molecules/empty-state/empty-state.js
+++ b/core/components/molecules/empty-state/empty-state.js
@@ -34,7 +34,7 @@ const EmptyState = ({ link, helpUrl, title, icon, action, ...props }) => {
 
   return (
     <EmptyState.Element {...Automation('empty-state')} {...props}>
-      <Title size={1}>{title}</Title>
+      <Title>{title}</Title>
       <EmptyState.Body>
         <Icon name={icon} size={110} color="blue" />
         <FreeText {...props} useParagraph />
@@ -62,9 +62,9 @@ EmptyState.Body = styled.div`
     opacity: 0.2;
   }
 `
-const Title = styled(Heading)`
-  margin: 0 0 ${spacing.xlarge} 0;
-`
+const Title = props => (
+  <Heading size={1} margin={{ top: 0, bottom: spacing.xlarge, left: 0, right: 0 }} {...props} />
+)
 
 const LearnMore = styled.div`
   display: inline-block;

--- a/core/components/molecules/list/list.js
+++ b/core/components/molecules/list/list.js
@@ -5,7 +5,7 @@ import Automation from '../../_helpers/automation-attribute'
 import containerStyles from '../../_helpers/container-styles'
 
 import { colors, spacing } from '@auth0/cosmos-tokens'
-import Heading, { StyledHeading } from '../../atoms/heading'
+import Heading from '../../atoms/heading'
 
 const List = props => {
   return (
@@ -31,7 +31,7 @@ List.Element = styled.ul`
 List.Label = styled.div`
   padding: ${spacing.xsmall};
 
-  ${StyledHeading[4]} {
+  ${Heading.Element} {
     margin: 0;
   }
 `

--- a/core/components/molecules/page-header/page-header.js
+++ b/core/components/molecules/page-header/page-header.js
@@ -54,7 +54,7 @@ PageHeader.Element = styled.div`
     }
   }
 
-  ${Heading.Element[1]} {
+  ${Heading.Element} {
     flex: 1;
     /*
     Components should not have margin by default.

--- a/internal/test/unit/__snapshots__/form-field.test.js.snap
+++ b/internal/test/unit/__snapshots__/form-field.test.js.snap
@@ -21,20 +21,20 @@ exports[`Form Field - old API renders the correct id 1`] = `
           layout="label-on-left"
         >
           <div
-            className="sc-eXEjpC gGdoaR"
+            className="sc-kPVwWT cyvKbU"
             data-cosmos-key="form.field"
           >
             <styled.div
               layout="label-on-left"
             >
               <div
-                className="sc-ibxdXY fQjZUt"
+                className="sc-kfGgVZ iZYuV"
               >
                 <styled.label
                   htmlFor="old_api-2"
                 >
                   <label
-                    className="sc-kfGgVZ gqJFqL"
+                    className="sc-gzOgki dqtKWn"
                     htmlFor="old_api-2"
                   >
                     Old API
@@ -46,7 +46,7 @@ exports[`Form Field - old API renders the correct id 1`] = `
               layout="label-on-left"
             >
               <div
-                className="sc-RefOD SmRKX"
+                className="sc-esjQYD diEjew"
               >
                 <Component
                   type="text"
@@ -63,20 +63,20 @@ exports[`Form Field - old API renders the correct id 1`] = `
                       layout="label-on-left"
                     >
                       <div
-                        className="sc-eXEjpC gGdoaR"
+                        className="sc-kPVwWT cyvKbU"
                         data-cosmos-key="form.field"
                       >
                         <styled.div
                           layout="label-on-left"
                         >
                           <div
-                            className="sc-ibxdXY fQjZUt"
+                            className="sc-kfGgVZ iZYuV"
                           >
                             <styled.label
                               htmlFor="-3"
                             >
                               <label
-                                className="sc-kfGgVZ gqJFqL"
+                                className="sc-gzOgki dqtKWn"
                                 htmlFor="-3"
                               />
                             </styled.label>
@@ -86,7 +86,7 @@ exports[`Form Field - old API renders the correct id 1`] = `
                           layout="label-on-left"
                         >
                           <div
-                            className="sc-RefOD SmRKX"
+                            className="sc-esjQYD diEjew"
                           >
                             <TextInput
                               actions={Array []}
@@ -119,7 +119,7 @@ exports[`Form Field - old API renders the correct id 1`] = `
                               >
                                 <styled.input
                                   actions={Array []}
-                                  className="sc-ksYbfQ fBGgFN"
+                                  className="sc-cHGsZl dkiCHB"
                                   code={false}
                                   data-cosmos-key="text-input"
                                   error={null}
@@ -134,7 +134,7 @@ exports[`Form Field - old API renders the correct id 1`] = `
                                   type="text"
                                 >
                                   <input
-                                    className="sc-ksYbfQ fBGgFN sc-Rmtcm eIYyWG"
+                                    className="sc-cHGsZl dkiCHB sc-iRbamj ljozcR"
                                     data-cosmos-key="text-input"
                                     id="-3"
                                     label=""
@@ -183,20 +183,20 @@ exports[`Form Field renders the correct id 1`] = `
           layout="label-on-left"
         >
           <div
-            className="sc-eXEjpC gGdoaR"
+            className="sc-kPVwWT cyvKbU"
             data-cosmos-key="form.field"
           >
             <styled.div
               layout="label-on-left"
             >
               <div
-                className="sc-ibxdXY fQjZUt"
+                className="sc-kfGgVZ iZYuV"
               >
                 <styled.label
                   htmlFor="field_label-1"
                 >
                   <label
-                    className="sc-kfGgVZ gqJFqL"
+                    className="sc-gzOgki dqtKWn"
                     htmlFor="field_label-1"
                   >
                     Field label
@@ -208,7 +208,7 @@ exports[`Form Field renders the correct id 1`] = `
               layout="label-on-left"
             >
               <div
-                className="sc-RefOD SmRKX"
+                className="sc-esjQYD diEjew"
               >
                 <TextInput
                   actions={Array []}
@@ -231,7 +231,7 @@ exports[`Form Field renders the correct id 1`] = `
                   >
                     <styled.input
                       actions={Array []}
-                      className="sc-ksYbfQ fBGgFN"
+                      className="sc-cHGsZl dkiCHB"
                       code={false}
                       data-cosmos-key="text-input"
                       error={null}
@@ -241,7 +241,7 @@ exports[`Form Field renders the correct id 1`] = `
                       type="text"
                     >
                       <input
-                        className="sc-ksYbfQ fBGgFN sc-Rmtcm eIYyWG"
+                        className="sc-cHGsZl dkiCHB sc-iRbamj ljozcR"
                         data-cosmos-key="text-input"
                         onChange={null}
                         readOnly={false}


### PR DESCRIPTION
The element used for a heading does not always match the size you want it to be.

Adding `as` prop to customise it based on the document tree. Defaults to the corresponding size.

Example:

```jsx
<Heading size={1}>Hello</Heading>

// renders
<h1 class="h1-styles">Hello</h1>

// can be changed:

<Heading size={1} as="h2">Hello</Heading>

// renders
<h2 class="h1-size">Hello</h2>
```

### Includes major refactor to make this possible. Have updated all the components that use `Heading`. Kept old API for backward compatibility.

