### PR TITLE
Add JSX support to EmptyState

### DIFF
--- a/core/components/molecules/empty-state/empty-state.md
+++ b/core/components/molecules/empty-state/empty-state.md
@@ -49,7 +49,7 @@ You can change how the help link opens by passing an `object` with `target` inst
 </EmptyState>
 ```
 
-### Adding beta tags
+### Empty state with beta tag
 
 ```js
 <EmptyState

--- a/core/components/molecules/empty-state/empty-state.md
+++ b/core/components/molecules/empty-state/empty-state.md
@@ -7,7 +7,7 @@ Empty states are displayed when a page has no content.
 
 ```jsx
 <EmptyState
-  {props} defaults={{title: "Clients", icon: "clients", link: "auth0.com"}}
+  {props} defaults={{title: "'Clients'", icon: "clients", link: "auth0.com"}}
   action={{
     icon: 'plus',
     label: 'Create Client',
@@ -46,5 +46,22 @@ You can change how the help link opens by passing an `object` with `target` inst
   link={{ href: 'https://auth0.com', target: '_blank' }}
 >
   We couldn't find files that match your search.
+</EmptyState>
+```
+
+### Adding beta tags
+
+```js
+<EmptyState
+  title={
+    <>
+      Hooks <Badge appearance="information">BETA</Badge>
+    </>
+  }
+  icon="hooks"
+  link={{ href: 'https://auth0.com', target: '_blank' }}
+>
+  Hooks allow you to customize the behavior of Auth0 with Node.js code that is executed in selected
+  extension points.
 </EmptyState>
 ```

--- a/core/components/molecules/empty-state/empty-state.story.tsx
+++ b/core/components/molecules/empty-state/empty-state.story.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { Example, Stack } from '../../_helpers/story-helpers'
+import React from "react";
 
-import { EmptyState } from '../../'
+import { storiesOf } from "@storybook/react";
+
+import { EmptyState } from "../../";
+import { Example, Stack } from "../../_helpers/story-helpers";
+import Badge from "../../atoms/badge";
 
 storiesOf('EmptyState', module).add('default', () => (
   <Example title="default">
@@ -14,7 +16,7 @@ storiesOf('EmptyState', module).add('default', () => (
       action={{
         icon: 'plus',
         label: 'Create Client',
-        handler: () => { }
+        handler: () => {}
       }}
     />
   </Example>
@@ -32,6 +34,21 @@ storiesOf('EmptyState', module).add('without action', () => (
   </Example>
 ))
 
+storiesOf('EmptyState', module).add('with beta tag', () => (
+  <EmptyState
+    title={
+      <>
+        Hooks <Badge appearance="information">BETA</Badge>
+      </>
+    }
+    icon="hooks"
+    link={{ href: 'https://auth0.com', target: '_blank' }}
+  >
+    Hooks allow you to customize the behavior of Auth0 with Node.js code that is executed in
+    selected extension points.
+  </EmptyState>
+))
+
 storiesOf('EmptyState', module).add('stressed', () => (
   <Example title="stressed - 119 characters in title and text">
     <EmptyState
@@ -42,7 +59,7 @@ storiesOf('EmptyState', module).add('stressed', () => (
       action={{
         icon: 'plus',
         label: 'Create Client',
-        handler: () => { }
+        handler: () => {}
       }}
     />
   </Example>

--- a/core/components/molecules/empty-state/empty-state.tsx
+++ b/core/components/molecules/empty-state/empty-state.tsx
@@ -1,14 +1,15 @@
-import * as React from 'react'
-import styled from '../../styled'
-import { colors, spacing } from '../../tokens'
-import Icon, { __ICONNAMES__ } from '../../atoms/icon'
-import Button from '../../atoms/button'
-import Link from '../../atoms/link'
-import Heading from '../../atoms/heading'
-import { ActionWithIcon } from '../../_helpers/action-shape'
-import FreeText from '../../_helpers/free-text'
-import Automation from '../../_helpers/automation-attribute'
-import containerStyles from '../../_helpers/container-styles'
+import * as React from "react";
+
+import { ActionWithIcon } from "../../_helpers/action-shape";
+import Automation from "../../_helpers/automation-attribute";
+import containerStyles from "../../_helpers/container-styles";
+import FreeText from "../../_helpers/free-text";
+import Button from "../../atoms/button";
+import Heading from "../../atoms/heading";
+import Icon, { __ICONNAMES__ } from "../../atoms/icon";
+import Link from "../../atoms/link";
+import styled from "../../styled";
+import { colors, spacing } from "../../tokens";
 
 const getHelpLink = link => {
   if (!link) return undefined
@@ -33,7 +34,7 @@ export interface IEmptyStateProps {
   /** HTML ID of the component */
   id?: string
   /** Big heading for section */
-  title: string
+  title: React.ReactNode
   /** Icon associated with section */
   icon: string
   /** @deprecated:children Message */


### PR DESCRIPTION
Add JSX support to `EmptyState`'s Title prop. This allows us to pass custom components as part of the Empty State titles like "Beta" tags.

<img width="846" alt="Screen Shot 2019-07-04 at 12 10 41 PM" src="https://user-images.githubusercontent.com/50875398/60676883-6592b400-9e56-11e9-8072-9558ac011ac6.png">
