### PR TITLE
[DXDP-635] Change '0 files selected' for 'No files selected' in…

### DIFF
--- a/core/components/atoms/file-input/file-input.story.tsx
+++ b/core/components/atoms/file-input/file-input.story.tsx
@@ -1,51 +1,45 @@
-import * as React from 'react'
+import * as React from "react";
 
-import { storiesOf } from '@storybook/react'
+import { storiesOf } from "@storybook/react";
 
-import { Example } from '../../_helpers/story-helpers'
-import FileInput from './'
+import { Example } from "../../_helpers/story-helpers";
+import FileInput from "./";
 
-storiesOf('FileInput', module).add('simple', () => (
+storiesOf("FileInput", module).add("simple", () => (
   <Example title="simple">
-    <FileInput items={[{ file: { name: 'file1.txt', size: 3579 } }]} />
+    <FileInput items={[{ file: { name: "file1.txt", size: 3579 } }]} />
   </Example>
-))
+));
 
-storiesOf('FileInput', module).add('multiple files', () => (
+storiesOf("FileInput", module).add("multiple files", () => (
   <Example title="multiple files">
     <FileInput
-      items={[
-        { file: { name: 'file1.txt', size: 3579 } },
-        { file: { name: 'file2.txt', size: 12356 } }
-      ]}
+      items={[{ file: { name: "file1.txt", size: 3579 } }, { file: { name: "file2.txt", size: 12356 } }]}
       multiple
     />
   </Example>
-))
+));
 
-storiesOf('FileInput', module).add('loading state', () => (
+storiesOf("FileInput", module).add("loading state", () => (
   <Example title="loading state">
     <FileInput
-      items={[
-        { file: { name: 'file1.txt', size: 3579 }, loading: true },
-        { file: { name: 'file2.txt', size: 12356 } }
-      ]}
+      items={[{ file: { name: "file1.txt", size: 3579 }, loading: true }, { file: { name: "file2.txt", size: 12356 } }]}
       multiple
     />
   </Example>
-))
+));
 
-storiesOf('FileInput', module).add('file name truncation', () => (
+storiesOf("FileInput", module).add("file name truncation", () => (
   <Example title="file name truncation">
     <FileInput
       items={[
         {
           file: {
-            name: 'this-file-is-more-than-50-characters-long-so-we-need-to-truncate.txt',
-            size: 99887
-          }
-        }
+            name: "this-file-is-more-than-50-characters-long-so-we-need-to-truncate.txt",
+            size: 99887,
+          },
+        },
       ]}
     />
   </Example>
-))
+));

--- a/core/components/atoms/file-input/file-input.story.tsx
+++ b/core/components/atoms/file-input/file-input.story.tsx
@@ -43,3 +43,9 @@ storiesOf("FileInput", module).add("file name truncation", () => (
     />
   </Example>
 ));
+
+storiesOf("FileInput", module).add("no files selected", () => (
+  <Example title="no files selected">
+    <FileInput items={[]} />
+  </Example>
+));

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -41,7 +41,7 @@ export interface IFileInputProps {
   /** accept state */
   accept?: string[];
   /** items state */
-  items: Array<FileInputItem>;
+  items: FileInputItem[];
   /** items state */
   multiple?: boolean;
 

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -13,6 +13,16 @@ import Spinner from "../spinner";
 
 export type FileInputSize = "default" | "large" | "small" | "compressed";
 
+export type FileInputFile = {
+  name: string;
+  size: number;
+};
+
+export type FileInputItem = {
+  file: FileInputFile;
+  loading?: boolean;
+};
+
 export interface IFileInputProps {
   /** HTML ID for the element */
   id?: string;
@@ -31,7 +41,7 @@ export interface IFileInputProps {
   /** accept state */
   accept?: string[];
   /** items state */
-  items: Array<{ file: any; loading?: boolean }>;
+  items: Array<FileInputItem>;
   /** items state */
   multiple?: boolean;
 

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -13,15 +13,15 @@ import Spinner from "../spinner";
 
 export type FileInputSize = "default" | "large" | "small" | "compressed";
 
-export type FileInputFile = {
+export interface IFileInputFile {
   name: string;
   size: number;
-};
+}
 
-export type FileInputItem = {
-  file: FileInputFile;
+export interface IFileInputItem {
+  file: IFileInputFile;
   loading?: boolean;
-};
+}
 
 export interface IFileInputProps {
   /** HTML ID for the element */
@@ -41,7 +41,7 @@ export interface IFileInputProps {
   /** accept state */
   accept?: string[];
   /** items state */
-  items: FileInputItem[];
+  items: IFileInputItem[];
   /** items state */
   multiple?: boolean;
 

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -152,7 +152,7 @@ class FileInput extends React.Component<IFileInputProps> {
             </FileInput.Button>
             {selectedItems && (
               <FileInput.Text>
-                {selectedItems.length} file
+                {selectedItems.length === 0 ? "No" : selectedItems.length} file
                 {selectedItems.length === 1 ? "" : "s"} selected
               </FileInput.Text>
             )}

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -1,55 +1,55 @@
-import * as React from 'react'
+import * as React from "react";
 
-import Automation from '../../_helpers/automation-attribute'
-import bytesConversion from '../../_helpers/bytes-conversion'
-import truncateMidString from '../../_helpers/truncate-mid-string'
-import Button from '../../atoms/button'
-import Icon from '../../atoms/icon'
-import styled from '../../styled'
-import { colors, misc } from '../../tokens'
-import { spacing } from '../../tokens/v2'
-import { StyledInput } from '../_styled-input'
-import Spinner from '../spinner'
+import Automation from "../../_helpers/automation-attribute";
+import bytesConversion from "../../_helpers/bytes-conversion";
+import truncateMidString from "../../_helpers/truncate-mid-string";
+import Button from "../../atoms/button";
+import Icon from "../../atoms/icon";
+import styled from "../../styled";
+import { colors, misc } from "../../tokens";
+import { spacing } from "../../tokens/v2";
+import { StyledInput } from "../_styled-input";
+import Spinner from "../spinner";
 
-export type FileInputSize = 'default' | 'large' | 'small' | 'compressed'
+export type FileInputSize = "default" | "large" | "small" | "compressed";
 
 export interface IFileInputProps {
   /** HTML ID for the element */
-  id?: string
+  id?: string;
   /** HTML name for the element */
-  name?: string
+  name?: string;
   /** Make input readOnly if it does not validate constraint */
-  readOnly?: boolean
+  readOnly?: boolean;
   /** Pass hasError to show error state */
-  hasError?: boolean
+  hasError?: boolean;
   /** @deprecated:hasError Pass error string directly to show error state */
-  error?: string
+  error?: string;
 
-  onChange?: Function
+  onChange?: Function;
   /** disabled state */
-  disabled?: boolean
+  disabled?: boolean;
   /** accept state */
-  accept?: string[]
+  accept?: string[];
   /** items state */
-  items: Array<{ file: any; loading?: boolean }>
+  items: Array<{ file: any; loading?: boolean }>;
   /** items state */
-  multiple?: boolean
+  multiple?: boolean;
 
-  renderItem?: Function
+  renderItem?: Function;
 }
 
 class FileInput extends React.Component<IFileInputProps> {
-  public static formatBytes = bytesConversion
-  public static Element = styled.div``
-  public static Button = styled(Button)``
+  public static formatBytes = bytesConversion;
+  public static Element = styled.div``;
+  public static Button = styled(Button)``;
 
   public static Spinner = styled(Spinner)`
     margin-right: ${spacing.xxsmall};
-  `
+  `;
 
   public static Container = styled.div`
     position: relative;
-  `
+  `;
   public static Input = styled.input`
     position: relative;
     z-index: 2;
@@ -57,7 +57,7 @@ class FileInput extends React.Component<IFileInputProps> {
     height: ${misc.button.default.height};
     margin: 0;
     opacity: 0;
-  `
+  `;
   public static Label = styled.label`
     position: absolute;
     top: 0;
@@ -67,7 +67,7 @@ class FileInput extends React.Component<IFileInputProps> {
     display: flex;
     height: ${misc.button.default.height};
     border-color: yellow;
-  `
+  `;
 
   public static Text = styled.span`
     display: block;
@@ -80,11 +80,11 @@ class FileInput extends React.Component<IFileInputProps> {
     color: black;
     text-overflow: ellipsis;
     white-space: nowrap;
-  `
+  `;
 
   public static List = styled.ul`
     margin-top: ${spacing.xsmall};
-  `
+  `;
 
   public static ListItem = styled.li`
     display: flex;
@@ -93,50 +93,50 @@ class FileInput extends React.Component<IFileInputProps> {
     border-bottom: 1px solid #e4e4e4;
     padding-top: ${spacing.xsmall};
     padding-bottom: ${spacing.xsmall};
-  `
+  `;
 
   public static ListItemBody = styled.div`
     display: flex;
     align-items: center;
-  `
+  `;
 
   public static FileName = styled.span`
     margin-left: ${spacing.xsmall};
-  `
+  `;
 
   public static FileNameWeight = styled.span`
     margin-left: 12px;
     color: ${colors.text.secondary};
-  `
+  `;
 
   public static Card = styled.div`
     border: 1px solid #e4e4e4;
     border-radius: 3px;
     padding: ${spacing.small};
-  `
+  `;
   public static defaultProps = {
-    multiple: false
-  }
+    multiple: false,
+  };
 
   public onChangeHandler = (event) => {
-    const items = Array.from(event.target.files).map((item) => ({ file: item, loading: false }))
+    const items = Array.from(event.target.files).map((item) => ({ file: item, loading: false }));
 
     if (this.props.onChange) {
-      this.props.onChange({ added: items })
+      this.props.onChange({ added: items });
     }
-  }
+  };
 
   public onDeleteHandler = (index) => {
     if (this.props.onChange) {
-      this.props.onChange({ deleted: { index, file: this.props.items[index] } })
+      this.props.onChange({ deleted: { index, file: this.props.items[index] } });
     }
-  }
+  };
 
   public render() {
-    const { multiple, items: selectedItems, disabled, accept } = this.props
+    const { multiple, items: selectedItems, disabled, accept } = this.props;
 
     return (
-      <FileInput.Element {...Automation('file-input')} {...this.props}>
+      <FileInput.Element {...Automation("file-input")} {...this.props}>
         <FileInput.Container>
           <FileInput.Input
             disabled={disabled}
@@ -144,7 +144,7 @@ class FileInput extends React.Component<IFileInputProps> {
             multiple={multiple}
             onChange={this.onChangeHandler}
             accept={accept}
-            {...Automation('file-input.input')}
+            {...Automation("file-input.input")}
           />
           <FileInput.Label htmlFor="customFileLong">
             <FileInput.Button disabled={disabled} icon="plus">
@@ -153,24 +153,24 @@ class FileInput extends React.Component<IFileInputProps> {
             {selectedItems && (
               <FileInput.Text>
                 {selectedItems.length} file
-                {selectedItems.length === 1 ? '' : 's'} selected
+                {selectedItems.length === 1 ? "" : "s"} selected
               </FileInput.Text>
             )}
           </FileInput.Label>
         </FileInput.Container>
 
-        <FileInput.List {...Automation('file-input.list')}>
+        <FileInput.List {...Automation("file-input.list")}>
           {selectedItems &&
             selectedItems.map((item, itemIndex) => {
-              const file = item.file
-              const deleteFileHandler = () => this.onDeleteHandler(itemIndex)
+              const file = item.file;
+              const deleteFileHandler = () => this.onDeleteHandler(itemIndex);
 
               if (this.props.renderItem) {
-                return this.props.renderItem(item, itemIndex, deleteFileHandler)
+                return this.props.renderItem(item, itemIndex, deleteFileHandler);
               }
 
               return (
-                <FileInput.ListItem key={file.name} {...Automation('file-input.list-item')}>
+                <FileInput.ListItem key={file.name} {...Automation("file-input.list-item")}>
                   <FileInput.ListItemBody>
                     {item.loading ? (
                       <FileInput.Spinner />
@@ -179,26 +179,24 @@ class FileInput extends React.Component<IFileInputProps> {
                     )}
 
                     <FileInput.FileName>{truncateMidString(file.name)}</FileInput.FileName>
-                    <FileInput.FileNameWeight>
-                      {bytesConversion(file.size)}
-                    </FileInput.FileNameWeight>
+                    <FileInput.FileNameWeight>{bytesConversion(file.size)}</FileInput.FileNameWeight>
                   </FileInput.ListItemBody>
                   <FileInput.Button
                     icon="delete"
                     size="small"
                     appearance="link"
-                    label={item.loading ? '' : 'Remove'}
+                    label={item.loading ? "" : "Remove"}
                     onClick={deleteFileHandler}
                     disabled={item.loading}
                   />
                 </FileInput.ListItem>
-              )
+              );
             })}
         </FileInput.List>
       </FileInput.Element>
-    )
+    );
   }
 }
 
-export default FileInput
-export { StyledInput }
+export default FileInput;
+export { StyledInput };


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

When there are no files selected, the `item` prop of the `FileInput` atom obtains an empty array. In this case the message shown to the user is `0 files selected`. This PR changes that message to `No files selected`.

![image](https://user-images.githubusercontent.com/37590801/65282313-a075c100-db02-11e9-9315-b7af2b5e1e89.png)


### Testing

There is no existing test file for the `FileInput` atom.

### Checklist

- [X ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X ] The correct base branch is being used, if not `master`
