### PR TITLE
Fixed accessibility spelling error in layouts and image.md

### DIFF
--- a/core/components/atoms/image/image.md
+++ b/core/components/atoms/image/image.md
@@ -152,7 +152,7 @@ _How do I write good alt text?_
 - Don't use images as text.
 - Don't include "image of," "picture of," etc. in your alt text.
 
-Since writting good alternative text is critical to pass an accecibility audit please make sure to read the articles below on the Resources section.
+Since writting good alternative text is critical to pass an accessibility audit please make sure to read the articles below on the Resources section.
 
 ## Resources
 

--- a/core/components/layouts/column-layout/column-layout.md
+++ b/core/components/layouts/column-layout/column-layout.md
@@ -35,7 +35,7 @@ Use the `ColumnLayout` to organize components horizontally into columns.
 
 Combine the `ColymnLayout` with the `RowLayout` to achieve complex grid arrangments.
 
-## Accecibility
+## Accessibility
 
 This layout is semantic free.
 

--- a/core/components/layouts/row-layout/row-layout.md
+++ b/core/components/layouts/row-layout/row-layout.md
@@ -27,7 +27,7 @@ Use the `Rowlayout` to organize components vertically into row.
 
 Combine the `ColymnLayout` with the `RowLayout` to achieve complex grid arrangments.
 
-## Accecibility
+## Accessibility
 
 This layout is semantic free.
 


### PR DESCRIPTION
In this pull request I fixed a simple spelling error in layouts and image.md for "Accessibility" from "Accecibility".

Please let me know if you have any questions, thanks!