### PR TITLE
Do not enable next page button if there are explicitly zero items.

### DIFF
--- a/core/components/molecules/pager/pager.md
+++ b/core/components/molecules/pager/pager.md
@@ -77,3 +77,9 @@ class PaginatedResource extends React.Component {
   }
 }
 ```
+
+### With explicit zero items
+
+```js
+<Pager page={1} items={0} perPage={50} />
+```

--- a/core/components/molecules/pager/pager.story.tsx
+++ b/core/components/molecules/pager/pager.story.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
+import * as React from 'react'
 
-import { storiesOf } from "@storybook/react";
+import { storiesOf } from '@storybook/react'
 
-import { Pager } from "../../";
-import { Example } from "../../_helpers/story-helpers";
+import { Pager } from '../../'
+import { Example } from '../../_helpers/story-helpers'
 
 storiesOf('Pager', module)
   .add('default', () => (
@@ -19,5 +19,10 @@ storiesOf('Pager', module)
   .add('without info', () => (
     <Example>
       <Pager items={20372} perPage={10} page={3} showInfo={false} />
+    </Example>
+  ))
+  .add('with explicit zero items', () => (
+    <Example>
+      <Pager page={1} items={0} perPage={50} />
     </Example>
   ))

--- a/core/components/molecules/pager/pager.tsx
+++ b/core/components/molecules/pager/pager.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import * as React from 'react'
 
-import Automation from "../../_helpers/automation-attribute";
-import containerStyles from "../../_helpers/container-styles";
-import { changePageIfAppropiate, pagesFromItems, totals } from "../../_helpers/pagination";
-import Button from "../../atoms/button";
-import styled from "../../styled";
+import Automation from '../../_helpers/automation-attribute'
+import containerStyles from '../../_helpers/container-styles'
+import { changePageIfAppropiate, pagesFromItems, totals } from '../../_helpers/pagination'
+import Button from '../../atoms/button'
+import styled from '../../styled'
 
 export interface IPagerProps {
   /** HTML ID of the component */
@@ -19,6 +19,7 @@ export interface IPagerProps {
 const Pager = ({ onPageChanged, page, perPage, items, showInfo, ...props }: IPagerProps) => {
   const inFirstPage = page === 1
   const inLastPage = showInfo && items && perPage ? pagesFromItems(items, perPage) === page : false
+  const nextPageEnabled = (typeof items === 'undefined' || items > 0) && !inLastPage
   const ignoreNextPageCheck = !items
   return (
     <Pager.Element {...Automation('pager')} {...props}>
@@ -46,7 +47,7 @@ const Pager = ({ onPageChanged, page, perPage, items, showInfo, ...props }: IPag
       <Button
         size="compressed"
         appearance="secondary"
-        disabled={inLastPage}
+        disabled={!nextPageEnabled}
         icon="chevron-right"
         iconAlign="right"
         onClick={() =>


### PR DESCRIPTION
> Same as #1603 but with working branch name.

Previously, passing page=1, perPage=50, items=0 would still let the next page button to be enabled, because we were only checking the user was not in the last page.

Now, we're checking the items prop to be present and equal to 0 to disable it in top of out existing checks. Therefore, merging this PR wouldn't affect any existing uses of the Pager without passing the items prop.

