### PR TITLE
Fix syntax error in the Alert component doc (#1636)

### DIFF
--- a/core/components/atoms/alert/alert.tsx
+++ b/core/components/atoms/alert/alert.tsx
@@ -18,7 +18,7 @@ export interface IAlertProps {
   type?: IAlertAppearance // deprecated: use appearance
   appearance?: IAlertAppearance
   icon?: string
-  title?: string | React.ReactNode
+  title?: React.ReactNode
   /** @deprecated:children  */
   text?: string
   /** @deprecated:children  */

--- a/internal/docs/component/prop-string.js
+++ b/internal/docs/component/prop-string.js
@@ -75,7 +75,7 @@ const getPropString = propData => {
 
     if (propData[name].type.name === 'enum') {
       /*
-        react-docgen convers everything to a string :/
+        react-docgen converts everything to a string :/
         so we need to find out if there is a number
         inside the string
       */
@@ -89,7 +89,7 @@ const getPropString = propData => {
     }
 
     /*
-      Case 6: Union
+      Case 7: Union
       The value for enum should be printed depending on their value
       Currently supports only number and string and empty objects
     */
@@ -109,9 +109,28 @@ const getPropString = propData => {
       }
     }
 
+    /*
+      Case 8: ReactNode
+      ReactNode encompasses primitive types (string, number, bool) as well as elements/components
+      Wrap strings in double quotes. For all others, default to {value} 
+    */
+
+    if (propData[name].type.name === 'ReactNode') {
+      if (typeof propData[name].value === 'string') {
+        propString += ` ${name}="${propData[name].value}"`
+        return true
+      }
+
+      propString += ` ${name}={${propData[name].value}}`
+      return true
+    }
+
     const stringTypes = ['IAlertAppearance', 'LinkType']
 
-    if (stringTypes.indexOf(propData[name].type.name) >= 0 || propData[name].type.name.includes('|')) {
+    if (
+      stringTypes.indexOf(propData[name].type.name) >= 0 ||
+      propData[name].type.name.includes('|')
+    ) {
       propString += ` ${name}="${propData[name].value}"`
       return true
     }


### PR DESCRIPTION
_( Copied from #1636 )_
----------------------------
### Description

This PR addresses the syntax error currently rendered at https://auth0-cosmos.now.sh/docs/#/component/alert

![image](https://user-images.githubusercontent.com/1138977/60683362-63842180-9e65-11e9-8ed7-513882d88d31.png)

The parsing in prop-string.js is handled by the default case, which wraps all values in `{}`-  breaking on string types. Added a ReactNode case to check the data type, similar to other cases. Considered extending the default case to handle multiple types, but opted for minimal changes to remove the error first.

### Testing
Unit tests pass locally. 
No additional or updated tests needed - component functionality was not altered.

### Checklist
- Verified local build correctly renders the Alert example.
![image](https://user-images.githubusercontent.com/1138977/60683830-0a69bd00-9e68-11e9-82a0-9263ce32dca6.png)
- All active GitHub checks for tests, formatting, and security are passing.
- The correct base branch is being used, if not `master`.