### PR TITLE
Extra rendering in formgroup fix

### DIFF
--- a/core/components/molecules/form-group/form-group.tsx
+++ b/core/components/molecules/form-group/form-group.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import styled from '../../styled'
 import Automation from '../../_helpers/automation-attribute'
 import containerStyles from '../../_helpers/container-styles'
+import isEmpty from 'lodash.isempty'
 
 import Well from '../../atoms/_well'
 import { spacing } from '../../tokens'
@@ -15,7 +16,11 @@ export interface IFormGroupProps {
 
 const FormGroup = ({ children, ...props }: IFormGroupProps) => {
   const wrappedChildren = React.Children.map(children, (child) => {
-    return <FormGroup.FormWrapper>{child}</FormGroup.FormWrapper>
+    if (isEmpty(child)) {
+      return null;
+    } else {
+      return <FormGroup.FormWrapper>{child}</FormGroup.FormWrapper>;
+    }
   })
 
   return (

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lint-staged": "7.2.0",
     "lodash.camelcase": "4.3.0",
     "lodash.frompairs": "4.0.1",
+    "lodash.isempty": "4.4.0",
     "md5-file": "^4.0.0",
     "nps": "5.9.2",
     "nps-i": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9124,6 +9124,11 @@ lodash.frompairs@4.0.1:
   resolved "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz#bc4e5207fa2757c136e573614e9664506b2b1bd2"
   integrity sha1-vE5SB/onV8E25XNhTpZkUGsrG9I=
 
+lodash.isempty@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"


### PR DESCRIPTION
### Description

Simple fix for the extra rendering issue when sending and element such as null or undefined on a form group.

### Testing

To test this fix, when creating a formGroup in the sandbox you can send null or an undefined element on it to check if they render.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
