### PR TITLE
Fix field actions prop type to support raw buttons

### DIFF
--- a/core/components/molecules/form/field/field.js
+++ b/core/components/molecules/form/field/field.js
@@ -107,7 +107,7 @@ Field.propTypes = {
   /** Error message to show in case of failed validation */
   error: PropTypes.string,
   /** Actions to be attached to input */
-  actions: PropTypes.arrayOf(actionShapeWithRequiredIcon)
+  actions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.node, actionShapeWithRequiredIcon]))
 }
 
 Field.defaultProps = {


### PR DESCRIPTION
Remove this prop type assertion error when using Components as actions in Form fields. 
![imagen](https://user-images.githubusercontent.com/4152942/53575065-90d76080-3b4f-11e9-91ac-2484a7bc1fe0.png)
