### PR TITLE
Always use a span for Text

### DIFF
--- a/core/components/atoms/text/text.tsx
+++ b/core/components/atoms/text/text.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react'
-import styled from '../../styled'
-import Automation from '../../_helpers/automation-attribute'
+import * as React from "react";
 
-import { colors, fonts } from '../../tokens'
+import Automation from "../../_helpers/automation-attribute";
+import styled from "../../styled";
+import { colors, fonts } from "../../tokens";
 
 type TextType = 'allcaps' | 'subdued' | 'strong'
 
@@ -31,7 +31,7 @@ const resolveTextComponent = (type: TextType) => {
 const Text = (props: ITextProps) => {
   const TextComponent = resolveTextComponent(props.type)
 
-  if (!TextComponent) return <>{props.children}</>
+  if (!TextComponent) return <span>{props.children}</span>
 
   return <TextComponent {...Automation('text')} {...props} />
 }


### PR DESCRIPTION
Make `<Text>` output consistent by always returning the same root element.