### PR TITLE
FileInput - Can't remove and add same file #1665

### DIFF
--- a/core/components/atoms/file-input/file-input.story.tsx
+++ b/core/components/atoms/file-input/file-input.story.tsx
@@ -3,7 +3,30 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 
 import { Example } from "../../_helpers/story-helpers";
-import FileInput from "./";
+import FileInput, { IFileInputItem } from "./";
+
+class StatefulExample extends React.Component<{}, { files: IFileInputItem[] }> {
+  state = { files: [] };
+
+  onChange = ({ added, deleted }: { added?: IFileInputItem[]; deleted?: { index: number; file: IFileInputItem } }) => {
+    if (added) {
+      this.setState((prevState) => ({ files: [...prevState.files, ...added] }));
+    }
+
+    if (deleted) {
+      const files = [...this.state.files];
+      files.splice(deleted.index, 1);
+
+      this.setState({ files: files });
+    }
+  };
+
+  render = () => (
+    <Example title="with stateful parent">
+      <FileInput items={this.state.files} onChange={this.onChange} />
+    </Example>
+  );
+}
 
 storiesOf("FileInput", module).add("simple", () => (
   <Example title="simple">
@@ -49,3 +72,7 @@ storiesOf("FileInput", module).add("no files selected", () => (
     <FileInput items={[]} />
   </Example>
 ));
+
+storiesOf("FileInput", module).add("with stateful parent", () => {
+  return <StatefulExample />;
+});

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -186,7 +186,7 @@ class FileInput extends React.Component<IFileInputProps> {
                 }
 
                 return (
-                  <FileInput.ListItem key={file.name} {...Automation("file-input.list-item")}>
+                  <FileInput.ListItem key={itemIndex} {...Automation("file-input.list-item")}>
                     <FileInput.ListItemBody>
                       {item.loading ? (
                         <FileInput.Spinner />

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -23,7 +23,6 @@ export interface IFileInputItem {
   loading?: boolean;
 }
 
-
 export interface IFileInputProps {
   /** HTML ID for the element */
   id?: string;

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -133,6 +133,10 @@ class FileInput extends React.Component<IFileInputProps> {
     const items = Array.from(event.target.files).map((item) => ({ file: item, loading: false }));
 
     if (this.props.onChange) {
+      /**
+       * File input cannot be controlled in a React-specific way.
+       * To allow re-adding a file that was just removed, clear the input value like this:
+       */
       event.target.value = null;
       this.props.onChange({ added: items });
     }

--- a/core/components/atoms/file-input/file-input.tsx
+++ b/core/components/atoms/file-input/file-input.tsx
@@ -133,6 +133,7 @@ class FileInput extends React.Component<IFileInputProps> {
     const items = Array.from(event.target.files).map((item) => ({ file: item, loading: false }));
 
     if (this.props.onChange) {
+      event.target.value = null;
       this.props.onChange({ added: items });
     }
   };


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

After removing a file from the files items list, the onChange event is not firing if you immediately try to re-add that file.

According to an entry in StackOverflow:

> File input cannot be controlled, there is no React specific way to do that.

The suggestion is to clear the input value like this:

```
e.target.value = null;
```

The best place to perform this action is before calling  `this.props.onChange` on the class method `onChangeHandler` and after the `files` value has already been extracted from the `event.target.files` object into the `items` local variable.

As such, after each upload, the value of the input element is reset. Fixes #1665 

### References

[How to reset ReactJS file input](https://stackoverflow.com/questions/42192346/how-to-reset-reactjs-file-input)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
