### PR TITLE
Removed unstable tag to alerts

### DIFF
--- a/core/components/atoms/alert/alert.md
+++ b/core/components/atoms/alert/alert.md
@@ -1,7 +1,6 @@
 ```meta
   category: Layout
   description: Show a message intended to draw the user's attention
-  unstable: true
 ```
 
 `import { Alert } from '@auth0/cosmos'`


### PR DESCRIPTION
The Alert is stable, so I'm removing the alert banner so that users know it's safe to use.