### PR TITLE
Improves read only checkbox styles

### DIFF
--- a/core/components/atoms/checkbox/checkbox.js
+++ b/core/components/atoms/checkbox/checkbox.js
@@ -69,12 +69,10 @@ Checkbox.Option = styled.label`
     transform: translateY(20%);
     height: 16px;
     width: 16px;
-    background-color: ${props =>
-      props.readOnly ? colors.radio.backgroundDisabled : colors.radio.background};
-    border: 1px solid
-      ${props => (props.readOnly ? colors.radio.borderDisabled : colors.radio.border)};
-    box-shadow: inset 0 1px 2px 0
-      ${props => (props.readOnly ? colors.radio.shadowDisabled : colors.radio.shadow)};
+    opacity: ${props => (props.readOnly ? 0.5 : null)};
+    background-color: ${colors.radio.background};
+    border: 1px solid ${colors.radio.border};
+    box-shadow: inset 0 1px 2px 0 ${colors.radio.shadow};
     border-radius: 2px;
   }
 

--- a/core/components/atoms/checkbox/checkbox.story.js
+++ b/core/components/atoms/checkbox/checkbox.story.js
@@ -6,7 +6,7 @@ import { Checkbox, Paragraph } from '@auth0/cosmos'
 
 const CheckBoxExample = () => (
   <Checkbox.Group name="example1" selected={['one', 'two']}>
-    <Checkbox name="one" value="one">
+    <Checkbox name="one" value="one" readOnly>
       Option 1
     </Checkbox>
     <Checkbox name="two" value="two">


### PR DESCRIPTION
The checkbox doesn't render the colors for `readOnly`. As a simple fix I've just reduced the opacity of the checkmark.

This PR fixes this bug on Manhattan:

> [BUG] Connections: Social connections-> Any provider. Even when a permission such as "Basic Profile" and "Extended Profile" (in the case of google) are required, the checkboxes look blue like if I could click on them, but I can't.