### PR TITLE
Cache metadata for faster rebuilds in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lint-staged": "7.2.0",
     "lodash.camelcase": "4.3.0",
     "lodash.frompairs": "4.0.1",
+    "md5-file": "^4.0.0",
     "nps": "5.9.2",
     "nps-i": "1.0.2",
     "nps-utils": "1.6.0",

--- a/tooling/component-metadata.ts
+++ b/tooling/component-metadata.ts
@@ -1,5 +1,6 @@
 const fs = require('fs-extra')
 const glob = require('glob')
+const md5File = require('md5-file')
 
 import * as docgen from 'react-docgen-typescript'
 
@@ -13,7 +14,10 @@ const colors = require('@auth0/cosmos/tokens/colors')
 /* CLI param for watch mode */
 const watch = process.argv.includes('-w') || process.argv.includes('--watch')
 const debug = process.argv.includes('-d') || process.argv.includes('--debug')
-let warning = 0
+
+/* Cache file metadata in memory for comparison on subsequent recompiles */
+const jsCache = []
+const mdCache = []
 
 /* Ensure meta directory exists */
 fs.ensureDirSync('core/components/meta')
@@ -22,22 +26,54 @@ fs.ensureDirSync('core/components/meta')
 const javascriptFiles = glob.sync('core/components/+(atoms|molecules|layouts)/**/*.ts*')
 let markdownFiles = glob.sync('core/components/+(atoms|molecules|layouts)/**/*.md')
 
-const run = () => {
-  info('Generating metadata')
-  let metadata = javascriptFiles
+const run = (event: string, srcPath?: string) => {
+  let warning = 0
+
+  if (event === 'ready') {
+    info('Generating metadata')
+  } else {
+    info(`Updating metadata for ${event === 'change' ? 'changed' : 'unlinked'} path ${srcPath}`)
+  }
+
+  javascriptFiles
+    /* Get all files on first run or only those matching the srcPath from change/unlink */
+    .filter(path => !srcPath || path.includes(srcPath.replace('.md', '')))
+    /* Ignore stories and type defs */
     .filter(path => !path.includes('story.tsx') || !path.includes('.d.ts'))
-    .map(path => {
+    .forEach(path => {
       try {
         /* ignore secondary files */
         const directoryName = path.split('/').splice(-2, 1)[0]
         const componentFileName = directoryName.replace('_', '') + '.tsx'
 
-
-        /* if component file does not exist, move on*/
+        /* if component file does not exist, move on */
         if (!path.includes(componentFileName)) return
 
-        const code = fs.readFileSync(path, 'utf8')
+        /* get documentation file path */
+        const documentationPath = path.replace('.tsx', '.md')
 
+        const cmpFileHash = md5File.sync(path)
+        const docFileHash = fs.existsSync(documentationPath)
+          ? md5File.sync(documentationPath)
+          : null
+
+        let cacheEntry = jsCache.find(f => f.name === componentFileName)
+
+        /* If component file and corresponding doc file are unchanged, move on */
+        if (cacheEntry && cacheEntry.hash === cmpFileHash && cacheEntry.docHash === docFileHash) {
+          return
+        }
+
+        if (!cacheEntry) {
+          cacheEntry = {
+            name: componentFileName
+          }
+
+          jsCache.push(cacheEntry)
+        }
+
+        cacheEntry.hash = cmpFileHash
+        cacheEntry.docHash = docFileHash
 
         /* parse the component code to get metadata */
         const data: any = docgen.parse(path, {
@@ -84,9 +120,6 @@ const run = () => {
         /* add filepath to metadata */
         data.filepath = path
 
-        /* get documentation file path */
-        const documentationPath = path.replace('.tsx', '.md')
-
         /* add documentation if exists */
         if (fs.existsSync(documentationPath)) {
           data.documentation = fs.readFileSync(documentationPath, 'utf8')
@@ -104,47 +137,60 @@ const run = () => {
         data.implemented = true
         data.internal = path.includes('_')
 
-        return data
+        cacheEntry.data = data
       } catch (err) {
         /* warn if there was a problem with getting metadata */
         if (debug) warn(`Could not parse metadata for ${path}: ${err.stack || err}`)
         else warning++
       }
     })
-    /*
-      filter out null values,
-      this protects against components that don't have metadata yet
-    */
-    .filter(meta => meta)
+
+  info('metadata done')
 
   /* Add documentation files that are not implemented yet */
-  markdownFiles.map(path => {
-    const data: any = {}
+  markdownFiles
+    .filter(path => !srcPath || path.includes(srcPath))
+    .forEach(path => {
+      const data: any = {}
 
-    /* attach content of documentation file */
-    data.documentation = fs.readFileSync(path, 'utf8')
+      /* infer display name from path */
+      data.displayName = camelCase(
+        path
+          .split('/')
+          .pop()
+          .replace('.md', '')
+      )
 
-    /* attach temporary filepath */
-    data.filepath = path
+      const currentHash = md5File.sync(path)
+      let cacheEntry = mdCache.find(f => f.data.displayName === data.displayName)
 
-    /* infer display name from path */
-    data.displayName = camelCase(
-      path
-        .split('/')
-        .pop()
-        .replace('.md', '')
-    )
+      if (cacheEntry && cacheEntry.hash === currentHash) {
+        return
+      }
 
-    /* add lazy hint for documentation */
-    data.implemented = false
+      if (!cacheEntry) {
+        cacheEntry = { data }
+        mdCache.push(cacheEntry)
+      }
 
-    metadata.push(data)
-  })
+      cacheEntry.hash = currentHash
+      /* attach content of documentation file */
+      data.documentation = fs.readFileSync(path, 'utf8')
+
+      /* attach temporary filepath */
+      data.filepath = path
+
+      /* add lazy hint for documentation */
+      data.implemented = false
+    })
 
   /*
     Write the file in docs folder
     TODO: Rethink tooling for docs which works across packages
   */
+
+  const metadata = [...jsCache, ...mdCache].map(entry => entry.data)
+
   fs.writeFileSync(
     'core/components/meta/metadata.json',
     JSON.stringify({ metadata }, null, 2),
@@ -162,7 +208,7 @@ const run = () => {
     'utf8'
   )
 
-  if (warning) {
+  if (event === 'ready' && warning) {
     warn(`${warning} components could use some docs love, run in --debug mode for more info`)
   }
 }
@@ -174,9 +220,9 @@ if (watch) {
     .watch('core/components', {
       ignored: ['node_modules', 'core/components/meta']
     })
-    .on('ready', run)
-    .on('change', run)
-    .on('unlink', run)
+    .on('ready', () => run('ready'))
+    .on('change', path => run('change', path))
+    .on('unlink', path => run('unlink', path))
 } else {
-  run()
+  run('ready')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9399,6 +9399,11 @@ math-random@^1.0.1:
   resolved "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
+md5-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-4.0.0.tgz#f3f7ba1e2dd1144d5bf1de698d0e5f44a4409584"
+  integrity sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==
+
 md5.js@^1.3.4:
   version "1.3.4"
   resolved "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"


### PR DESCRIPTION
### Description

When running the `metadata.dev` script, any watched component or .md change triggers a full rebuild of `core/components/meta/metadata.json` that runs for several seconds, significantly delaying reload.

Improved rebuild performance on incremental changes by:
* Caching metadata and a hash for each file.
* Only scanning files matching a changed path (if passed).
* Refreshing cache with metadata related to individual file change.
* Rebuilding metadata.json from cached data.

### Testing
Fixes apply to build/dev tooling. 


**Added dev dependency https://www.npmjs.com/package/md5-file. Will need to run `yarn` before testing.**

Can be manually tested by running the project in `docs.dev` mode and altering one of the component markdown files after the initial build.

### Checklist

- All active GitHub checks for tests, formatting, and security are passing
- The correct base branch is being used, if not `master`
