### PR TITLE
[DXDP-885] - Guard document.body reference in select component

### DIFF
--- a/core/components/atoms/select/select.tsx
+++ b/core/components/atoms/select/select.tsx
@@ -296,7 +296,7 @@ class Select extends React.Component<ISelectProps, ISelectState> {
               isLoading={props.loading}
               onMenuOpen={this.updateMenuState(true)}
               onMenuClose={this.updateMenuState(false)}
-              menuPortalTarget={document.body}
+              menuPortalTarget={!!document ? document.body : null}
               menuIsOpen={props.defaultMenuOpen}
               defaultValue={props.defaultValue}
               getOptionValue={props.getOptionValue}


### PR DESCRIPTION
On the server document my not be defined so we need to guard the reference inside of render.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Added a guarded reference to document.body since the document is not defined on the server during SSR.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
