### PR TITLE
Adds a space when there are icons on a textarea

### DIFF
--- a/core/components/atoms/_input-with-actions/input-with-actions.js
+++ b/core/components/atoms/_input-with-actions/input-with-actions.js
@@ -24,7 +24,8 @@ const getPaddingForActions = actions => {
 const StyledWrapper = styled.div`
   position: relative;
 
-  input {
+  input,
+  textarea {
     padding-right: ${props => getPaddingForActions(props.actions)};
   }
 

--- a/core/components/atoms/textarea/text-area.story.js
+++ b/core/components/atoms/textarea/text-area.story.js
@@ -51,3 +51,12 @@ storiesOf('TextArea').add('with actions as buttons', () => (
     />
   </Example>
 ))
+
+storiesOf('TextArea').add('with a copy action', () => (
+  <Example title="with a copy action">
+    <TextArea
+      placeholder="Small text area"
+      actions={[<Button icon="copy" onClick={e => console.log(e)} />]}
+    />
+  </Example>
+))


### PR DESCRIPTION
This PR adds a space on text areas with icons, so the text doesn't run under the icon.