### PR TITLE
Breadcrumb accessibility improvements

### DIFF
--- a/core/components/atoms/breadcrumb/breadcrumb.md
+++ b/core/components/atoms/breadcrumb/breadcrumb.md
@@ -11,7 +11,9 @@
 <Breadcrumb>
   <Breadcrumb.Link href="/home">Home</Breadcrumb.Link>
   <Breadcrumb.Link href="/parent">Parent</Breadcrumb.Link>
-  <Breadcrumb.Link href="/parent/page">Page</Breadcrumb.Link>
+  <Breadcrumb.Link aria-current="page" href="/parent/page">
+    Page
+  </Breadcrumb.Link>
 </Breadcrumb>
 ```
 
@@ -24,6 +26,7 @@ A breadcrumb is a hierarchical representation of the page within the application
 - The breadcrumb is displayed as single horizontal line.
 - Using this component is optional: it only makes sense when there is a hierarchy of pages to display.
 - The last item of the breadcrumb indicates the current page and it’s not clickable.
+- The last item can be given an [`aria-current`](https://www.w3.org/TR/wai-aria-1.1/#aria-current) attribute to indicate to assistive technologies that it is the current item.
 
 ## Examples
 

--- a/core/components/atoms/breadcrumb/breadcrumb.tsx
+++ b/core/components/atoms/breadcrumb/breadcrumb.tsx
@@ -6,7 +6,7 @@ import { fonts, spacing, colors } from '../../tokens'
 import containerStyles from '../../_helpers/container-styles'
 
 import Icon from '../icon'
-import Link, { LinkOnClickHandler } from '../link'
+import Link, { ILinkProps } from '../link'
 
 const Separator = styled(Icon)`
   margin: 0 ${spacing.small};
@@ -23,10 +23,10 @@ export interface IBreadcrumbProps {
 }
 
 const Breadcrumb = (props: IBreadcrumbProps) => (
-  <Breadcrumb.Element {...Automation('breadcrumb')} {...props} />
+  <Breadcrumb.Element aria-label="Breadcrumb" {...Automation('breadcrumb')} {...props} />
 )
 
-Breadcrumb.Element = styled.div`
+Breadcrumb.Element = styled.nav`
   ${containerStyles};
 
   /* overrides for link */
@@ -79,20 +79,15 @@ Breadcrumb.Element = styled.div`
   }
 `
 
-export interface IBreadcrumbLinkProps {
-  /** HTML ID of the component */
-  id?: string
-  href?: string
+export interface IBreadcrumbLinkProps extends ILinkProps {
   icon?: string
-  children?: string | JSX.Element
-  onClick?: LinkOnClickHandler
 }
 
 Breadcrumb.Link = (props: IBreadcrumbLinkProps) => (
   <Link {...Automation('breadcrumb.link')} {...props}>
     {props.icon && <LinkIcon name={props.icon} size={12} color="grayDarkest" />}
     {props.children}
-    <Separator name="chevron-right-fill" size={12} color="grayMedium" />
+    <Separator aria-hidden={true} name="chevron-right-fill" size={12} color="grayMedium" />
   </Link>
 )
 


### PR DESCRIPTION
### Description

Some changes to the Breadcrumb for better accessibility.

* Use `nav` instead of `div` for element
* Add `aria-label` to element
* Add docs about using `aria-current`
* Make `IBreadCrumbLinkProps` extend `ILinkProps`

### References

Fixes #1289

### Testing

Tested using [ChromeVox](https://chrome.google.com/webstore/detail/chromevox/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en), and seemed to have improved announcement.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`


This PR closes #1621