### PR TITLE
Fix SSR using injectGlobal

### DIFF
--- a/core/components/_helpers/globals.ts
+++ b/core/components/_helpers/globals.ts
@@ -1,4 +1,5 @@
 import { fonts, misc } from '../tokens'
+import { injectGlobal } from 'styled-components'
 
 let includeGlobals = true
 
@@ -6,24 +7,14 @@ if (process && process.env && process.env.COSMOS_DISABLE_RESETS) {
   includeGlobals = false
 }
 
-const insertAtTheStart = styles => {
-  let tag = document.getElementById('cosmos-globals')
-
-  if (tag) {
-    tag.innerHTML = styles
-  } else {
-    tag = document.createElement('style')
-    tag.id = 'cosmos-globals'
-    tag.innerHTML = styles
-
-    // Register the resets before anything else
-    const head = document.getElementsByTagName('head')[0]
-    head.insertBefore(tag, head.firstChild)
+const injectCosmosGlobals = () =>
+  includeGlobals ?
+    injectGlobal`
+  /* TODO: REMOVE */
+  remove-me-after-review {
+    font-family: 'resets not disabled';
   }
-}
 
-if (includeGlobals) {
-  insertAtTheStart(`
   html, body, div, span, applet, object, iframe,
   h1, h2, h3, h4, h5, h6, p, blockquote, pre,
   a, abbr, acronym, address, big, cite, code,
@@ -90,10 +81,13 @@ if (includeGlobals) {
   }
 
 
-`)
-} else {
-  /* We still insert some styles to add missing fonts and keep other things sane 😅 */
-  insertAtTheStart(`
+` :
+    injectGlobal`
+    /* TODO: REMOVE */
+    remove-me-after-review {
+      font-family: 'resets disabled';
+    }
+    
     * {
       box-sizing: border-box;
     }
@@ -112,5 +106,6 @@ if (includeGlobals) {
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
     }
-  `)
-}
+  `
+
+export default injectCosmosGlobals

--- a/core/components/components.ts
+++ b/core/components/components.ts
@@ -8,7 +8,7 @@
 /* eslint-disable import/first */
 
 /* resets for font */
-import './_helpers/globals'
+import injectCosmosGlobals from  './_helpers/globals'
 
 /* internal */
 import Box from './atoms/_box'
@@ -116,5 +116,6 @@ export {
   TextArea,
   TextInput,
   Tooltip,
-  Well
+  Well,
+  injectCosmosGlobals
 }

--- a/core/components/index.ts
+++ b/core/components/index.ts
@@ -47,7 +47,8 @@ import {
   GalleryLayout,
   RowLayout,
   PageLayout,
-  StackLayout
+  StackLayout,
+  injectCosmosGlobals
 } from './components'
 
 export {
@@ -99,5 +100,6 @@ export {
   GalleryLayout,
   RowLayout,
   PageLayout,
-  StackLayout
+  StackLayout,
+  injectCosmosGlobals
 }

--- a/core/components/styled.ts
+++ b/core/components/styled.ts
@@ -3,7 +3,8 @@ import styled, {
   css,
   injectGlobal,
   ThemeProvider,
-  StyledComponentClass
+  StyledComponentClass,
+  ServerStyleSheet
 } from 'styled-components'
 import domElements from './_helpers/dom-elements'
 
@@ -40,4 +41,4 @@ domElements.forEach((domElement) => {
 })
 
 export default styledWithHelpers
-export { keyframes, css, injectGlobal, StyledComponentClass, ThemeProvider }
+export { keyframes, css, injectGlobal, StyledComponentClass, ThemeProvider, ServerStyleSheet }


### PR DESCRIPTION
### Description
This PR tries to solve the SSR issue of not finding `document` when trying to inject global styles.

For SSR, globals in styled components should be included using either `injectGlobal` pre-v4 or `createGlobalStyle` for v4 (we have v3 in Cosmos).

`injectGlobal` adds the styles to the styled-components global stylesheet and for server side rendering they're collected with `collectStyles` and included in the final CSS.

Example usage in `_document.js` for NextJS:
```js
import Document from "next/document";
import { injectCosmosGlobals } from "@auth0/cosmos";
import { ServerStyleSheet } from "@auth0/cosmos/styled";

// This line uses injectGlobal and add them to the ServerStyleSheet below
injectCosmosGlobals();

export default class MyDocument extends Document {
  static async getInitialProps(ctx) {
    const sheet = new ServerStyleSheet();
    const originalRenderPage = ctx.renderPage;

    try {
      ctx.renderPage = () =>
        originalRenderPage({
          enhanceApp: App => props => sheet.collectStyles(<App {...props} />)
        });

      const initialProps = await Document.getInitialProps(ctx);
      return {
        ...initialProps,
        styles: (
          <>
            {initialProps.styles}
            {sheet.getStyleElement()}
          </>
        )
      };
    } catch(e) {
      console.log('styled-components failed!')
      console.log(e)
    }
  }
}
```

This approach works well but due to the current insertion of styles using `document` even if a check for `document` existence is placed, in SSR frameworks, Cosmos is imported again in the client side and thus duplicating the styles.

Any time there's an `import { sth } from '@auth0/cosmos'` styles are injected (only once if run two times client side).

...WIP