### PR TITLE
Reset count in console warning message on recompile

### DIFF
--- a/tooling/component-metadata.ts
+++ b/tooling/component-metadata.ts
@@ -13,7 +13,6 @@ const colors = require('@auth0/cosmos/tokens/colors')
 /* CLI param for watch mode */
 const watch = process.argv.includes('-w') || process.argv.includes('--watch')
 const debug = process.argv.includes('-d') || process.argv.includes('--debug')
-let warning = 0
 
 /* Ensure meta directory exists */
 fs.ensureDirSync('core/components/meta')
@@ -23,6 +22,7 @@ const javascriptFiles = glob.sync('core/components/+(atoms|molecules|layouts)/**
 let markdownFiles = glob.sync('core/components/+(atoms|molecules|layouts)/**/*.md')
 
 const run = () => {
+  let warning = 0
   info('Generating metadata')
   let metadata = javascriptFiles
     .filter(path => !path.includes('story.tsx') || !path.includes('.d.ts'))


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

When running the project in`docs.dev` or `metadata.dev` mode, the component count in the metadata.dev console warning increases with every recompile.

![image](https://user-images.githubusercontent.com/1138977/60684556-5454a200-9e6c-11e9-8a55-bcee65a0fcf9.png)
 
Moved the `warning` var into the function scope to fix.

### Testing

No testing additions/updates needed. Fix applies to the development workflow only. Verified the count does not increase with subsequent recompilations.

### Checklist

- All active GitHub checks for tests, formatting, and security are passing
- The correct base branch is being used, if not `master`
