### PR TITLE
DXDP-1904 - Fixing Avatar component infinite loop when image not provided and gravatar fails to load

### DIFF
--- a/core/components/_helpers/story-example.tsx
+++ b/core/components/_helpers/story-example.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react'
-import styled from '../styled'
-import { colors } from '../tokens'
+import * as React from "react";
+
+import styled from "../styled";
+import { colors } from "../tokens";
 
 const Title = styled.div`
   position: absolute;

--- a/core/components/atoms/avatar/avatar.story.tsx
+++ b/core/components/atoms/avatar/avatar.story.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react'
-import { storiesOf } from '@storybook/react'
-import { Example, Stack } from '../../_helpers/story-helpers'
-import { Avatar } from '../../'
+import * as React from "react";
+
+import { storiesOf } from "@storybook/react";
+
+import { Avatar } from "../../";
+import { Example, Stack } from "../../_helpers/story-helpers";
 
 const EXAMPLE_IMAGE =
   'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNDhweCIgaGVpZ2h0PSI0OHB4IiB2aWV3Qm94PSIwIDAgNDggNDgiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDUwLjIgKDU1MDQ3KSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5IZWxwZXJzIC8gQXZhdGFycyAvIFR5cGVzIC8gTW9iaWxlPC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IkhlbHBlcnMtLy1BdmF0YXJzLS8tVHlwZXMtLy1Nb2JpbGUiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJHcm91cC0yIj4KICAgICAgICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZSIgeD0iMCIgeT0iMCIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ij48L3JlY3Q+CiAgICAgICAgPC9nPgogICAgICAgIDxnIGlkPSJzZXJ2aWNlIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMC4wMDAwMDAsIDExLjAwMDAwMCkiIGZpbGwtcnVsZT0ibm9uemVybyI+CiAgICAgICAgICAgIDxwb2x5Z29uIGlkPSJGaWxsLTUzIiBmaWxsPSIjNDRDN0Y0IiBwb2ludHM9IjYuODAzNzg5NTUgMjEuMzk4OTkzIDMuOTk0NjE0NDcgMTkuNzczOTkzIDEyLjczNjA5MjQgNC42MDQxNjY2NyAxNS41NDUyNjc1IDYuMjI5MTY2NjciPjwvcG9seWdvbj4KICAgICAgICAgICAgPHBvbHlnb24gaWQ9IkZpbGwtNTQiIGZpbGw9IiNFQzU0MjQiIHBvaW50cz0iMjEuNDc2MTg4NyAyMS4zOTg5OTMgMTIuNzM0NzEwOCA2LjIyOTE2NjY3IDE1LjU0Mzg4NTkgNC42MDQxNjY2NyAyNC4yODUzNjM3IDE5Ljc3Mzk5MyI+PC9wb2x5Z29uPgogICAgICAgICAgICA8cGF0aCBkPSJNMTkuNTUyNTg2Niw1LjQxNjY2NjY3IEMxOS41NTI1ODY2LDguNDA4MjAxNDIgMTcuMTMyMTUwNiwxMC44MzMzMzMzIDE0LjE0NjM0MTUsMTAuODMzMzMzMyBDMTEuMTYwNTYyNCwxMC44MzMzMzMzIDguNzQwMDk2MjksOC40MDgyMDE0MiA4Ljc0MDA5NjI5LDUuNDE2NjY2NjcgQzguNzQwMDk2MjksMi40MjUxMzE5NSAxMS4xNjA1NjI0LDAgMTQuMTQ2MzQxNSwwIEMxNy4xMzIxNTA2LDAgMTkuNTUyNTg2NiwyLjQyNTEzMTk1IDE5LjU1MjU4NjYsNS40MTY2NjY2NyIgaWQ9IkZpbGwtNTUiIGZpbGw9IiMxNjIxNEQiPjwvcGF0aD4KICAgICAgICAgICAgPHBhdGggZD0iTTEwLjgxMjQ5MDMsMjAuNTgzMzMzMyBDMTAuODEyNDkwMywyMy41NzQ4NjggOC4zOTIwNTQyNCwyNiA1LjQwNjI0NTE1LDI2IEMyLjQyMDQ2NjA1LDI2IDAsMjMuNTc0ODY4IDAsMjAuNTgzMzMzMyBDMCwxNy41OTE3OTg2IDIuNDIwNDY2MDUsMTUuMTY2NjY2NyA1LjQwNjI0NTE1LDE1LjE2NjY2NjcgQzguMzkyMDU0MjQsMTUuMTY2NjY2NyAxMC44MTI0OTAzLDE3LjU5MTc5ODYgMTAuODEyNDkwMywyMC41ODMzMzMzIiBpZD0iRmlsbC01NiIgZmlsbD0iI0VDNTQyNCI+PC9wYXRoPgogICAgICAgICAgICA8cGF0aCBkPSJNMjguMjkyNjgyOSwyMC41ODMzMzMzIEMyOC4yOTI2ODI5LDE3LjU5MTc5ODYgMjUuODcyMjE2OCwxNS4xNjY2NjY3IDIyLjg4NjQzNzcsMTUuMTY2NjY2NyBDMTkuOTAwNjU4NywxNS4xNjY2NjY3IDE3LjQ4MDE5MjcsMTcuNTkxNzk4NiAxNy40ODAxOTI3LDIwLjU4MzMzMzMgQzE3LjQ4MDE5MjcsMjMuNTc0ODY4IDE5LjkwMDY1ODcsMjYgMjIuODg2NDM3NywyNiBDMjUuODcyMjE2OCwyNiAyOC4yOTI2ODI5LDIzLjU3NDg2OCAyOC4yOTI2ODI5LDIwLjU4MzMzMzMiIGlkPSJGaWxsLTU3IiBmaWxsPSIjNDRDN0Y0Ij48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4='
@@ -144,4 +146,85 @@ storiesOf('Avatar', module).add('fitted images', () => (
       />
     </Stack>
   </Example>
+))
+
+storiesOf('Avatar', module).add('failure fallbacks', () => (
+  <>
+    <Example title="Full fallback - All fail + all missing props">
+      <Stack>
+        <Avatar
+          type="user"
+          size="xlarge"
+          email="wrong@email.coma"
+          initials="failed-initials"
+          image="some-relative-path-not-found"
+        />
+        <Avatar
+          type="user"
+          size="xlarge"
+        />
+      </Stack>
+    </Example>
+    <Example title="Missing image fallbacks">
+      <Stack>
+        <Avatar
+          type="user"
+          size="xlarge"
+          email="wrong@email.coma"
+          initials="failed-initials"
+        />
+        <Avatar
+          type="user"
+          size="xlarge"
+          initials="failed-initials"
+        />
+        <Avatar
+          type="user"
+          size="xlarge"
+          email="wrong@email.coma"
+        />
+        <span>All stories with missing <code>image</code> prop used to have an infinite loop issue causing incidents - it's already fixed!</span>
+      </Stack>
+    </Example>
+    <Example title="Missing email">
+      <Stack>
+        <Avatar
+          type="user"
+          size="xlarge"
+          initials="failed-initials"
+          image="some-relative-path-not-found"
+        />
+        <Avatar
+          type="user"
+          size="xlarge"
+          initials="failed-initials"
+        />
+        <Avatar
+          type="user"
+          size="xlarge"
+          image="some-relative-path-not-found"
+        />
+      </Stack>
+    </Example>
+    <Example title="Missing initials">
+      <Stack>
+        <Avatar
+          type="user"
+          size="xlarge"
+          email="wrong@email.coma"
+          image="some-relative-path-not-found"
+        />
+        <Avatar
+          type="user"
+          size="xlarge"
+          image="some-relative-path-not-found"
+        />
+        <Avatar
+          type="user"
+          size="xlarge"
+          email="wrong@email.coma"
+        />
+      </Stack>
+    </Example>
+  </>
 ))

--- a/core/components/atoms/avatar/avatar.tsx
+++ b/core/components/atoms/avatar/avatar.tsx
@@ -33,7 +33,12 @@ const imageForAvatar = (source, handleError) => {
       fit="cover"
       src={source}
       onError={(event) => {
-        event.target.src = null
+        try {
+          event.target.removeAttribute('src')
+        } catch (e) {
+          event.target.src = undefined
+        }
+        event.target.onerror = undefined
         event.target.onError = undefined
         handleError(event)
       }}

--- a/core/components/atoms/avatar/avatar.tsx
+++ b/core/components/atoms/avatar/avatar.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import styled from '../../styled'
-import { Image } from '../../'
-import { colors, misc } from '../../tokens'
-import Icon, { __ICONNAMES__ } from '../icon'
-import getUserAvatarUrl from '../../_helpers/avatar-url'
-import Automation from '../../_helpers/automation-attribute'
-import { prependOnceListener } from 'cluster'
+import * as React from "react";
+
+import { Image } from "../../";
+import Automation from "../../_helpers/automation-attribute";
+import getUserAvatarUrl from "../../_helpers/avatar-url";
+import styled from "../../styled";
+import { colors, misc } from "../../tokens";
+import Icon, { __ICONNAMES__ } from "../icon";
 
 const iconSizes = {
   xsmall: 14,
@@ -124,9 +124,9 @@ class Avatar extends React.Component<IAvatarProps, IAvatarState> {
 
   public discardSource(source: 'image' | 'gravatar') {
     switch (source) {
-      case 'image':
+      case sources.image:
         return this.setState({ imageErrored: true })
-      case 'gravatar':
+      case sources.gravatar:
         return this.setState({ gravatarErrored: true })
       default:
         return
@@ -137,14 +137,15 @@ class Avatar extends React.Component<IAvatarProps, IAvatarState> {
     const { imageErrored, gravatarErrored } = this.state
     const { email, initials, icon, image } = this.props
 
+    // NOTE: The following order of checks MATTER. They determine the fallback
+    //       precedence when there are any missing props or failed attempts.
+    //       Carefully review all scenarios are covered when changing the
+    //       following lines.
     if (icon) { return sources.icon }
     if (imageErrored && gravatarErrored) { return sources.fallback }
-    if (imageErrored || !image) {
-      if (email || initials) { return sources.gravatar }
-      return sources.fallback
-    }
-
-    return sources.image
+    if (image && !imageErrored) { return sources.image }
+    if ((email || initials) && !gravatarErrored) { return sources.gravatar }
+    return sources.fallback
   }
 
   public render() {

--- a/internal/test/unit/__snapshots__/avatar.test.tsx.snap
+++ b/internal/test/unit/__snapshots__/avatar.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Avatar .getSource() should return "fallback" if both image and gravatar errors to load 1`] = `"fallback"`;
+
+exports[`Avatar .getSource() should return "fallback" if not image nor gravatar property is passed 1`] = `"fallback"`;
+
+exports[`Avatar .getSource() should return "fallback" when gravatar errors to load with email 1`] = `"fallback"`;
+
+exports[`Avatar .getSource() should return "fallback" when gravatar errors to load with initials 1`] = `"fallback"`;
+
+exports[`Avatar .getSource() should return "fallback" when image errors and no gravatar prop is passed 1`] = `"fallback"`;
+
+exports[`Avatar .getSource() should return "gravatar" when both initials and email are passed 1`] = `"gravatar"`;
+
+exports[`Avatar .getSource() should return "gravatar" when email is passed 1`] = `"gravatar"`;
+
+exports[`Avatar .getSource() should return "gravatar" when image errors to load and email is passed 1`] = `"gravatar"`;
+
+exports[`Avatar .getSource() should return "gravatar" when image errors to load and initials are passed 1`] = `"gravatar"`;
+
+exports[`Avatar .getSource() should return "gravatar" when initials are passed 1`] = `"gravatar"`;
+
+exports[`Avatar .getSource() should return "icon" prefered over anything 1`] = `"icon"`;
+
+exports[`Avatar .getSource() should return "image" when image prop passed 1`] = `"image"`;
+
+exports[`Avatar .getSource() should return "image" when image, initials and emails props are passed 1`] = `"image"`;

--- a/internal/test/unit/avatar.test.tsx
+++ b/internal/test/unit/avatar.test.tsx
@@ -1,0 +1,113 @@
+import { shallow } from "enzyme";
+import * as React from "react";
+
+import { Avatar } from "@auth0/cosmos";
+
+const TEST_IMAGE = "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&h=200&fit=crop&crop=faces&s=a72ca28288878f8404a795f39642a46f";
+
+describe('Avatar', () => {
+  describe('.getSource()', () => {
+    it('should return "icon" prefered over anything', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" icon="plus" initials="dd" email="pepe@example.com" />)
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "fallback" if not image nor gravatar property is passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" />)
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "fallback" if both image and gravatar errors to load', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" initials="dd" email="pepe@example.com" image={TEST_IMAGE} />)
+
+      wrapper.setState({
+        imageErrored: true,
+        gravatarErrored: true
+      })
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "image" when image prop passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" initials="dd" email="pepe@example.com" image={TEST_IMAGE} />)
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "image" when image, initials and emails props are passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" initials="dd" email="pepe@example.com" image={TEST_IMAGE} />)
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "fallback" when image errors and no gravatar prop is passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" image={TEST_IMAGE} />)
+
+      wrapper.setState({
+        imageErrored: true
+      })
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "gravatar" when image errors to load and email is passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" image={TEST_IMAGE} email="pepe@exammple.com" />)
+
+      wrapper.setState({
+        imageErrored: true
+      })
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "gravatar" when image errors to load and initials are passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" image={TEST_IMAGE} initials="dd" />)
+
+      wrapper.setState({
+        imageErrored: true
+      })
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "gravatar" when email is passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" email="pepe@example.com" />)
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "gravatar" when initials are passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" initials="dd" />)
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "gravatar" when both initials and email are passed', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" initials="dd" email="pepe@example.com" />)
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "fallback" when gravatar errors to load with email', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" email="pepe@example.com" />)
+
+      wrapper.setState({
+        gravatarErrored: true
+      })
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+
+    it('should return "fallback" when gravatar errors to load with initials', () => {
+      const wrapper = shallow<Avatar>(<Avatar size="medium" type="user" initials="dd" />)
+
+      wrapper.setState({
+        gravatarErrored: true
+      })
+
+      expect(wrapper.instance().getSource()).toMatchSnapshot()
+    })
+  })
+})


### PR DESCRIPTION
#### Description
We've identified an infinite loop in the Avatar component for when the `image` prop is not provided. In combination with bad `initials` or `email` props that end up failing to load, the following line get's HIT:

https://github.com/auth0/cosmos/blob/f96aaee5d6586a71d05c7a80b3cc2c003a4802eb/core/components/atoms/avatar/avatar.tsx#L143

You can notice that there is no handled case for when the Gravatar source has failed to load (except for the one in combination with image errors). This combination of events start an infinite loop of Line 143 being constantly hit, running several requests per second attempting indefinitely to load Gravatar again and again.

#### Motivation and Context
This is a bug which can cause systems to exhaust or block the user due to the excess of requests produced by the infinite loop.

#### How has this been tested?
There are stories in the storybook that reproduced the issue, now fixed!
