### PR TITLE
Ignore split char in values when extracting default props

### DIFF
--- a/core/components/atoms/checkbox/checkbox.md
+++ b/core/components/atoms/checkbox/checkbox.md
@@ -28,7 +28,7 @@ class Example extends React.Component {
   render() {
     return (
       <Checkbox
-        name="example"
+        defaults={{name: "example"}}
         onChange={evt => this.handleChange(evt)}
         value="one"
         checked={this.state.selected.indexOf('one') >= 0}

--- a/core/components/atoms/image/image.md
+++ b/core/components/atoms/image/image.md
@@ -7,8 +7,11 @@
 
 ```jsx
 <Image
-  source="https://images.unsplash.com/photo-1465101162946-4377e57745c3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2257&h=1200&q=80"
-  alt="The cosmos"
+  {props}
+  defaults={{
+    src: "https://images.unsplash.com/photo-1465101162946-4377e57745c3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2257&h=1200&q=80",
+    alt: "The cosmos"
+  }}
 />
 ```
 

--- a/core/components/atoms/link/link.md
+++ b/core/components/atoms/link/link.md
@@ -8,7 +8,7 @@
 ---
 
 ```jsx
-<Link href="https://auth0.com" {props}>Click me!</Link>
+<Link defaults={{href: "https://auth0.com"}} {props}>Click me!</Link>
 ```
 
 #### Examples

--- a/core/components/atoms/radio/radio.md
+++ b/core/components/atoms/radio/radio.md
@@ -25,7 +25,7 @@ class Example extends React.Component {
   render() {
     return (
       <Radio
-        name="example1"
+        defaults={{name: "example1"}}
         selected={this.state.selected}
         onChange={evt => this.handleChange(evt)}
         {props}

--- a/internal/docs/component/get-defaults-from-code.js
+++ b/internal/docs/component/get-defaults-from-code.js
@@ -1,10 +1,8 @@
+const REGEX_DEFAULTS_STR = /\s*defaults=(\{\s*){2}([\s\S]+?)(\s*\}){2}/
+
 const getDefaultString = code => {
-  const string = code
-    .split('defaults={{')[1]
-    .split('}}>')[0]
-    .split('}} ')[0]
-    .split('}}\n')[0]
-  return string
+  const matches = code.match(REGEX_DEFAULTS_STR)
+  return matches ? matches[2].trim() : null
 }
 
 const getDefaultsFromCode = code => {
@@ -12,13 +10,14 @@ const getDefaultsFromCode = code => {
 
   // code ~ <Component defaults={{key1: "value1", key2: "value2"}}/>
 
-  if (!code.includes('defaults')) return values
+  if (!REGEX_DEFAULTS_STR.test(code)) return values
 
-  const string = getDefaultString(code)
+  const defaultsString = getDefaultString(code)
   // string ~ key1: "value1", key2: "value2"
 
-  string.split(',').forEach(pair => {
-    const [key, value] = pair.split(':')
+  defaultsString.split(',').forEach(pair => {
+    // Split on the first ":" only (value may be a URL)
+    const [key, value] = pair.split(/:(.+)/)
     values[key.trim()] = JSON.parse(value.trim())
   })
   // values ~ { key1: "value1", key2: "value2" }
@@ -34,7 +33,7 @@ const stripDefaultsFromDocs = code => {
   const string = getDefaultString(code)
   // string ~ key1: "value1", key2: "value2"
 
-  const strippedCode = code.replace(/\s*defaults=\{\s*\{.*\}\s*\}/, '')
+  const strippedCode = code.replace(REGEX_DEFAULTS_STR, '')
   // strippedCode ~ <Component />
 
   return strippedCode


### PR DESCRIPTION
### Description
Noticed the [Image](https://auth0-cosmos.now.sh/docs/#/component/image) live code example was not responding to prop input changes.
Fixed with a combination of updating defaults and limiting the key/value split to the first `:` (avoiding additional splits of a url value). Also tweaked the defaults str regex to be used for both matching/extraction and stripping.

Updated the following examples to eliminate potential rendering of duplicate props:
* https://auth0-cosmos.now.sh/docs/#/component/checkbox
* https://auth0-cosmos.now.sh/docs/#/component/image
* https://auth0-cosmos.now.sh/docs/#/component/link
* https://auth0-cosmos.now.sh/docs/#/component/radio

### References

Should address issue #1383

### Testing
Manually tested updated examples and regression tested others to ensure parsing, formatting, and interactions work as expected.

### Checklist
- [N/A] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`