### PR TITLE
Fix typo in table docs example

### DIFF
--- a/internal/docs/overview/examples/tables.js
+++ b/internal/docs/overview/examples/tables.js
@@ -21,7 +21,7 @@ const TablesExample = () => (
           },
           {
             name: 'Ray Bradbury',
-            email: 'ray.asimov@gmail.com',
+            email: 'ray.bradbury@gmail.com',
             latest_login: '2 months ago',
             num_logins: '25',
             connection: 'Username-Password',


### PR DESCRIPTION
### Description

Ray Bradbury's email is listed as "ray.asimov@gmail.com." This is incorrect.