### PR TITLE
Add missing dependency in published package

### DIFF
--- a/core/components/package.json
+++ b/core/components/package.json
@@ -17,7 +17,8 @@
     "react-popper": "1.3.2",
     "react-select": "2.3.0",
     "react-sortable-hoc": "^0.8.3",
-    "styled-components": "3.4.10"
+    "styled-components": "3.4.10",
+    "lodash.isempty": "4.4.0"
   },
   "peerDependencies": {
     "react": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "lint-staged": "7.2.0",
     "lodash.camelcase": "4.3.0",
     "lodash.frompairs": "4.0.1",
-    "lodash.isempty": "4.4.0",
     "md5-file": "^4.0.0",
     "nps": "5.9.2",
     "nps-i": "1.0.2",


### PR DESCRIPTION
Add missing dependency `lodash.isempty` in published package.