### PR TITLE
Limit exposure of prop switching to string literal union types

### DIFF
--- a/core/components/atoms/select/select.md
+++ b/core/components/atoms/select/select.md
@@ -7,7 +7,7 @@
 
 ```jsx
 <Select {props}
-  placeholder="Select an option..."
+  defaults={{placeholder: "Select an option..."}} 
   options={[
     { text: 'One', value: 1, disabled: true },
     { text: 'Two', value: 2 },

--- a/core/components/atoms/text-input/text-input.md
+++ b/core/components/atoms/text-input/text-input.md
@@ -6,7 +6,7 @@
 `import { TextInput } from '@auth0/cosmos'`
 
 ```jsx
-<TextInput placeholder="Placeholder text" {props} />
+<TextInput defaults={{placeholder: "Placeholder text"}} {props} />
 ```
 
 ### Input types

--- a/core/components/atoms/textarea/textarea.md
+++ b/core/components/atoms/textarea/textarea.md
@@ -7,7 +7,7 @@
 Note: `TextArea` is camelcased, it's not `Textarea`.
 
 ```jsx
-<TextArea {props} placeholder="Placeholder text" />
+<TextArea {props} defaults={{placeholder: "Placeholder text"}} />
 ```
 
 ### Length of the TextArea

--- a/internal/docs/component/get-defaults-from-code.js
+++ b/internal/docs/component/get-defaults-from-code.js
@@ -34,7 +34,7 @@ const stripDefaultsFromDocs = code => {
   const string = getDefaultString(code)
   // string ~ key1: "value1", key2: "value2"
 
-  const strippedCode = code.replace(/\s*defaults=\{\s*\{}.*\}\s*\}/, '')
+  const strippedCode = code.replace(/\s*defaults=\{\s*\{.*\}\s*\}/, '')
   // strippedCode ~ <Component />
 
   return strippedCode

--- a/internal/docs/component/get-defaults-from-code.js
+++ b/internal/docs/component/get-defaults-from-code.js
@@ -34,7 +34,7 @@ const stripDefaultsFromDocs = code => {
   const string = getDefaultString(code)
   // string ~ key1: "value1", key2: "value2"
 
-  const strippedCode = code.replace(` defaults={{${string}}}`, '')
+  const strippedCode = code.replace(/\s*defaults=\{\s*\{}.*\}\s*\}/, '')
   // strippedCode ~ <Component />
 
   return strippedCode

--- a/internal/docs/component/prop-switcher.js
+++ b/internal/docs/component/prop-switcher.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import { TextInput, Switch, Select } from '@auth0/cosmos'
 
+/* Test if string matches a string literal union type ( 'string1' | 'string2' | 'string3') */
+const REGEX_LITERAL_UNION = /\| ['"]/
+
 const PropSwitcher = ({ propName, data, onPropsChange }) => {
   let handler = value => onPropsChange(propName, value.toString())
 
@@ -9,8 +12,12 @@ const PropSwitcher = ({ propName, data, onPropsChange }) => {
   } else if (['string', 'number'].includes(data.type.name)) {
     if (data.value === 'null') data.value = ''
     return <TextInput defaultValue={data.value} onChange={e => handler(e.target.value)} />
-  } else if (data.type.name.includes('|')) {
-    const options = data.type.name.replace(/"/g, '').split(' | ').map(value => ({ text: value, value }))
+  } else if (REGEX_LITERAL_UNION.test(data.type.name)) {
+    /* Split string literal union into options */
+    const options = data.type.name
+      .replace(/['"]/g, '')
+      .split(' | ')
+      .map(value => ({ text: value, value }))
     return (
       <Select defaultValue={data.value} onChange={e => handler(e.target.value)} options={options} />
     )


### PR DESCRIPTION
### Description
This PR addresses #1542 with 2 fixes:
* Updated markdown examples. Refactored props as defaults for any editable property to force prepopulating the value. Otherwise, any edit to an existing prop=value in the live code generates a duplicate (see https://auth0-cosmos.now.sh/docs/#/component/select and edit the `placeholder` prop).
* Hide the prop-type switcher for any union type that is not a string literal. Currently, all type unions are parsed as select options. See https://auth0-cosmos.now.sh/docs/#/component/select - `options` prop.
![image](https://user-images.githubusercontent.com/1138977/60809559-f3bdb180-a158-11e9-9ebb-2b9f77aea3ae.png)


**Note**: Only updated a few markdown files with the defaults. Will update the rest after PR is approved.

### References

Addresses issue #1542

### Testing

No additional or updated tests needed - component functionality was not altered.
Manually tested: 
https://auth0-cosmos.now.sh/docs/#/component/select
https://auth0-cosmos.now.sh/docs/#/component/text-input
https://auth0-cosmos.now.sh/docs/#/component/textarea
Verified placeholder edits do not generate duplicate props.

### Checklist

- All active GitHub checks for tests, formatting, and security are passing
- The correct base branch is being used, if not `master`