### PR TITLE
Switch: change onToggle to onChange

### DIFF
--- a/core/components/atoms/switch/switch.js
+++ b/core/components/atoms/switch/switch.js
@@ -2,6 +2,7 @@ import React from 'react'
 import styled, { css } from '@auth0/cosmos/styled'
 import PropTypes from 'prop-types'
 import Automation from '../../_helpers/automation-attribute'
+import { deprecate } from '../../_helpers/custom-validations'
 
 import { colors, fonts, spacing, misc } from '@auth0/cosmos-tokens'
 
@@ -17,7 +18,9 @@ class Switch extends React.Component {
 
     if (this.props.readOnly) return
     this.setState(currentState => {
-      if (this.props.onToggle) this.props.onToggle(!currentState.on)
+      if (this.props.onChange) this.props.onChange(!currentState.on)
+      else if (this.props.onToggle) this.props.onToggle(!currentState.on)
+
       return { on: !currentState.on }
     })
   }
@@ -146,7 +149,7 @@ const Label = styled.label`
     margin-left: ${props => (props.labelPosition == 'left' ? '0' : spacing.small)};
     margin-right: ${props => (props.labelPosition == 'left' ? spacing.small : '0')};
 
-    /* 
+    /*
     In order to make the switch always the same width
     we are setting a fixed height and overlapping the switch labels
     */
@@ -171,8 +174,10 @@ const Label = styled.label`
 const StyledSwitch = Switch.Element
 
 Switch.propTypes = {
-  /** Function called on toggle */
+  /** @deprecatede:onChange Function called on toggle */
   onToggle: PropTypes.func,
+  /** Function called when value changes */
+  onChange: PropTypes.func,
   /** State of the toggle */
   on: PropTypes.bool,
   /** Labels to show, import for accessibility */
@@ -182,11 +187,15 @@ Switch.propTypes = {
   /** Locked switch */
   readOnly: PropTypes.bool,
   /** Label on left side */
-  labelPosition: PropTypes.oneOf(['right', 'left'])
+  labelPosition: PropTypes.oneOf(['right', 'left']),
+
+  /** deprecations */
+  _onToggle: props => deprecate(props, { name: 'onToggle', replacement: 'onChange' })
 }
 
 Switch.defaultProps = {
   onToggle: null,
+  onChange: null,
   on: false,
   accessibleLabels: ['Enabled', 'Disabled'],
   hideAccessibleLabels: false,

--- a/core/components/atoms/switch/switch.md
+++ b/core/components/atoms/switch/switch.md
@@ -5,17 +5,17 @@
 `import { Switch } from '@auth0/cosmos'`
 
 ```jsx
-<Switch {props} onToggle={value => console.log(value)} />
+<Switch {props} onChange={value => console.log(value)} />
 ```
 
 ## Examples
 
 ### Events
 
-`onToggle` should always be provided for handling changes in the value.
+`onChange` should always be provided for handling changes in the value.
 
 ```js
-<Switch onToggle={value => console.log(value)} />
+<Switch onChange={value => console.log(value)} />
 ```
 
 ### Default state
@@ -23,7 +23,7 @@
 You can change the default state of the switch by passing the `on` prop.
 
 ```js
-<Switch on onToggle={value => console.log(value)} />
+<Switch on onChange={value => console.log(value)} />
 ```
 
 ### Read-only
@@ -43,10 +43,10 @@ You can change the accessibility labels by passing an array with two strings. Th
 
 ```js
 <Stack align="space-between">
-  <Switch accessibleLabels={['ON', 'OFF']} onToggle={value => console.log(value)} />
+  <Switch accessibleLabels={['ON', 'OFF']} onChange={value => console.log(value)} />
   <Switch
     accessibleLabels={['ON', 'OFF']}
-    onToggle={value => console.log(value)}
+    onChange={value => console.log(value)}
     labelPosition="left"
   />
 </Stack>
@@ -55,5 +55,5 @@ You can change the accessibility labels by passing an array with two strings. Th
 You can hide the accessibility labels and display just the switch passing the `hideAccessibleLabels` prop.
 
 ```js
-<Switch hideAccessibleLabels onToggle={() => {}} />
+<Switch hideAccessibleLabels onChange={() => {}} />
 ```

--- a/core/components/atoms/switch/switch.story.js
+++ b/core/components/atoms/switch/switch.story.js
@@ -6,19 +6,19 @@ import { Switch } from '@auth0/cosmos'
 
 storiesOf('Switch', module).add('default', () => (
   <Example title="Switch">
-    <Switch onToggle={value => console.log(value)} />
+    <Switch onChange={value => console.log(value)} />
   </Example>
 ))
 
 storiesOf('Switch', module).add('left label', () => (
   <Example title="Switch">
-    <Switch onToggle={value => console.log(value)} labelPosition="left" />
+    <Switch onChange={value => console.log(value)} labelPosition="left" />
   </Example>
 ))
 
 storiesOf('Switch', module).add('on', () => (
   <Example title="Switch">
-    <Switch on onToggle={value => console.log(value)} />
+    <Switch on onChange={value => console.log(value)} />
   </Example>
 ))
 
@@ -31,14 +31,14 @@ storiesOf('Switch', module).add('readonly', () => (
 
 storiesOf('Switch', module).add('accessibility labels', () => (
   <Example title="Switch">
-    <Switch accessibleLabels={[]} onToggle={() => {}} />
-    <Switch accessibleLabels={['ON', 'OFF']} onToggle={() => {}} />
-    <Switch on accessibleLabels={['ON', 'OFF']} onToggle={() => {}} />
+    <Switch accessibleLabels={[]} onChange={() => {}} />
+    <Switch accessibleLabels={['ON', 'OFF']} onChange={() => {}} />
+    <Switch on accessibleLabels={['ON', 'OFF']} onChange={() => {}} />
   </Example>
 ))
 
 storiesOf('Switch', module).add('hidden accessibility labels', () => (
   <Example title="Switch">
-    <Switch hideAccessibleLabels onToggle={() => {}} />
+    <Switch hideAccessibleLabels onChange={() => {}} />
   </Example>
 ))

--- a/internal/docs/pages/migration-guide.js
+++ b/internal/docs/pages/migration-guide.js
@@ -67,6 +67,22 @@ class MigrationGuide extends React.Component {
         </div>
 
         <div>
+          <Heading3>Switch</Heading3>
+
+          <Link href="#/component/switch">Open docs</Link>
+
+          <CodeBlock language="jsx">
+            {`
+// replace onToggle:function
+<Switch onToggle={value => console.log(value)} />
+
+// with onChange:function
+<Switch onChange={value => console.log(value)} />
+        `}
+          </CodeBlock>
+        </div>
+
+        <div>
           <Heading3>AvatarBlock</Heading3>
 
           <Link href="#/component/avatar-block">Open docs</Link>

--- a/internal/test/integration/atoms/switch.fixture.js
+++ b/internal/test/integration/atoms/switch.fixture.js
@@ -4,7 +4,7 @@ import { mockFn } from '../helpers/event-handler'
 
 class Fixture extends React.Component {
   render() {
-    return <Switch id="custom-id" onToggle={mockFn} />
+    return <Switch id="custom-id" onChange={mockFn} />
   }
 }
 

--- a/internal/test/integration/atoms/switch.test.js
+++ b/internal/test/integration/atoms/switch.test.js
@@ -6,6 +6,6 @@ test('Accepts custom id prop', () => {
   customIdTest(Fixture, 'switch')
 })
 
-test('Calls onToggle', () => {
+test('Calls onChange', () => {
   eventHandlerTest(Fixture, 'switch')
 })


### PR DESCRIPTION
```diff
- <Switch onToggle={value => console.log(value)} />
+ <Switch onChange={value => console.log(value)} />
```

soft deprecation as usual.

[why?](https://sid.studio/post/name-behaviors-not-interactions/)

- [x] Updated switch docs
- [x] Update switch story
- [x] Updated switch test


Have not updated updated other components that use it. Will do that after this PR is merged/approved. (it's backward compatible)
