### PR TITLE
Alert a11y

### DIFF
--- a/core/components/atoms/alert/alert.tsx
+++ b/core/components/atoms/alert/alert.tsx
@@ -6,30 +6,31 @@ import FreeText from "../../_helpers/free-text";
 import { rootProps } from "../../_helpers/root-props";
 import styled, { css } from "../../styled";
 import { colors, fonts, spacing } from "../../tokens";
+import Button from "../button";
 import Icon, { __ICONNAMES__ } from "../icon";
 import Link, { StyledLink } from "../link";
 import Text from "../text";
 
-export type IAlertElementProps = Partial<IAlertProps>
-export type IAlertAppearance = 'default' | 'information' | 'success' | 'warning' | 'danger'
+export type IAlertElementProps = Partial<IAlertProps>;
+export type IAlertAppearance = "default" | "information" | "success" | "warning" | "danger";
 
 export interface IAlertProps {
   /** HTML ID of the component */
-  id?: string
-  appearance?: IAlertAppearance
-  icon?: string
-  title?: React.ReactNode
+  id?: string;
+  appearance?: IAlertAppearance;
+  icon?: string;
+  title?: React.ReactNode;
   /** @deprecated:children  */
-  text?: string
+  text?: string;
   /** @deprecated:children  */
-  link?: string
-  dismissible?: boolean
-  onDismiss?: () => void
-  dismissAfterSeconds?: number
+  link?: string;
+  dismissible?: boolean;
+  onDismiss?: () => void;
+  dismissAfterSeconds?: number;
 }
 
 export interface IAlertState {
-  visible: boolean
+  visible: boolean;
 }
 
 const ReadMoreLink = styled(Link)`
@@ -39,26 +40,26 @@ const ReadMoreLink = styled(Link)`
     text-decoration: none;
   }
   margin-left: ${spacing.xxsmall};
-`
+`;
 
 class Alert extends React.Component<IAlertProps, IAlertState> {
   public static defaultProps = {
-    appearance: 'default',
-    dismissible: true,
-  }
+    appearance: "default",
+    dismissible: true
+  };
 
-  public static Element: any
-  public timer: any
+  public static Element: any;
+  public timer: any;
 
   constructor(props) {
-    super(props)
-    this.state = { visible: true }
+    super(props);
+    this.state = { visible: true };
   }
 
   public componentDidMount() {
     if (this.props.dismissAfterSeconds) {
       /* timer to auto dismiss the component */
-      this.timer = window.setTimeout(this.dismiss, this.props.dismissAfterSeconds * 1000)
+      this.timer = window.setTimeout(this.dismiss, this.props.dismissAfterSeconds * 1000);
     }
   }
 
@@ -71,19 +72,19 @@ class Alert extends React.Component<IAlertProps, IAlertState> {
       component
     */
     if (this.timer) {
-      window.clearTimeout(this.timer)
+      window.clearTimeout(this.timer);
     }
   }
 
   public dismiss = () => {
-    this.setState({ visible: false })
-    if (typeof this.props.onDismiss === 'function') {
-      this.props.onDismiss()
+    this.setState({ visible: false });
+    if (typeof this.props.onDismiss === "function") {
+      this.props.onDismiss();
     }
-  }
+  };
 
   public render() {
-    const appearance = this.props.appearance
+    const appearance = this.props.appearance;
 
     if (this.state.visible) {
       return (
@@ -91,61 +92,62 @@ class Alert extends React.Component<IAlertProps, IAlertState> {
           appearance={appearance}
           dismissible={this.props.dismissible}
           data-cosmos-appearance={appearance}
-          {...Automation('alert')}
+          {...Automation("alert")}
           {...rootProps(this.props)}
+          role="alert"
         >
-          {this.props.icon && <Icon name={this.props.icon} color={iconColorMap[appearance]} />}
-          <span>
+          {this.props.icon && (
+            <AlertIcon>
+              <Icon name={this.props.icon} color={iconColorMap[appearance]} />
+            </AlertIcon>
+          )}
+
+          <AlertContent>
             <Text type="strong">{this.props.title}</Text> <FreeText {...this.props} />
             {this.props.link && (
               <ReadMoreLink appearance="default" href={this.props.link} target="_blank">
                 Read more
               </ReadMoreLink>
             )}
-          </span>
+          </AlertContent>
+
           {this.props.dismissible && (
-            <Cross onClick={this.dismiss} {...Automation('alert.dismiss')} />
+            <Button
+              aria-label="Close"
+              size="default"
+              appearance="link"
+              icon="close"
+              onClick={this.dismiss}
+              {...Automation("alert.dismiss")}
+            />
           )}
         </Alert.Element>
-      )
+      );
     } else {
-      return null
+      return null;
     }
   }
 }
 
-const Cross = styled.a`
-  cursor: pointer;
-  font-size: 1.5em;
-  line-height: 1;
-  &:after {
-    content: '×';
-    font-weight: ${fonts.weight.bold};
-  }
-`
-
-const styledForCross = css`
-  padding-right: ${spacing.large};
-`
-
 Alert.Element = styled.div<IAlertElementProps>`
   ${containerStyles};
-  padding: ${spacing.small} ${spacing.small};
-  ${(props) => props.dismissible && styledForCross};
-
+  padding: ${spacing.small} ${(props) => (props.dismissible === true ? "40px" : "spacing.small")} ${spacing.small}
+    ${spacing.small};
   background-color: ${(props) => colors.alert[props.appearance].background};
   color: ${(props) => colors.alert[props.appearance].text};
   border-radius: 3px;
   position: relative;
   display: flex;
+
   ${Icon.Element} {
-    margin-right: 12px;
+    display: block;
     position: relative;
     top: 1px;
     path {
       fill: ${(props) => colors.alert[props.appearance].text};
     }
   }
+
   ${StyledLink} {
     color: ${(props) => colors.alert[props.appearance].text};
     text-decoration: underline;
@@ -153,29 +155,35 @@ Alert.Element = styled.div<IAlertElementProps>`
       text-decoration: none;
     }
   }
-  ${Cross} {
+  ${Button.Element} {
     position: absolute;
     right: 0;
-    top: 0;
-    color: ${(props) => colors.alert[props.appearance].text};
-    opacity: 0.3;
+    top: 2px;
+    opacity: 0.5;
     padding: ${spacing.small} ${spacing.small};
-    &:hover {
-      opacity: 0.5;
+    &:hover,
+    &:focus {
+      opacity: 1;
     }
   }
-`
+`;
+
+const AlertIcon = styled.div`
+  margin-right: 12px;
+`;
+
+const AlertContent = styled.div``;
 
 /*
   Icon only accepts colors from colors.base
   This is a map between alert types and base colors
 */
 const iconColorMap = {
-  default: 'default',
-  information: 'blueDarker',
-  success: 'greenDarker',
-  warning: 'yellow',
-  danger: 'redDarker',
-}
+  default: "default",
+  information: "blueDarker",
+  success: "greenDarker",
+  warning: "yellow",
+  danger: "redDarker"
+};
 
-export default Alert
+export default Alert;


### PR DESCRIPTION
This PR makes the alert accessible following [WAI ARIA pattern](https://www.w3.org/TR/wai-aria-practices/examples/alert/alert.html):

- Adds a `role="alert"` to the alert container
- Adds an `aria-label="Close"` to the dismiss button
- Changes the dismiss button from an `a` to ` button`
- Cleans up the markup, in general, to make it more maintainable.
- Improves the CSS
- Changes the `x` icon to use the same icon to the Dialog for consistency.

The documentation preview is not working, but it's also not working in production either: https://auth0-cosmos.now.sh/docs/#/component/alert 